### PR TITLE
Bump YoastSEO.js to 1.34.0

### DIFF
--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -1,7 +1,7 @@
 /* global jQuery, tinyMCE, YoastSEO, wpseoWooReplaceVarsL10n */
 ( function() {
 	var pluginName = "replaceWooVariablePlugin";
-	var ReplaceVar = window.YoastReplaceVarPlugin.ReplaceVar;
+	var ReplaceVar = window.YoastReplaceVarPlugin && window.YoastReplaceVarPlugin.ReplaceVar;
 	var placeholders = {};
 
 	var modifiableFields = [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Yoast/wpseo-woocommerce"
   },
   "dependencies": {
-    "yoastseo": "^1.33.1"
+    "yoastseo": "^1.34.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6488,9 +6488,9 @@ yargs@~3.5.4:
     window-size "0.1.0"
     wordwrap "0.0.2"
 
-yoastseo@^1.33.1:
-  version "1.33.1"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.33.1.tgz#da04fd320a933cb7ef3bbe6a91cc5216a33105d2"
+yoastseo@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.34.0.tgz#d21066142268623e36c1f616c6e739bd2a2a5587"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"


### PR DESCRIPTION
Bump YoastSEO.js to 1.34.0

## Summary

This PR can be summarized in the following changelog entry:

* Bumps YoastSEO.js to 1.34.0

## Fix

* Fixes JS error on the product overview page.

## Test instructions

This PR can be tested by following these steps:

* Check whether nothing breaks.