### PR TITLE
Filters excluded catalog products from the sitemap

### DIFF
--- a/tests/doubles/woocommerce-seo-double.php
+++ b/tests/doubles/woocommerce-seo-double.php
@@ -20,4 +20,11 @@ class Yoast_WooCommerce_SEO_Double extends Yoast_WooCommerce_SEO {
 	public function check_dependencies( $wp_version ) {
 		return parent::check_dependencies( $wp_version );
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function filter_hidden_product( $url, $type, $post ) {
+		return parent::filter_hidden_product( $url, $type, $post );
+	}
 }

--- a/tests/doubles/woocommerce-seo-double.php
+++ b/tests/doubles/woocommerce-seo-double.php
@@ -22,7 +22,7 @@ class Yoast_WooCommerce_SEO_Double extends Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public function filter_hidden_product( $url, $type, $post ) {
 		return parent::filter_hidden_product( $url, $type, $post );

--- a/tests/doubles/woocommerce-seo-double.php
+++ b/tests/doubles/woocommerce-seo-double.php
@@ -22,7 +22,13 @@ class Yoast_WooCommerce_SEO_Double extends Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * @inheritDoc
+	 * Prevents a hidden product from being added to the sitemap.
+	 *
+	 * @param array   $url  The url data.
+	 * @param string  $type The object type.
+	 * @param WP_Post $post The post object.
+	 *
+	 * @return bool|array False when entry is hidden.
 	 */
 	public function filter_hidden_product( $url, $type, $post ) {
 		return parent::filter_hidden_product( $url, $type, $post );

--- a/tests/woocommerce-seo-test.php
+++ b/tests/woocommerce-seo-test.php
@@ -59,6 +59,130 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	}
 
 	/**
+	 * Tests the sitemap filtering of a product that is not hidden.
+	 *
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 */
+	public function test_filter_hidden_product_for_product_that_is_visible() {
+		$product = self::factory()->post->create_and_get(
+			array(
+				'post_type' => 'product',
+			)
+		);
+
+		$instance = $this
+			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->setMethods( array( 'excluded_from_catalog' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'excluded_from_catalog' )
+			->will( $this->returnValue( array(  ) ) );
+
+		$this->assertEquals(
+			array( 'loc' => 'http://shop.site/product' ),
+			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
+		);
+	}
+
+	/**
+	 * Tests the sitemap filtering of a product that is hidden from the catalog.
+	 *
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 */
+	public function test_filter_hidden_product_for_product_that_is_hidden() {
+		$product = self::factory()->post->create_and_get(
+			array(
+				'post_type' => 'product',
+			)
+		);
+
+		$instance = $this
+			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->setMethods( array( 'excluded_from_catalog' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->once() )
+			->method( 'excluded_from_catalog' )
+			->will( $this->returnValue( array( $product->ID ) ) );
+
+		$this->assertFalse(
+			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
+		);
+	}
+
+	/**
+	 * Tests the sitemap filtering of a product that is not a product
+	 *
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 */
+	public function test_filter_hidden_product_for_a_non_product() {
+		$product = self::factory()->post->create_and_get(
+			array(
+				'post_type' => 'post',
+			)
+		);
+
+		$instance = $this
+			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->setMethods( array( 'excluded_from_catalog' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'excluded_from_catalog' );
+
+		$this->assertEquals(
+			array( 'loc' => 'http://shop.site/product' ),
+			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
+		);
+	}
+
+	/**
+	 * Tests the sitemap filtering of a product when a invalid post object is given.
+	 *
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 */
+	public function test_filter_hidden_product_when_invalid_post_object_is_given() {
+		$instance = $this
+			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->setMethods( array( 'excluded_from_catalog' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'excluded_from_catalog' );
+
+		$this->assertEquals(
+			array( 'loc' => 'http://shop.site/product' ),
+			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', null )
+		);
+	}
+
+	/**
+	 * Tests the sitemap filtering when no url loc is given to the url data.
+	 *
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 */
+	public function test_filter_hidden_product_when_no_url_loc_is_present() {
+		$instance = $this
+			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->setMethods( array( 'excluded_from_catalog' ) )
+			->getMock();
+
+		$instance
+			->expects( $this->never() )
+			->method( 'excluded_from_catalog' );
+
+		$this->assertEquals(
+			array( 'no-loc' => 'http://shop.site/product' ),
+			$instance->filter_hidden_product( array( 'no-loc' => 'http://shop.site/product' ), 'post', null )
+		);
+	}
+
+	/**
 	 * Data provider for the check dependencies test.
 	 *
 	 * [0]: Expected

--- a/tests/woocommerce-seo-test.php
+++ b/tests/woocommerce-seo-test.php
@@ -78,7 +78,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 		$instance
 			->expects( $this->once() )
 			->method( 'excluded_from_catalog' )
-			->will( $this->returnValue( array(  ) ) );
+			->will( $this->returnValue( array() ) );
 
 		$this->assertEquals(
 			array( 'loc' => 'http://shop.site/product' ),

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -266,7 +266,7 @@ class Yoast_WooCommerce_SEO {
 		static $excluded_from_catalog;
 
 		if ( $excluded_from_catalog === null ) {
-			$query                 = new WP_Query(
+			$query = new WP_Query(
 				array(
 					'fields'    => 'ids',
 					'post_type' => 'product',

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -241,11 +241,12 @@ class Yoast_WooCommerce_SEO {
 	 * @return bool|array False when entry is hidden.
 	 */
 	public function filter_hidden_product( $url, $type, $post ) {
+
 		if ( empty( $url['loc'] ) ) {
 			return $url;
 		}
-
-		if ( $post instanceof WP_Post === false ) {
+		
+		if ( ! is_object( $post ) || ! property_exists( $post, 'post_type' ) ) {
 			return $url;
 		}
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -228,7 +228,7 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		add_filter( 'wpseo_sitemap_entry', array( $this, 'filter_hidden_product' ), 10, 3 );
-    add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_woocommerce_pages' ) );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_woocommerce_pages' ) );
 	}
 
 	/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -287,7 +287,7 @@ class Yoast_WooCommerce_SEO {
 			$excluded_from_catalog = $query->get_posts();
 		}
 
-		return $excluded_from_catalog;		
+		return $excluded_from_catalog;
 	}
 
 	/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -266,7 +266,7 @@ class Yoast_WooCommerce_SEO {
 		static $excluded_from_catalog;
 
 		if ( $excluded_from_catalog === null ) {
-			$query = new WP_Query(
+			$query                 = new WP_Query(
 				array(
 					'fields'    => 'ids',
 					'post_type' => 'product',

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -244,6 +244,10 @@ class Yoast_WooCommerce_SEO {
 			return $url;
 		}
 
+		if ( $post instanceof WP_Post === false ) {
+			return $url;
+		}
+
 		if ( $post->post_type !== 'product' ) {
 			return $url;
 		}
@@ -254,7 +258,6 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		return $url;
-
 	}
 
 	/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -266,10 +266,11 @@ class Yoast_WooCommerce_SEO {
 		static $excluded_from_catalog;
 
 		if ( $excluded_from_catalog === null ) {
-			$query = new WP_Query(
+			$query                 = new WP_Query(
 				array(
 					'fields'    => 'ids',
 					'post_type' => 'product',
+					// phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_tax_query
 					'tax_query' => array(
 						array(
 							'taxonomy' => 'product_visibility',

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -241,11 +241,10 @@ class Yoast_WooCommerce_SEO {
 	 * @return bool|array False when entry is hidden.
 	 */
 	public function filter_hidden_product( $url, $type, $post ) {
-
 		if ( empty( $url['loc'] ) ) {
 			return $url;
 		}
-		
+
 		if ( ! is_object( $post ) || ! property_exists( $post, 'post_type' ) ) {
 			return $url;
 		}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Hides excluded catalog products from the products sitemap.

## Test instructions

This PR can be tested by following these steps:

* Add a product (for example: Product A)
* View the products sitemap and verify the product being visible.
* Edit the product by excluding it from the catalog:
![cursor_and_edit_product_ _local_wordpress_dev_ _wordpress](https://user-images.githubusercontent.com/325040/41595944-edf90484-73c8-11e8-8739-8375b44dc66e.png)
![edit_product_ _local_wordpress_dev_ _wordpress](https://user-images.githubusercontent.com/325040/41595984-0c4176a6-73c9-11e8-87b9-6e8c2a9640c0.png)
* Visit the sitemap and the product should be hidden.

Fixes #42