### PR TITLE
Update YoastSEO.js to v1.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Yoast/wpseo-woocommerce"
   },
   "dependencies": {
-    "yoastseo": "^1.32.0"
+    "yoastseo": "^1.33.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6491,9 +6491,9 @@ yargs@~3.5.4:
     window-size "0.1.0"
     wordwrap "0.0.2"
 
-yoastseo@^1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.32.0.tgz#d15982118849c3d5ba2438776b49bfc83cb1d53a"
+yoastseo@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.33.0.tgz#9cea8af7fea97c382e2ef0317133dacc51f11237"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated YoastSEO.js to v1.33.0

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Check if everything still works.

Fixes #
