### PR TITLE
PHPCS ruleset: update the prefixes array

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -78,9 +78,13 @@
 		<properties>
 			<!-- Provide the prefixes to look for. -->
 			<property name="prefixes" type="array">
+				<!-- Temporarily allowed until the prefixes are fixed. -->
 				<element value="wpseo"/>
 				<element value="yoast"/>
 				<element value="initialize_yoast"/>
+				<!-- These are the new prefixes which all code should comply with in the future. -->
+				<element value="yoast_woocommerce"/>
+				<element value="Yoast\WP\Woocommerce"/>
 			</property>
 
 			<!-- Test classes do not need to be prefixed as they won't go into production. -->


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Updates the PHPCS prefixes array to cover the new prefixes which should be used from now on for global structures as well as namespaced structures based on the agreed prefixes per September 2018.

## Test instructions

This PR can be tested by following these steps:
* _N/A_

The change can be tested, but this isn't really needed as you'd be testing PHPCS + WPCS (which test this anyway).
