### PR TITLE
Fixed "update plugin" on the plugins page

### DIFF
--- a/classes/class-product-wpseo-woocommerce.php
+++ b/classes/class-product-wpseo-woocommerce.php
@@ -10,7 +10,7 @@ if ( ! class_exists( 'Yoast_Product_WPSEO_WooCommerce' ) ) {
 		public function __construct() {
 			$file = plugin_basename( Yoast_WooCommerce_SEO::get_plugin_file() );
 			$slug = dirname( $file );
-			
+
 			parent::__construct(
 				'http://yoast.com/edd-sl-api',
 				'WooCommerce Yoast SEO',

--- a/classes/class-product-wpseo-woocommerce.php
+++ b/classes/class-product-wpseo-woocommerce.php
@@ -8,15 +8,19 @@ if ( ! class_exists( 'Yoast_Product_WPSEO_WooCommerce' ) ) {
 	class Yoast_Product_WPSEO_WooCommerce extends Yoast_Product {
 
 		public function __construct() {
+			$file = plugin_basename( Yoast_WooCommerce_SEO::get_plugin_file() );
+			$slug = dirname( $file );
+			
 			parent::__construct(
 				'http://yoast.com/edd-sl-api',
 				'WooCommerce Yoast SEO',
-				plugin_basename( Yoast_WooCommerce_SEO::get_plugin_file() ),
+				$slug,
 				Yoast_WooCommerce_SEO::VERSION,
 				'https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/',
 				'admin.php?page=wpseo_licenses#top#licenses',
 				'yoast-woo-seo',
-				'Yoast'
+				'Yoast',
+				$file
 			);
 		}
 	}


### PR DESCRIPTION
Changed arguments to comply with Licence Manager updates so we use an HTML ID safe string for slug needed for correct usage of the shiny updates routine.

See https://github.com/Yoast/wordpress-seo-premium/issues/274

Consideration:
We realise that using an older License Manager version might break functionality but upgrading Free or Premium will solve this (which everybody should do), so not considered a huge problem.