### PR TITLE
Use the hook with less priority to attach images on

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -126,7 +126,7 @@ class Yoast_WooCommerce_SEO {
 				add_action( 'wpseo_opengraph', array( $this, 'og_enhancement' ), 50 );
 
 				if ( class_exists( 'WPSEO_OpenGraph_Image' ) ) {
-					add_action( 'wpseo_add_opengraph_images', array( $this, 'set_opengraph_image' ) );
+					add_action( 'wpseo_add_opengraph_additional_images', array( $this, 'set_opengraph_image' ) );
 				}
 
 				add_filter( 'wpseo_sitemap_exclude_post_type', array( $this, 'xml_sitemap_post_types' ), 10, 2 );


### PR DESCRIPTION
This prevents the gallery images to be used as page image if an image with more priority has been configured.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the first image in the Image Gallery is used on Facebook to compliment the page when shared, instead of the configured Facebook image or Featured image.

## Test instructions

This PR can be tested by following these steps:

* Add a featured image or Facebook Image to a WooCommerce Product
* Add images to the image gallery for the Product
* Without this PR the gallery images would be above the images in the `<head>` of the rendered product page
* With this PR the gallery images will be below the featured/FB image

Requires https://github.com/Yoast/wordpress-seo/pull/8267
Fixes https://github.com/Yoast/wpseo-woocommerce/issues/169
