### PR TITLE
Exclude artifact folder from pot file creation

### DIFF
--- a/grunt/config/makepot.js
+++ b/grunt/config/makepot.js
@@ -4,6 +4,7 @@ module.exports = {
 		options: {
 			domainPath: "<%= paths.languages %>",
 			potFilename: "<%= pkg.plugin.textdomain %>.pot",
+			exclude: [ "artifact/.*" ],
 			potHeaders: {
 				poedit: true,
 				"report-msgid-bugs-to": "<%= pkg.pot.reportmsgidbugsto %>",

--- a/languages/yoast-woo-seo.pot
+++ b/languages/yoast-woo-seo.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Yoast SEO: WooCommerce 7.5\n"
 "Report-Msgid-Bugs-To: https://github.com/yoast/wpseo-woocommerce/issues\n"
-"POT-Creation-Date: 2018-05-15 09:06:04+00:00\n"
+"POT-Creation-Date: 2018-05-15 14:39:06+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -280,8 +280,8 @@ msgstr ""
 
 #. Description of the plugin/theme
 msgid ""
-"This extension to WooCommerce and WordPress SEO by Yoast makes sure there's "
-"perfect communication between the two plugins."
+"This extension to WooCommerce and Yoast SEO makes sure there's perfect "
+"communication between the two plugins."
 msgstr ""
 
 #. Author of the plugin/theme


### PR DESCRIPTION
## Summary

If an artifact was build previously, this will be taken into account when re-generating the language files. Resulting in double entries which are not relevant.

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Excluded the `optionally present` artifact folder from being parsed for translations.

## Test instructions

This PR can be tested by following these steps:

* `grunt copy:artifact` - This generates an `artifact` folder in your local directory
* `grunt build:i18n` - This rebuilds the `pot` file

Related https://github.com/Yoast/wpseo-news/issues/406
