### PR TITLE
Fix rel next prev archive pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classmap": [ "classes/" ]
     },
     "require": {
-        "xrstf/composer-php52": "^1.0",
+        "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1000d7be6cb258d948e9b2e33b63f6bf",
-    "content-hash": "8eee077370b766c787959f659cf6f733",
+    "hash": "038e03d48ae425256d44219803e727e4",
+    "content-hash": "94c6c7841c492e9b6b9cf1423edad8a0",
     "packages": [
         {
             "name": "xrstf/composer-php52",
-            "version": "v1.0.19",
+            "version": "v1.0.20",
             "source": {
-                "type": "hg",
-                "url": "https://bitbucket.org/xrstf/composer-php52",
-                "reference": "9a4a9c46d0347b39bf9159815301dc66fc25324e"
+                "type": "git",
+                "url": "https://github.com/composer-php52/composer-php52.git",
+                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://bitbucket.org/xrstf/composer-php52/get/9a4a9c46d0347b39bf9159815301dc66fc25324e.zip",
-                "reference": "9a4a9c46d0347b39bf9159815301dc66fc25324e",
+                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
+                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
                 "shasum": ""
             },
             "type": "library",
@@ -36,8 +36,7 @@
             "license": [
                 "MIT"
             ],
-            "homepage": "http://www.xrstf.de/",
-            "time": "2015-10-01 14:11:58"
+            "time": "2016-04-16 21:52:24"
         },
         {
             "name": "yoast/wp-helpscout",

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -637,11 +637,19 @@ class Yoast_WooCommerce_SEO {
 	 */
 	function xml_post_type_archive_link( $link, $post_type ) {
 
-		if ( $post_type === 'product' ) {
-			return false;
-		} else {
+		if ( 'product' !== $post_type ) {
 			return $link;
 		}
+
+		if ( function_exists( 'wc_get_page_id' ) ) {
+			$shop_page_id = wc_get_page_id( 'shop' );
+			$home_page_id = (int) get_option( 'page_on_front' );
+			if ( $home_page_id === $shop_page_id ) {
+				return false;
+			}
+		}
+
+		return $link;
 	}
 
 	public function init_beacon() {


### PR DESCRIPTION
If the home page is set to the shop page we want to exclude the 'product' link from the sitemaps.

**How to reproduce**
Prerequisites:
* WooCommerce
* Yoast SEO for WordPress
* WooCommerce for SEO

Set blog home to "shop".
Install WooCommerce dummy data (https://docs.woothemes.com/document/importing-woocommerce-dummy-data/)

Go to page 2 on the front page of the blog.
1. See if the meta fields for rel=prev and rel=next are present.
1. Go to the product-sitemap.xml and see if the "shop" / home page URL are present (it wasn't and it shouldn't)

Fixes #100