### PR TITLE
Clean up: remove methods deprecated < WooCommerce SEO 4.0

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -1139,52 +1139,6 @@ class Yoast_WooCommerce_SEO {
 		);
 	}
 
-	/********************** DEPRECATED METHODS **********************/
-
-	/**
-	 * Initialize the plugin defaults.
-	 *
-	 * @deprecated 1.1.0 - now auto-handled by class WPSEO_Option_Woo
-	 */
-	public function initialize_defaults() {
-		_deprecated_function( __CLASS__ . '::' . __METHOD__, 'WooCommerce SEO 1.1.0', null );
-	}
-
-	/**
-	 * Registers the plugins setting for the Settings API
-	 *
-	 * @since      1.0
-	 * @deprecated 1.1.0 - now auto-handled by class WPSEO_Option_Woo
-	 */
-	public function options_init() {
-		_deprecated_function( __CLASS__ . '::' . __METHOD__, 'WooCommerce SEO 1.1.0', null );
-	}
-
-	/**
-	 * Keep old behaviour of getting the twitter domain in a different way than in WPSEO, but prevent duplicate
-	 * twitter:domain meta tags
-	 *
-	 * @deprecated 3.1
-	 *
-	 * @param string $domain The domain to filter.
-	 *
-	 * @return  string
-	 */
-	public function filter_twitter_domain( $domain ) {
-		_deprecated_function( __CLASS__ . '::' . __METHOD__, 'WooCommerce SEO 3.1', null );
-
-		return '';
-	}
-
-	/**
-	 * Output the extra data for the Twitter Card
-	 *
-	 * @deprecated 3.1
-	 * @since      1.0
-	 */
-	public function twitter_enhancement() {
-		_deprecated_function( __CLASS__ . '::' . __METHOD__, 'WooCommerce SEO 3.1', null );
-	}
 }
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _Various (internal) methods which had been previously deprecated and had been deprecated for more than a year, have now been removed._

## Relevant technical choices:

Removed method deprecated more than a year ago.
There are a few more deprecated methods (one or two if I remember correctly), but those are far more recent, so should remain for now.

## Test instructions

This PR can be tested by following these steps:
* Things should still work as expected even when this code is removed, that's all you can check for really.
