### PR TITLE
Bump YoastSEO to 1.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Yoast/wpseo-woocommerce"
   },
   "dependencies": {
-    "yoastseo": "^1.30"
+    "yoastseo": "^1.30.1"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5302,9 +5302,9 @@ yargs@~3.5.4:
     window-size "0.1.0"
     wordwrap "0.0.2"
 
-yoastseo@^1.30:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.0.tgz#9bd482097ad4aa0e48a74af2c2b5484e70e51fba"
+yoastseo@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.1.tgz#56ae066ede0009d840debaf3f129c130433b363a"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Bump YoastSEO.js to 1.30.1

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks.