### PR TITLE
Bump Yoast SEO minimal version requirement to 8.1

### DIFF
--- a/tests/woocommerce-seo-test.php
+++ b/tests/woocommerce-seo-test.php
@@ -198,8 +198,8 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			array( false, '7.0', '3.5', 'WordPress is below the minimal required version.' ),
 			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
 			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '7.0', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
-			array( true, '8.0', '4.8', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '8.1', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '8.1', '4.8', 'WordPress and WordPress SEO have the minimal required versions.' ),
 		);
 	}
 }

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -113,8 +113,8 @@ class Yoast_WooCommerce_SEO {
 			return false;
 		}
 
-		// Make sure Yoast SEO is at least 7.0, including the RC versions, so bigger than 6.9.
-		if ( ! version_compare( $wordpress_seo_version, '6.9', '>' ) ) {
+		// Make sure Yoast SEO is at least 8.1, including the RC versions.
+		if ( ! version_compare( $wordpress_seo_version, '8.1-RC0', '>=' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_upgrade_error' );
 
 			return false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The minimal required version of Yoast SEO (Premium) has been updated to 8.1

## Test instructions

This PR can be tested by following these steps:

* Install Yoast SEO 8.0 or lower
* See the message at the top of the plugins screen that Yoast SEO: WooCommerce requires the latest version of Yoast SEO to work.