### PR TITLE
Travis: test builds against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
       env: WP_VERSION=master
-    - php: nightly
+    - php: "7.4snapshot"
       env: WP_VERSION=master
     - stage: deploy
       env: WP_VERSION=4.9
@@ -59,7 +59,7 @@ jobs:
           all_branches: true
   allow_failures:
     # Allow failures for unstable builds.
-    - php: nightly
+    - php: "7.4snapshot"
     - env: WP_VERSION=master
 
 cache:
@@ -80,7 +80,7 @@ install:
     composer install --no-dev --no-interaction
   fi
 - if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev yoast/yoastcs dealerdirect/phpcodesniffer-composer-installer; fi
-- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then composer require --dev phpunit/phpunit ^5.7; fi
+- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then composer require --dev phpunit/phpunit ^5.7; fi
 - composer dump-autoload
 - phpenv local --unset
 
@@ -138,7 +138,7 @@ script:
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 - |
-  if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
     vendor/bin/phpunit
     travis_time_finish && travis_fold end "PHP.tests"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

As PHP 8.x - current `nightly` - is not expected to be released until December 2020, with PHP 7.4 expected in December 2019, I've elected to replace the build against `nightly` with a build against `7.4snapshot`.

Once PHP 7.4 is released, the "high PHP" build - currently PHP 7.3 - should be replaced with a build against PHP 7.4 (stable) and the "unstable" build - now `7.4snapshot` - should be reverted to `nightly`.

## Test instructions

This PR can be tested by following these steps:

* Once the travis build has been fixed (#319), ask me to rebase this PR and then verify that the Travis build runs as expected.