### PR TITLE
Fixed configuration files for building artifacts

### DIFF
--- a/tools/grunt/config/aliases.yaml
+++ b/tools/grunt/config/aliases.yaml
@@ -33,13 +33,6 @@ check:
   - 'copy:artifact'
   - 'compress:artifact'
 
-# Copy the needed files to the ./artifact folder
-'copy:artifact':
-  - 'copy:artifactFiles'
-
-# Create a compressed zip from the ./artifact folder
-'compress:artifact':
-  - 'compress:artifactFiles'
 'release':
   - 'release:js'
   - 'build:i18n'

--- a/tools/grunt/config/compress.js
+++ b/tools/grunt/config/compress.js
@@ -1,14 +1,13 @@
 module.exports = {
-	artifactFiles: {
+	artifact: {
 		options: {
 			archive: "artifact.zip",
 		},
 		files: [
 			{
-				expand: true,
 				cwd: "artifact/",
 				src: [ "**" ],
-				dest: "./",
+				dest: "wpseo-woocommerce",
 			},
 		],
 	},

--- a/tools/grunt/config/copy.js
+++ b/tools/grunt/config/copy.js
@@ -1,5 +1,5 @@
 module.exports = {
-	artifactFiles: {
+	artifact: {
 		files: [
 			{
 				expand: true,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

*  N/A

## Relevant technical choices:

* Altered some of the Grunt configuration files to be more in line with the configuration used in Free. This also resolves the issue that zips that are created, are suffixed with a random hash, resulting in faulty installs.

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and ensure you've run `yarn`.
* Run `grunt artifact`.
* A zip file named `artifact.zip` should now be present in your directory. Unzip it and ensure the folder name is the same as the plugin name and does not contain a suffix.
