### PR TITLE
Clean up: remove back-fill which is no longer needed

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -1263,17 +1263,6 @@ function initialize_yoast_woocommerce_seo() {
 	}
 }
 
-if ( ! function_exists( 'wp_installing' ) ) {
-	/**
-	 * We need to define wp_installing in WordPress versions older than 4.4
-	 *
-	 * @return bool
-	 */
-	function wp_installing() {
-		return defined( 'WP_INSTALLING' );
-	}
-}
-
 /**
  * Instantiate the plugin license manager for the current plugin and activate it's license.
  */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Removed backfill for `wp_installing()` as this was introduced in WordPress 4.4.

## Relevant technical choices:

* The minimum supported WP version is now WP 4.8. The `wp_installing()` function was introduced in WP 4.4.

## Test instructions

This PR can be tested by following these steps:
* The plugin should still start up & hook-in as normal. No changes should be noticeable.
