### PR TITLE
Fix link to a page that has been renamed to wpseo_advanced

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -411,12 +411,14 @@ class Yoast_WooCommerce_SEO {
 		if ( $wpseo_options['breadcrumbs-enable'] === true ) {
 			echo '<h2>' . __( 'Breadcrumbs', 'yoast-woo-seo' ) . '</h2>';
 			echo '<p>',
+
 				sprintf(
-					/* translators: %1$s resolves to interal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO */
+                /* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce */
                     __( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sBreadcrumbs settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
                     '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=breadcrumbs' ) ) . '">',
 					'</a>',
-					'Yoast SEO'
+					'Yoast SEO',
+                    'WooCommerce'
 				), "</p>\n";
 				$this->checkbox( 'breadcrumbs', __( 'Replace WooCommerce Breadcrumbs', 'yoast-woo-seo' ) );
 		}

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -413,8 +413,8 @@ class Yoast_WooCommerce_SEO {
 			echo '<p>',
 				sprintf(
 					/* translators: %1$s resolves to interal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO */
-					__( 'Both WooCommerce and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sInternal Links settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
-					'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_internal-links' ) ) . '">',
+                    __( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sBreadcrumbs settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
+                    '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=breadcrumbs' ) ) . '">',
 					'</a>',
 					'Yoast SEO'
 				), "</p>\n";

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -413,12 +413,12 @@ class Yoast_WooCommerce_SEO {
 			echo '<p>',
 
 				sprintf(
-                /* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce */
-                    __( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sBreadcrumbs settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
-                    '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=breadcrumbs' ) ) . '">',
+					/* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce */
+					__( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sBreadcrumbs settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
+					'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=breadcrumbs' ) ) . '">',
 					'</a>',
 					'Yoast SEO',
-                    'WooCommerce'
+					'WooCommerce'
 				), "</p>\n";
 				$this->checkbox( 'breadcrumbs', __( 'Replace WooCommerce Breadcrumbs', 'yoast-woo-seo' ) );
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
Fixes a bug where there was a link to a settings page that no longer existed.

## Test instructions

This PR can be tested by following these steps:

* Checkout trunk.
* Activate Yoast SEO & Yoast SEO for WooCommerce
* Go to SEO->Advanced->Breadcrumbs
* Enable breadcrumbs
* Go to SEO-> WooCommerce SEO
* See that under 'Breadcrumbs' the 'internal links settings page' url does not work.
* Checkout this PR.
* See that under 'Breadcrumbs' the link has been renamed to 'Breadcrumbs settings page' and the link now works.  

Fixes #130 
