### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ branches:
 jobs:
   fast_finish: true
   include:
-    - php: 7.2
-      env: WP_VERSION=4.9 WP_MULTISITE=1 PHPLINT=1 PHPCS=1
+    - php: 7.3
+      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1 PHPCS=1
     - php: 5.2
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
@@ -25,7 +25,7 @@ jobs:
       dist: precise
       env: WP_VERSION=4.9
     - php: 5.6
-      env: WP_VERSION=4.9
+      env: WP_VERSION=5.0
     - php: 7.0
       env: WP_VERSION=4.9
     - php: 5.2
@@ -95,7 +95,6 @@ before_script:
 - git clone --depth=50 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
 - cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
-- composer selfupdate 1.0.0 --no-interaction
 - composer install --no-dev --no-interaction
 - phpenv local --unset
 - cd -
@@ -141,4 +140,4 @@ script:
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* This plugin has been tested with PHP 7.3.

## Relevant technical choices:

Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

As of this week, Travis has (finally) made a PHP 7.3 alias available now RC3 is out, so I've added a new build to test against PHP 7.3 so there won't be any unwelcome surprises when PHP 7.3 comes out.

As WP 4.9 is known not to be fully compatible with PHP 7.3, while WP 5.0 *should* be (at some point), the PHP 7.3 build tests against WP 5.0, which considering the tight release schedule for WP 5.0, is not a bad thing to test against anyway.

Current status of WP in regards to the impact on this plugin:
* WP 4.9 branch: still needs a patch for the issue with `compact()`.
* WP 5.0 branch: dito + the patch for the `continue in switch` issue which is already included in `4.9` and `trunk` still needs to be merged into `5.0` as well.

For the full list of known issues, see: [Core Trac PHP 7.3 keyword list](https://core.trac.wordpress.org/query?keywords=~php73&col=id&col=summary&col=status&col=owner&col=type&col=priority&col=milestone&order=priority).

**IMPORTANT**: this PR should not be merged blindly. Please read the comments I've left in-line to understand the implications.

Basically, there is a choice to be made:
* Don't test against PHP 7.3 (yet) until there is a WP version available which is fully compatible with it.
    In that case, this PR could be set to `blocked` for the time being and adjusted and unblocked once WP is compatible.
* Test against PHP 7.3 in combination with WP 4.9 or 5.0, but allow the builds to fail.
    In that case, you may as well not add the build as - in my experience - devs only look at the details of Travis builds when the build fails, so if the build doesn't fail, adding this extra run just makes the build slower.
* Test against PHP 7.3 in combination with WP 4.9 or 5.0 and demand the build passes **_(= current implementation)_**.
   For the unit tests to be able to pass, the change in the PHPUnit configuration is needed for now as tests creating mock posts are impacted by the `compact()` issue.
   The downside of this change is that if the plugin itself would throw PHP notices, those may go undetected until the change to the PHPUnit config is reverted once WP is compatible.



## Test instructions

This PR can be tested by following these steps:

* Check if the Travis build for PHP 7.3 has passed.