### PR TITLE
Change `og:brand` to `product:brand`

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -832,7 +832,7 @@ class Yoast_WooCommerce_SEO {
 			if ( is_array( $terms ) && count( $terms ) > 0 ) {
 				$term_values = array_values( $terms );
 				$term        = array_shift( $term_values );
-				echo '<meta property="og:brand" content="' . esc_attr( $term->name ) . "\"/>\n";
+				echo '<meta property="product:brand" content="' . esc_attr( $term->name ) . '"/>' . "\n";
 			}
 		}
 		/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -841,8 +841,8 @@ class Yoast_WooCommerce_SEO {
 		 * @api bool unsigned Defaults to true.
 		 */
 		if ( apply_filters( 'wpseo_woocommerce_og_price', true ) ) {
-			echo '<meta property="product:price:amount" content="' . esc_attr( $product->get_price() ) . "\"/>\n";
-			echo '<meta property="product:price:currency" content="' . esc_attr( get_woocommerce_currency() ) . "\"/>\n";
+			echo '<meta property="product:price:amount" content="' . esc_attr( $product->get_price() ) . '"/>' . "\n";
+			echo '<meta property="product:price:currency" content="' . esc_attr( get_woocommerce_currency() ) . '"/>' . "\n";
 		}
 
 		if ( $product->is_in_stock() ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Changes `og:brand` to `product:brand` to match the OpenGraph specifications better.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Enable WooCommerce SEO
* Go to SEO > WooCommerce settings
* Enable a category to use as "Brand"
* Go to a product
* Create or select a "Brand" category
* Save the product
* View the front-end page of the product
* Inspect the source and see the `product:brand` as meta entry, instead of `og:brand`

If you have a live site, you can verify with the Facebook debug tool
* https://developers.facebook.com/tools/debug/

Fixes #225 
