### PR TITLE
Remove "WooCommerce SEO" and other product names from translations

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -333,14 +333,14 @@ class Yoast_WooCommerce_SEO {
 	 * @return array All submenu pages including our own.
 	 */
 	public function add_submenu_pages( $submenu_pages ) {
-		$submenu_pages[] = array(
-			'wpseo_dashboard',
-			__( 'WooCommerce SEO Settings', 'yoast-woo-seo' ),
-			__( 'WooCommerce SEO', 'yoast-woo-seo' ),
-			'wpseo_manage_options',
-			$this->short_name,
-			array( $this, 'admin_panel' ),
-		);
+	    $submenu_pages[] = array(
+            'wpseo_dashboard',
+            sprintf( __( '%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
+            'WooCommerce SEO',
+            'wpseo_manage_options',
+            $this->short_name,
+            array( $this, 'admin_panel' ),
+        );
 
 		return $submenu_pages;
 	}
@@ -429,7 +429,10 @@ class Yoast_WooCommerce_SEO {
 				__( 'Both WooCommerce and %1$s add columns to the product page, to remove all but the SEO score column from %1$s on that page, check this box.', 'yoast-woo-seo' ),
 				'Yoast SEO'
 			), "</p>\n";
-			$this->checkbox( 'hide_columns', __( 'Remove Yoast SEO columns', 'yoast-woo-seo' ) );
+            $this->checkbox('hide_columns', sprintf(
+            /* translators: %1$s resolves to Yoast SEO */
+                __('Remove %1$s columns', 'yoast-woo-seo'), 'Yoast SEO')
+            );
 
 			echo '<br class="clear"/>';
 			echo '<p>',
@@ -1010,11 +1013,12 @@ class Yoast_WooCommerce_SEO {
 function yoast_wpseo_woocommerce_missing_error() {
 	echo '<div class="error"><p>',
 		sprintf(
-			/* translators: %1$s resolves to the plugin search for Yoast SEO, %2$s resolves to the closing tag, %3$s resolves to Yoast SEO */
-			__( 'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the WooCommerce SEO module to work.', 'yoast-woo-seo' ),
+			/* translators: %1$s resolves to the plugin search for Yoast SEO, %2$s resolves to the closing tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce SEO */
+			__( 'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.', 'yoast-woo-seo' ),
 			'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=yoast+seo&plugin-search-input=Search+Plugins' ) ) . '">',
 			'</a>',
-			'Yoast SEO'
+			'Yoast SEO',
+            'WooCommerce SEO'
 		), '</p></div>';
 }
 
@@ -1024,7 +1028,12 @@ function yoast_wpseo_woocommerce_missing_error() {
  * @since 1.0.1
  */
 function yoast_wpseo_woocommerce_wordpress_upgrade_error() {
-	echo '<div class="error"><p>' . __( 'Please upgrade WordPress to the latest version to allow WordPress and the WooCommerce SEO module to work properly.', 'yoast-woo-seo' ) . '</p></div>';
+	echo '<div class="error"><p>' .
+        sprintf(
+            /* translators: %1$s resolves to WooCommerce SEO */
+            __( 'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.', 'yoast-woo-seo' ),
+            'WooCommerce SEO' ) .
+        '</p></div>';
 }
 
 /**
@@ -1035,9 +1044,10 @@ function yoast_wpseo_woocommerce_wordpress_upgrade_error() {
 function yoast_wpseo_woocommerce_upgrade_error() {
 	echo '<div class="error"><p>',
 		sprintf(
-			/* translators: %1$s resolves to Yoast SEO */
-			__( 'Please upgrade the %1$s plugin to the latest version to allow the WooCommerce SEO module to work.', 'yoast-woo-seo' ),
-			'Yoast SEO'
+			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce SEO */
+			__( 'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.', 'yoast-woo-seo' ),
+			'Yoast SEO',
+            'WooCommerce SEO'
 		), '</p></div>';
 }
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -439,7 +439,7 @@ class Yoast_WooCommerce_SEO {
 			), "</p>\n";
 			$this->checkbox('hide_columns', sprintf(
 			/* translators: %1$s resolves to Yoast SEO */
-				__('Remove %1$s columns', 'yoast-woo-seo'), 'Yoast SEO')
+				__( 'Remove %1$s columns', 'yoast-woo-seo' ), 'Yoast SEO' )
 			);
 
 			echo '<br class="clear"/>';

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -335,7 +335,9 @@ class Yoast_WooCommerce_SEO {
 	public function add_submenu_pages( $submenu_pages ) {
 		$submenu_pages[] = array(
 			'wpseo_dashboard',
-			sprintf( __( '%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
+			sprintf( __(
+			        /* translators: %1$s resolves to WooCommerce SEO  */
+			        '%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
 			'WooCommerce SEO',
 			'wpseo_manage_options',
 			$this->short_name,
@@ -412,7 +414,7 @@ class Yoast_WooCommerce_SEO {
 			echo '<h2>' . __( 'Breadcrumbs', 'yoast-woo-seo' ) . '</h2>';
 			echo '<p>',
 				sprintf(
-					/* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WoOCommerce */
+					/* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce */
 					__( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sInternal Links settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
 					'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_internal-links' ) ) . '">',
 					'</a>',
@@ -421,7 +423,7 @@ class Yoast_WooCommerce_SEO {
 				), "</p>\n";
 				$this->checkbox( 'breadcrumbs',
 					sprintf(
-							/* translators: %1$s resolves to WooCommerce */
+					    /* translators: %1$s resolves to WooCommerce */
 						__( 'Replace %1$s Breadcrumbs', 'yoast-woo-seo' ),
 						'WooCommerce'
 					)
@@ -438,7 +440,7 @@ class Yoast_WooCommerce_SEO {
 				'WooCommerce'
 			), "</p>\n";
 			$this->checkbox('hide_columns', sprintf(
-			/* translators: %1$s resolves to Yoast SEO */
+			    /* translators: %1$s resolves to Yoast SEO */
 				__( 'Remove %1$s columns', 'yoast-woo-seo' ), 'Yoast SEO' )
 			);
 
@@ -451,8 +453,8 @@ class Yoast_WooCommerce_SEO {
 				'WooCommerce'
 			), "</p>\n";
 			$this->checkbox( 'metabox_woo_top',
-				/* translators: %1$s resolves to WooCommerce */
 				sprintf(
+                    /* translators: %1$s resolves to WooCommerce */
 					__( 'Move %1$s up', 'yoast-woo-seo' ),
 					'WooCommerce'
 				)

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -412,22 +412,30 @@ class Yoast_WooCommerce_SEO {
 			echo '<h2>' . __( 'Breadcrumbs', 'yoast-woo-seo' ) . '</h2>';
 			echo '<p>',
 				sprintf(
-					/* translators: %1$s resolves to interal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO */
-					__( 'Both WooCommerce and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sInternal Links settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
+					/* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WoOCommerce */
+					__( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sInternal Links settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
 					'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_internal-links' ) ) . '">',
 					'</a>',
-					'Yoast SEO'
+					'Yoast SEO',
+                    'WooCommerce'
 				), "</p>\n";
-				$this->checkbox( 'breadcrumbs', __( 'Replace WooCommerce Breadcrumbs', 'yoast-woo-seo' ) );
+				$this->checkbox( 'breadcrumbs',
+                    sprintf(
+                            /* translators: %1$s resolves to WooCommerce */
+				        __( 'Replace %1$s Breadcrumbs', 'yoast-woo-seo' ),
+                        'WooCommerce'
+                    )
+                );
 		}
 
 		echo '<br class="clear"/>';
 		echo '<h2>' . __( 'Admin', 'yoast-woo-seo' ) . '</h2>';
 		echo '<p>',
 			sprintf(
-				/* translators: %1$s resolves to Yoast SEO */
-				__( 'Both WooCommerce and %1$s add columns to the product page, to remove all but the SEO score column from %1$s on that page, check this box.', 'yoast-woo-seo' ),
-				'Yoast SEO'
+				/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce */
+				__( 'Both %2$s and %1$s add columns to the product page, to remove all but the SEO score column from %1$s on that page, check this box.', 'yoast-woo-seo' ),
+				'Yoast SEO',
+                'WooCommerce'
 			), "</p>\n";
             $this->checkbox('hide_columns', sprintf(
             /* translators: %1$s resolves to Yoast SEO */
@@ -437,11 +445,18 @@ class Yoast_WooCommerce_SEO {
 			echo '<br class="clear"/>';
 			echo '<p>',
 			sprintf(
-				/* translators: %1$s resolves to Yoast SEO */
-				__( 'Both WooCommerce and %1$s add metaboxes to the edit product page, if you want WooCommerce to be above %1$s, check the box.', 'yoast-woo-seo' ),
-				'Yoast SEO'
+				/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce */
+				__( 'Both %2$s and %1$s add metaboxes to the edit product page, if you want %2$s to be above %1$s, check the box.', 'yoast-woo-seo' ),
+				'Yoast SEO',
+                'WooCommerce'
 			), "</p>\n";
-			$this->checkbox( 'metabox_woo_top', __( 'Move WooCommerce up', 'yoast-woo-seo' ) );
+			$this->checkbox( 'metabox_woo_top',
+                /* translators: %1$s resolves to WooCommerce */
+                sprintf(
+			        __( 'Move %1$s up', 'yoast-woo-seo' ),
+                    'WooCommerce'
+                )
+            );
 
 			echo '<br class="clear"/>';
 
@@ -1032,7 +1047,8 @@ function yoast_wpseo_woocommerce_wordpress_upgrade_error() {
         sprintf(
             /* translators: %1$s resolves to WooCommerce SEO */
             __( 'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.', 'yoast-woo-seo' ),
-            'WooCommerce SEO' ) .
+            'WooCommerce SEO'
+        ) .
         '</p></div>';
 }
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -336,8 +336,8 @@ class Yoast_WooCommerce_SEO {
 		$submenu_pages[] = array(
 			'wpseo_dashboard',
 			sprintf( __(
-			        /* translators: %1$s resolves to WooCommerce SEO  */
-			        '%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
+					/* translators: %1$s resolves to WooCommerce SEO  */
+					'%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
 			'WooCommerce SEO',
 			'wpseo_manage_options',
 			$this->short_name,
@@ -423,7 +423,7 @@ class Yoast_WooCommerce_SEO {
 				), "</p>\n";
 				$this->checkbox( 'breadcrumbs',
 					sprintf(
-					    /* translators: %1$s resolves to WooCommerce */
+						/* translators: %1$s resolves to WooCommerce */
 						__( 'Replace %1$s Breadcrumbs', 'yoast-woo-seo' ),
 						'WooCommerce'
 					)
@@ -440,7 +440,7 @@ class Yoast_WooCommerce_SEO {
 				'WooCommerce'
 			), "</p>\n";
 			$this->checkbox('hide_columns', sprintf(
-			    /* translators: %1$s resolves to Yoast SEO */
+				/* translators: %1$s resolves to Yoast SEO */
 				__( 'Remove %1$s columns', 'yoast-woo-seo' ), 'Yoast SEO' )
 			);
 
@@ -454,7 +454,7 @@ class Yoast_WooCommerce_SEO {
 			), "</p>\n";
 			$this->checkbox( 'metabox_woo_top',
 				sprintf(
-                    /* translators: %1$s resolves to WooCommerce */
+					/* translators: %1$s resolves to WooCommerce */
 					__( 'Move %1$s up', 'yoast-woo-seo' ),
 					'WooCommerce'
 				)

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -333,14 +333,14 @@ class Yoast_WooCommerce_SEO {
 	 * @return array All submenu pages including our own.
 	 */
 	public function add_submenu_pages( $submenu_pages ) {
-	    $submenu_pages[] = array(
-            'wpseo_dashboard',
-            sprintf( __( '%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
-            'WooCommerce SEO',
-            'wpseo_manage_options',
-            $this->short_name,
-            array( $this, 'admin_panel' ),
-        );
+		$submenu_pages[] = array(
+			'wpseo_dashboard',
+			sprintf( __( '%1$s Settings', 'yoast-woo-seo' ), 'WooCommerce SEO' ),
+			'WooCommerce SEO',
+			'wpseo_manage_options',
+			$this->short_name,
+			array( $this, 'admin_panel' ),
+		);
 
 		return $submenu_pages;
 	}
@@ -417,15 +417,15 @@ class Yoast_WooCommerce_SEO {
 					'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_internal-links' ) ) . '">',
 					'</a>',
 					'Yoast SEO',
-                    'WooCommerce'
+					'WooCommerce'
 				), "</p>\n";
 				$this->checkbox( 'breadcrumbs',
-                    sprintf(
-                            /* translators: %1$s resolves to WooCommerce */
-				        __( 'Replace %1$s Breadcrumbs', 'yoast-woo-seo' ),
-                        'WooCommerce'
-                    )
-                );
+					sprintf(
+							/* translators: %1$s resolves to WooCommerce */
+						__( 'Replace %1$s Breadcrumbs', 'yoast-woo-seo' ),
+						'WooCommerce'
+					)
+				);
 		}
 
 		echo '<br class="clear"/>';
@@ -435,12 +435,12 @@ class Yoast_WooCommerce_SEO {
 				/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce */
 				__( 'Both %2$s and %1$s add columns to the product page, to remove all but the SEO score column from %1$s on that page, check this box.', 'yoast-woo-seo' ),
 				'Yoast SEO',
-                'WooCommerce'
+				'WooCommerce'
 			), "</p>\n";
-            $this->checkbox('hide_columns', sprintf(
-            /* translators: %1$s resolves to Yoast SEO */
-                __('Remove %1$s columns', 'yoast-woo-seo'), 'Yoast SEO')
-            );
+			$this->checkbox('hide_columns', sprintf(
+			/* translators: %1$s resolves to Yoast SEO */
+				__('Remove %1$s columns', 'yoast-woo-seo'), 'Yoast SEO')
+			);
 
 			echo '<br class="clear"/>';
 			echo '<p>',
@@ -448,15 +448,15 @@ class Yoast_WooCommerce_SEO {
 				/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce */
 				__( 'Both %2$s and %1$s add metaboxes to the edit product page, if you want %2$s to be above %1$s, check the box.', 'yoast-woo-seo' ),
 				'Yoast SEO',
-                'WooCommerce'
+				'WooCommerce'
 			), "</p>\n";
 			$this->checkbox( 'metabox_woo_top',
-                /* translators: %1$s resolves to WooCommerce */
-                sprintf(
-			        __( 'Move %1$s up', 'yoast-woo-seo' ),
-                    'WooCommerce'
-                )
-            );
+				/* translators: %1$s resolves to WooCommerce */
+				sprintf(
+					__( 'Move %1$s up', 'yoast-woo-seo' ),
+					'WooCommerce'
+				)
+			);
 
 			echo '<br class="clear"/>';
 
@@ -1033,7 +1033,7 @@ function yoast_wpseo_woocommerce_missing_error() {
 			'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=yoast+seo&plugin-search-input=Search+Plugins' ) ) . '">',
 			'</a>',
 			'Yoast SEO',
-            'WooCommerce SEO'
+			'WooCommerce SEO'
 		), '</p></div>';
 }
 
@@ -1044,12 +1044,12 @@ function yoast_wpseo_woocommerce_missing_error() {
  */
 function yoast_wpseo_woocommerce_wordpress_upgrade_error() {
 	echo '<div class="error"><p>' .
-        sprintf(
-            /* translators: %1$s resolves to WooCommerce SEO */
-            __( 'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.', 'yoast-woo-seo' ),
-            'WooCommerce SEO'
-        ) .
-        '</p></div>';
+		sprintf(
+			/* translators: %1$s resolves to WooCommerce SEO */
+			__( 'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.', 'yoast-woo-seo' ),
+			'WooCommerce SEO'
+		) .
+		'</p></div>';
 }
 
 /**
@@ -1063,7 +1063,7 @@ function yoast_wpseo_woocommerce_upgrade_error() {
 			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce SEO */
 			__( 'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.', 'yoast-woo-seo' ),
 			'Yoast SEO',
-            'WooCommerce SEO'
+			'WooCommerce SEO'
 		), '</p></div>';
 }
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -439,7 +439,7 @@ class Yoast_WooCommerce_SEO {
 				'Yoast SEO',
 				'WooCommerce'
 			), "</p>\n";
-			$this->checkbox('hide_columns', sprintf(
+			$this->checkbox( 'hide_columns', sprintf(
 				/* translators: %1$s resolves to Yoast SEO */
 				__( 'Remove %1$s columns', 'yoast-woo-seo' ), 'Yoast SEO' )
 			);


### PR DESCRIPTION
Fixes #163 

Removes Yoast SEO, WooCommerce SEO and WooCommerce out of translations.