### PR TITLE
Bump YoastSEO.js to 1.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Yoast/wpseo-woocommerce"
   },
   "dependencies": {
-    "yoastseo": "^1.30.2"
+    "yoastseo": "^1.31.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5466,9 +5466,9 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sassdash@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.8.2.tgz#42d59b4932f13034695604bd8437e2b598afd368"
+sassdash@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.9.0.tgz#e2114e80af0c01639d1c6b88a3eb350740cb1169"
 
 sax@^1.2.4:
   version "1.2.4"
@@ -6491,16 +6491,16 @@ yargs@~3.5.4:
     window-size "0.1.0"
     wordwrap "0.0.2"
 
-yoastseo@^1.30.2:
-  version "1.30.2"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.30.2.tgz#857a622593c8d67784e83748b6a3da9ec0c7dd98"
+yoastseo@^1.31.0:
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.31.0.tgz#4ff9f37dcefe629ac66676ae4f2afcb1b4e54b2a"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"
     jest "^22.0.0"
     lodash "^4.14.1"
     node-sass "^4.7.2"
-    sassdash "^0.8.1"
+    sassdash "^0.9.0"
     tokenizer2 "^2.0.0"
 
 zip-stream@^1.1.0:


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Bumps YoastSEO.js to 1.31

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks.