### PR TITLE
CS/QA: use `wp_strip_all_tags()`

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -693,7 +693,7 @@ class Yoast_WooCommerce_SEO {
 			$term_desc = term_description();
 
 			if ( ! empty( $term_desc ) ) {
-				$desc = trim( strip_tags( $term_desc ) );
+				$desc = wp_strip_all_tags( $term_desc, true );
 				$desc = strip_shortcodes( $desc );
 			}
 		}
@@ -1012,7 +1012,7 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		if ( method_exists( $product, 'get_price' ) ) {
-			return strip_tags( wc_price( $product->get_price() ) );
+			return wp_strip_all_tags( wc_price( $product->get_price() ), true );
 		}
 
 		return '';


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:

The `wp_strip_all_tags()` function is more comprehensive than the PHP native `strip_tags()` function.

The advantage of `wp_strip_all_tags()` over `strip_tags()` is that it does not leave the content of removed `<script>` and `<style>` tags behind.

> This differs from `strip_tags()` because it removes the contents of the `<script>` and `<style>` tags. E.g. `strip_tags( '<script>something</script>' )` will return ‘something’. `wp_strip_all_tags()` will return ”

It can also remove superfluous whitespace within the string which may be left behind after removing the tags. For this, the second parameter `$remove_breaks` needs to be passed and set to `true`.

Refs:
* https://developer.wordpress.org/reference/functions/wp_strip_all_tags/
* http://php.net/manual/en/function.strip-tags.php

## Test instructions

* Verify that the value if the Open Graph description tag is the same as before for a WooCommerce product taxonomy page.
* Add a `<script>` or `<style>` tag in the taxonomy term description value and see the improved output.

* Similarly for the second change, use `wc_price` as a variable to be replaced in a product meta description, then edit the price to use some nefarious code and see the improved output.
