### PR TITLE
CS/QA: Use strict comparisons with array functions

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -885,7 +885,7 @@ class Yoast_WooCommerce_SEO {
 	protected function is_woocommerce_page( $page ) {
 		$woo_pages = array( 'wpseo_woo' );
 
-		return in_array( $page, $woo_pages );
+		return in_array( $page, $woo_pages, true );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

For array functions which do loose type comparisons, setting the third `$strict` parameter to `false` can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.

## Test instructions

Testing recommended, though I don't expect any issues.