### PR TITLE
Upgrade yoast/wp-helpscout to 2.0.4 in composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -77,16 +77,16 @@
         },
         {
             "name": "yoast/wp-helpscout",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-helpscout.git",
-                "reference": "00c6d777497c935af76ba1b4962823165139bbbc"
+                "reference": "15549e900f67d62dbd0dd0b7fb72b7d064b65204"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-helpscout/zipball/00c6d777497c935af76ba1b4962823165139bbbc",
-                "reference": "00c6d777497c935af76ba1b4962823165139bbbc",
+                "url": "https://api.github.com/repos/Yoast/wp-helpscout/zipball/15549e900f67d62dbd0dd0b7fb72b7d064b65204",
+                "reference": "15549e900f67d62dbd0dd0b7fb72b7d064b65204",
                 "shasum": ""
             },
             "type": "library",
@@ -110,7 +110,7 @@
                 }
             ],
             "description": "A package to integrate the helpscout beacon into WordPress",
-            "time": "2017-08-03T07:48:33+00:00"
+            "time": "2018-10-31T09:37:07+00:00"
         }
     ],
     "packages-dev": [
@@ -595,7 +595,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-08-14T15:39:17+00:00"
+            "time": "2018-06-08T09:55:50+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Test if the help scout beacon still works on http://local.wordpress.test/wp-admin/admin.php?page=wpseo_woo