### PR TITLE
CS/XSS: always escape output [2]

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -1156,15 +1156,16 @@ class Yoast_WooCommerce_SEO {
  * @since 1.0.1
  */
 function yoast_wpseo_woocommerce_missing_error() {
-	echo '<div class="error"><p>',
-		sprintf(
-			/* translators: %1$s resolves to the plugin search for Yoast SEO, %2$s resolves to the closing tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce SEO */
-			__( 'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.', 'yoast-woo-seo' ),
-			'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=yoast+seo&plugin-search-input=Search+Plugins' ) ) . '">',
-			'</a>',
-			'Yoast SEO',
-			'WooCommerce SEO'
-		), '</p></div>';
+	echo '<div class="error"><p>';
+	printf(
+		/* translators: %1$s resolves to the plugin search for Yoast SEO, %2$s resolves to the closing tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce SEO */
+		esc_html__( 'Please %1$sinstall &amp; activate %3$s%2$s and then enable its XML sitemap functionality to allow the %4$s module to work.', 'yoast-woo-seo' ),
+		'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=yoast+seo&plugin-search-input=Search+Plugins' ) ) . '">',
+		'</a>',
+		'Yoast SEO',
+		'WooCommerce SEO'
+	);
+	echo '</p></div>';
 }
 
 /**
@@ -1173,13 +1174,13 @@ function yoast_wpseo_woocommerce_missing_error() {
  * @since 1.0.1
  */
 function yoast_wpseo_woocommerce_wordpress_upgrade_error() {
-	echo '<div class="error"><p>' .
-		sprintf(
-			/* translators: %1$s resolves to WooCommerce SEO */
-			__( 'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.', 'yoast-woo-seo' ),
-			'WooCommerce SEO'
-		) .
-		'</p></div>';
+	echo '<div class="error"><p>';
+	printf(
+		/* translators: %1$s resolves to WooCommerce SEO */
+		esc_html__( 'Please upgrade WordPress to the latest version to allow WordPress and the %1$s module to work properly.', 'yoast-woo-seo' ),
+		'WooCommerce SEO'
+	);
+	echo '</p></div>';
 }
 
 /**
@@ -1188,13 +1189,14 @@ function yoast_wpseo_woocommerce_wordpress_upgrade_error() {
  * @since 1.0.1
  */
 function yoast_wpseo_woocommerce_upgrade_error() {
-	echo '<div class="error"><p>',
-		sprintf(
-			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce SEO */
-			__( 'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.', 'yoast-woo-seo' ),
-			'Yoast SEO',
-			'WooCommerce SEO'
-		), '</p></div>';
+	echo '<div class="error"><p>';
+	printf(
+		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce SEO */
+		esc_html__( 'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.', 'yoast-woo-seo' ),
+		'Yoast SEO',
+		'WooCommerce SEO'
+	);
+	echo '</p></div>';
 }
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_Security hardening_

## Relevant technical choices:
* No functional changes.
* QA/CS compliance.

All output should be escaped, including translations.

Includes minor code build-up changes.

Side-note: the version checks used in the `initialize_yoast_woocommerce_seo()` method seem a bit out of sync.... Should those be updated ?

https://github.com/Yoast/wpseo-woocommerce/blob/456cafe0273c54d97b61b30cc20f7448244467f9/wpseo-woocommerce.php#L1212-L1216

## Test instructions

Testing recommended, but no problems expected.

Test this by triggering each error message and reviewing the output, i.e.:
* Try and use WooCommerce SEO on an old WP version
* Try and use WooCommerce SEO with a really old version of WPSEO
* Try and use WooCommerce SEO with WPSEO deactivated WPSEO.
