### PR TITLE
Fix local static member reference phpcs error

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -1328,7 +1328,7 @@ class Yoast_WooCommerce_SEO {
 	 */
 	private function localize_woo_script() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$version       = $asset_manager->flatten_version( Yoast_WooCommerce_SEO::VERSION );
+		$version       = $asset_manager->flatten_version( self::VERSION );
 
 		return array(
 			'script_url'     => plugins_url( 'js/yoastseo-woo-worker-' . $version . WPSEO_CSSJS_SUFFIX . '.js', self::get_plugin_file() ),


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Fixes the following PHPCS error: 
```FILE: wpseo-woocommerce.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 1331 | ERROR | [x] Must use "self::" for local static member
      |       |     reference
      |       |     (Squiz.Classes.SelfMemberReference.NotUsed)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```
## Test instructions

This PR can be tested by following these steps:

* Run PHPCS with and without this change. I did that using `./vendor/bin/phpcs`. See that it's fixed with this change.

After this has been merged, the release branch should be merged into trunk, because trunk is broken as well.

