### PR TITLE
Do not cut hand-crafted post excerpts

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -590,10 +590,10 @@ class Yoast_WooCommerce_SEO {
 						$metadesc = $product->post->post_excerpt;
 					} elseif ( $product->post->post_content != '' ) {
 						$metadesc = $product->post->post_content;
-					}
 
-					if ( ! empty( $metadesc ) ) {
-						$metadesc = wp_html_excerpt( $metadesc, 156 );
+						if ( ! empty( $metadesc ) ) {
+							$metadesc = wp_html_excerpt( $metadesc, 156 );
+						}
 					}
 				}
 			}


### PR DESCRIPTION
when forming the meta- and og:description. Only use the hard 156-char limit when there is no excerpt defined by the user and we have to cut a piece from the entire post content.
