### PR TITLE
Add WordPress SEO version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
     "autoload": {
         "classmap": [ "classes/" ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/"
+        ]
+    },
     "require": {
         "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0||^2.0",

--- a/tests/doubles/woocommerce-double.php
+++ b/tests/doubles/woocommerce-double.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @package WPSEO\Tests
+ */
+
+/**
+ * Class Yoast_WooCommerce_SEO_Double
+ */
+class Yoast_WooCommerce_SEO_Double extends Yoast_WooCommerce_SEO {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function check_dependencies( $wp_version ) {
+		return parent::check_dependencies( $wp_version );
+	}
+}

--- a/tests/test-class-wpseo-woocommerce.php
+++ b/tests/test-class-wpseo-woocommerce.php
@@ -27,4 +27,53 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Tests the check dependencies function.
+	 *
+	 * @dataProvider check_dependencies_data
+	 *
+	 * @param bool   $expected              The expected value.
+	 * @param string $wordpress_seo_version The WordPress SEO version to check.
+	 * @param string $wordpress_version     The WordPress version to check.
+	 * @param string $message               Message given by PHPUnit after assertion.
+	 *
+	 * @covers Yoast_WooCommerce_SEO::check_dependencies()
+	 *
+	 * @group test
+	 */
+	public function test_check_dependencies( $expected, $wordpress_seo_version, $wordpress_version, $message ) {
+		$class_instance = $this
+			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_wordpress_seo_version' ) )
+			->getMock();
+
+		$class_instance
+			->method( 'get_wordpress_seo_version' )
+			->will( $this->returnValue( $wordpress_seo_version ) );
+
+
+		$this->assertEquals( $expected, $class_instance->check_dependencies( $wordpress_version ), $message );
+	}
+
+	/**
+	 * Data provider for the check dependencies test.
+	 *
+	 * [0]: Expected
+	 * [1]: WordPress SEO Version
+	 * [2]: WordPress Version
+	 * [3]: Message for PHPUnit.
+	 *
+	 * @return array
+	 */
+	public function check_dependencies_data() {
+		return array(
+			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
+			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
+			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
+			array( true, '7.0', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '8.0', '3.5', 'WordPress and WordPress SEO have the minimal required versions.' ),
+		);
+	}
 }

--- a/tests/test-class-wpseo-woocommerce.php
+++ b/tests/test-class-wpseo-woocommerce.php
@@ -39,8 +39,6 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * @param string $message               Message given by PHPUnit after assertion.
 	 *
 	 * @covers Yoast_WooCommerce_SEO::check_dependencies()
