### PR TITLE
Don't cut hand-crafted excerpts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ cache:
     - $HOME/.composer/cache
 
 install:
-- phpenv local 5.6
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
 - composer selfupdate 1.0.0 --no-interaction
 - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then composer require --dev phpunit/phpunit ^5.7; fi
 - composer install --no-interaction

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -678,25 +678,25 @@ class Yoast_WooCommerce_SEO {
 			return '';
 		}
 
-		$product_id = get_the_id();
-		$product = $this->get_product_for_id( $product_id );
+		$product = $this->get_product_for_id( get_the_id() );
 
-		if ( is_object( $product ) ) {
-			$short_description = $this->get_short_product_description( $product );
-			$long_description = $this->get_product_description( $product );
-			if ( $short_description !== '' ) {
-				$meta_description = $short_description;
-			}
-			elseif ( $long_description !== '' ) {
-				$meta_description = $long_description;
-			}
-
-			if ( ! empty( $meta_description ) ) {
-				return wp_html_excerpt( $meta_description, 156 );
-			}
+		if ( ! is_object( $product ) ) {
+		    return '';
 		}
 
-		return '';
+        $short_description = $this->get_short_product_description( $product );
+        $long_description = $this->get_product_description( $product );
+
+        if ( $short_description !== '' ) {
+            $meta_description = $short_description;
+        }
+
+        if ( $long_description !== '' ) {
+	        $meta_description =  wp_html_excerpt( $long_description, 156 );
+        }
+
+
+		return $meta_description;
 	}
 
 	/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -659,14 +659,14 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Returns the meta description. It checks which value should be used when the given meta description is empty.
+	 * Returns the meta description. Checks which value should be used when the given meta description is empty.
 	 *
-	 * When the meta description it will use the short_description if that one is set. Otherwise it will use the full
-	 * product description. If everything is empty, it will return an empty string.
+	 * It will use the short_description if that one is set. Otherwise it will use the full
+	 * product description limited to 156 characters. If everything is empty, it will return an empty string.
 	 *
 	 * @param string $meta_description The meta description to check.
 	 *
-	 * @return string
+	 * @return string The meta description.
 	 */
 	public function metadesc( $meta_description ) {
 
@@ -688,15 +688,14 @@ class Yoast_WooCommerce_SEO {
 		$long_description = $this->get_product_description( $product );
 
 		if ( $short_description !== '' ) {
-			$meta_description = $short_description;
+			return $short_description;
 		}
 
 		if ( $long_description !== '' ) {
-			$meta_description = wp_html_excerpt( $long_description, 156 );
+			return wp_html_excerpt( $long_description, 156 );
 		}
 
-
-		return $meta_description;
+		return '';
 	}
 
 	/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -692,7 +692,7 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		if ( $long_description !== '' ) {
-			$meta_description =  wp_html_excerpt( $long_description, 156 );
+			$meta_description = wp_html_excerpt( $long_description, 156 );
 		}
 
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -681,19 +681,19 @@ class Yoast_WooCommerce_SEO {
 		$product = $this->get_product_for_id( get_the_id() );
 
 		if ( ! is_object( $product ) ) {
-		    return '';
+			return '';
 		}
 
-        $short_description = $this->get_short_product_description( $product );
-        $long_description = $this->get_product_description( $product );
+		$short_description = $this->get_short_product_description( $product );
+		$long_description = $this->get_product_description( $product );
 
-        if ( $short_description !== '' ) {
-            $meta_description = $short_description;
-        }
+		if ( $short_description !== '' ) {
+			$meta_description = $short_description;
+		}
 
-        if ( $long_description !== '' ) {
-	        $meta_description =  wp_html_excerpt( $long_description, 156 );
-        }
+		if ( $long_description !== '' ) {
+			$meta_description =  wp_html_excerpt( $long_description, 156 );
+		}
 
 
 		return $meta_description;


### PR DESCRIPTION
This code cleans up some of the code in the `metadesc` function and implements a fix introduced in #90.

Changelog entry:
* Fixes a bug where the short description was cut to the hard 156-character limit.

Props to @NickIvanter for the original fix.