### PR TITLE
Allow for the new wp_installing() function.

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -822,7 +822,7 @@ function initialize_yoast_woocommerce_seo() {
 	}
 }
 
-if ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) {
+if ( ( function_exists( 'wp_installing' ) && wp_installing() === false ) || ( ! function_exists( 'wp_installing' ) && ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) ) ) {
 	add_action( 'plugins_loaded', 'initialize_yoast_woocommerce_seo', 20 );
 }
 


### PR DESCRIPTION
Introduced in WP 4.4.
See: https://core.trac.wordpress.org/changeset/34828