-	 *
-	 * @group test
 	 */
 	public function test_check_dependencies( $expected, $wordpress_seo_version, $wordpress_version, $message ) {
 		$class_instance = $this

--- a/tests/test-class-wpseo-woocommerce.php
+++ b/tests/test-class-wpseo-woocommerce.php
@@ -69,10 +69,11 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	public function check_dependencies_data() {
 		return array(
 			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
+			array( false, '7.0', '3.5', 'WordPress is below the minimal required version.' ),
 			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
 			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
 			array( true, '7.0', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
-			array( true, '8.0', '3.5', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '8.0', '4.8', 'WordPress and WordPress SEO have the minimal required versions.' ),
 		);
 	}
 }

--- a/tests/test-class-wpseo-woocommerce.php
+++ b/tests/test-class-wpseo-woocommerce.php
@@ -48,6 +48,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->getMock();
 
 		$class_instance
+			->expects( $this->any() )
 			->method( 'get_wordpress_seo_version' )
 			->will( $this->returnValue( $wordpress_seo_version ) );
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -67,7 +67,7 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Class constructor
+	 * Class constructor.
 	 *
 	 * @since 1.0
 	 */

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -102,8 +102,8 @@ class Yoast_WooCommerce_SEO {
 			return false;
 		}
 
-		// When version is below 7.0.
-		if ( ! version_compare( $wordpress_seo_version, '7.0', '>=' ) ) {
+		// Make sure Yoast SEO is at least 7.0, including the RC versions, so bigger than 6.9.
+		if ( ! version_compare( $wordpress_seo_version, '6.9', '>' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_upgrade_error' );
 
 			return false;

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -87,7 +87,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return bool True whether the dependencies are okay.
 	 */
 	protected function check_dependencies( $wp_version ) {
-		if ( ! version_compare( $wp_version, '3.5', '>=' ) ) {
+		if ( ! version_compare( $wp_version, '4.8', '>=' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_wordpress_upgrade_error' );
 
 			return false;

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -67,11 +67,72 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Class constructor, basically hooks all the required functionality.
+	 * Class constructor
 	 *
 	 * @since 1.0
 	 */
 	public function __construct() {
+		global $wp_version;
+
+		if ( $this->check_dependencies( $wp_version ) ) {
+			$this->initialize();
+		}
+	}
+
+	/**
+	 * Checks the dependencies. Sets a notice when requirements aren't met.
+	 *
+	 * @param string $wp_version The current version of WordPress.
+	 *
+	 * @return bool True whether the dependencies are okay.
+	 */
+	protected function check_dependencies( $wp_version ) {
+		if ( ! version_compare( $wp_version, '3.5', '>=' ) ) {
+			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_wordpress_upgrade_error' );
+
+			return false;
+		}
+
+		$wordpress_seo_version = $this->get_wordpress_seo_version();
+
+		// When WordPress SEO is not installed.
+		if ( ! $wordpress_seo_version ) {
+			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_missing_error' );
+
+			return false;
+		}
+
+		// When version is below 7.0.
+		if ( ! version_compare( $wordpress_seo_version, '7.0', '>=' ) ) {
+			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_upgrade_error' );
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the WordPress SEO version when set.
+	 *
+	 * @return bool|string The version whether it is set.
+	 */
+	protected function get_wordpress_seo_version() {
+		if ( ! defined( 'WPSEO_VERSION' ) ) {
+			return false;
+		}
+
+		return WPSEO_VERSION;
+	}
+
+	/**
+	 * Initializes the plugin, basically hooks all the required functionality.
+	 *
+	 * @since 7.0
+	 *
+	 * @return void
+	 */
+	protected function initialize() {
 		if ( $this->is_woocommerce_page( filter_input( INPUT_GET, 'page' ) ) ) {
 			$this->register_i18n_promo_class();
 		}
@@ -1199,30 +1260,19 @@ function yoast_wpseo_woocommerce_upgrade_error() {
 
 
 /**
- * Initialize the plugin class, to make sure all the required functionality is loaded, do this after plugins_loaded.
+ * Initializes the plugin class, to make sure all the required functionality is loaded, do this after plugins_loaded.
  *
  * @since 1.0
+ *
+ * @return void
  */
 function initialize_yoast_woocommerce_seo() {
 	global $yoast_woo_seo;
-	global $wp_version;
 
 	load_plugin_textdomain( 'yoast-woo-seo', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-	if ( ! version_compare( $wp_version, '3.5', '>=' ) ) {
-		add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_wordpress_upgrade_error' );
-	}
-	elseif ( defined( 'WPSEO_VERSION' ) ) {
-		if ( version_compare( WPSEO_VERSION, '1.5', '>=' ) ) {
-			$yoast_woo_seo = new Yoast_WooCommerce_SEO();
-		}
-		else {
-			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_upgrade_error' );
-		}
-	}
-	else {
-		add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_missing_error' );
-	}
+	// Initializes the plugin.
+	$yoast_woo_seo = new Yoast_WooCommerce_SEO();
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Show a notice when a WordPress SEO version below 7.0 is installed.
* Show a notice when a WordPress version below 4.8 is installed.

## Test instructions

This PR can be tested by following these steps:

* Have this branch and WordPress SEO active. Change in WordPress SEO the value of constant `WPSEO_VERSION` in a value below 7.0
* A notice should be shown. 
* Change the value of the constant to 7.0 or 7.1 and see the notice being gone.

* The minimal required WordPress version can be tested by adding this to the 'wpseo-woocommerce.php' file:
```php
add_action( 'admin_init', function() {
	global $wp_version;

	$wp_version = 4.7;
} );
```

Fixes #195 
Fixes #212
