### PR TITLE
Set specific dist for PHP 5.2 and PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 sudo: false
 
 branches:
@@ -13,17 +13,27 @@ matrix:
     - php: 7.0
       env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1
     - php: 5.2
-      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1
+      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
+      dist: precise
+      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
     - php: 5.3
+      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
+      dist: precise
       env: WP_VERSION=4.6
     - php: 5.6
       env: WP_VERSION=4.6
     - php: 7.1
       env: WP_VERSION=4.8
     - php: 5.2
+      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
+      dist: precise
       env: WP_VERSION=master
     - php: nightly
       env: WP_VERSION=master
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: nightly
+    - env: WP_VERSION=master
 
 cache:
   directories:


### PR DESCRIPTION
This is not a permanent fix, as support will be dropped in September.

See also https://core.trac.wordpress.org/changeset/41072/