### PR TITLE
Reference the correct settings page

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -600,7 +600,7 @@ class Yoast_WooCommerce_SEO {
 			printf(
 				/* translators: %1$s resolves to internal links options page, %2$s resolves to closing link tag, %3$s resolves to Yoast SEO, %4$s resolves to WooCommerce */
 				esc_html__( 'Both %4$s and %3$s have breadcrumbs functionality. The %3$s breadcrumbs have a slightly higher chance of being picked up by search engines and you can configure them a bit more, on the %1$sBreadcrumbs settings page%2$s. To enable them, check the box below and the WooCommerce breadcrumbs will be replaced.', 'yoast-woo-seo' ),
-				'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_advanced&tab=breadcrumbs' ) ) . '">',
+				'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles#top#breadcrumbs' ) ) . '">',
 				'</a>',
 				'Yoast SEO',
 				'WooCommerce'


### PR DESCRIPTION
Fixes: https://github.com/Yoast/wpseo-woocommerce/issues/267

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `Yoast SEO Breadcrumbs` settings page link did not go to the correct page.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Follow instructions in the issue

Fixes #267 
