### PR TITLE
Remove the Yoast SEO columns if necessary.

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -429,7 +429,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return mixed
 	 */
 	function column_heading( $columns ) {
-		unset( $columns['wpseo-title'], $columns['wpseo-metadesc'], $columns['wpseo-focuskw'] );
+		unset( $columns['wpseo-title'], $columns['wpseo-metadesc'], $columns['wpseo-focuskw'], $columns['wpseo-score'], $columns['wpseo-score-readability'] );
 
 		return $columns;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
- [bugfix] Fixes a bug where not all Yoast SEO columns where hidden.

## Relevant technical choices:

* -

## Test instructions

This PR can be tested by following these steps:

* Follow the steps to reproduce the issue and see the issue being solved by this pull request.

Fixes #136
