### PR TITLE
Added --ignore-platform-reqs flag to composer install for wordpress-seo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ before_script:
 - git clone --depth=50 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
 - cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
 - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then phpenv local 5.6.13; fi
-- composer install --no-dev --no-interaction
+- composer install --no-dev --no-interaction --ignore-platform-reqs
 - phpenv local --unset
 - cd -
 
@@ -128,16 +128,13 @@ script:
   fi
 # PHP Tests
 - |
+  travis_fold start "PHP.tests" && travis_time_start
   if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then
-    travis_fold start "PHP.tests" && travis_time_start
     phpunit -c phpunit.xml
-    travis_time_finish && travis_fold end "PHP.tests"
   fi
 - |
   if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
-    travis_fold start "PHP.tests" && travis_time_start
     vendor/bin/phpunit -c phpunit.xml
-    travis_time_finish && travis_fold end "PHP.tests"
   fi
-
+  travis_time_finish && travis_fold end "PHP.tests"
 - if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-userfacing] Fixes travis build that crashed due to changes in `wordpress-seo`.

## Relevant technical choices:

* Mimicked this solution from https://github.com/Yoast/wpseo-news/blob/trunk/.travis.yml#L113

## Test instructions

This PR can be tested by following these steps:

* Wait for the travis build to succeed.

Fixes #319 
