### PR TITLE
Build: Travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,4 +82,5 @@ before_script:
 script:
 - if [[ "$PHPLINT" == "1" ]]; then find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
 - if [[ "$PHPCS" == "1" ]]; then vendor/bin/phpcs -v; fi
-- phpunit -c phpunit.xml
+- if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpunit -c phpunit.xml; fi
+- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then vendor/bin/phpunit -c phpunit.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,3 +84,4 @@ script:
 - if [[ "$PHPCS" == "1" ]]; then vendor/bin/phpcs -v; fi
 - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then phpunit -c phpunit.xml; fi
 - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then vendor/bin/phpunit -c phpunit.xml; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "yoast/wpseo-woocommerce",
     "description": "This extension to WooCommerce and WordPress SEO by Yoast makes sure there's perfect communication between the two plugins.",
     "type": "wordpress-plugin",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Team Yoast",


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:

This PR contains two tweaks to the Travis build script - each in a separate commit for easier review. Also see the commit messages for additional info:

1. On line 50 of the script, a specific PHPUnit version is pulled in via Composer for certain PHP versions. This PHPUnit version is subsequently never used.
    This commit brings the command to run PHPUnit in line with this.
    Alternatively, - as it looks like the build runs fine with PHPUnit 6 -, the `composer require` on line 50 could be removed.
2. Validate the `composer.json` file during the builds.


## Test instructions
* Check the Travis build logs to see the effects.


