### PR TITLE
Bump YoastSEO.js to v1.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Yoast/wpseo-woocommerce"
   },
   "dependencies": {
-    "yoastseo": "^1.35.5"
+    "yoastseo": "^1.36.0"
   },
   "devDependencies": {
     "@yoast/grunt-plugin-tasks": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5531,7 +5531,7 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sassdash@^0.9.0:
+sassdash@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/sassdash/-/sassdash-0.9.0.tgz#e2114e80af0c01639d1c6b88a3eb350740cb1169"
 
@@ -6557,16 +6557,16 @@ yargs@~3.5.4:
     window-size "0.1.0"
     wordwrap "0.0.2"
 
-yoastseo@^1.35.5:
-  version "1.35.5"
-  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.35.5.tgz#37a8df691f365e8537a5b27279dd3be0e0cb60d6"
+yoastseo@^1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/yoastseo/-/yoastseo-1.36.0.tgz#8abc9d8f1b8ecc01a2848bef73be6fdbbd61eb99"
   dependencies:
     htmlparser2 "^3.9.2"
     jed "^1.1.0"
     jest "^23.0.0"
     lodash "^4.14.1"
     node-sass "^4.7.2"
-    sassdash "^0.9.0"
+    sassdash "0.9.0"
     tokenizer2 "^2.0.0"
 
 zip-stream@^1.1.0:


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Bump YoastSEO.js to v1.36.0

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
