### PR TITLE
Bump minimal required yoastseo version to 10.1 and WordPress version to 5.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,7 +47,7 @@
 	-->
 
 	<!-- Set the minimum supported WP version. This is used by several sniffs. -->
-	<config name="minimum_supported_wp_version" value="4.8"/>
+	<config name="minimum_supported_wp_version" value="5.0"/>
 
 	<!-- Verify that all gettext calls use the correct text domain. -->
 	<rule ref="WordPress.WP.I18n">

--- a/tests/woocommerce-seo-test.php
+++ b/tests/woocommerce-seo-test.php
@@ -195,11 +195,11 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	public function check_dependencies_data() {
 		return array(
 			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
-			array( false, '7.0', '3.5', 'WordPress is below the minimal required version.' ),
+			array( false, '7.0', '4.9', 'WordPress is below the minimal required version.' ),
 			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
-			array( false, '6.0', '5.0', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '8.1', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
-			array( true, '8.1', '4.8', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( false, '8.1', '5.0', 'WordPress SEO is below the minimal required version.' ),
+			array( true, '10.1', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '10.1', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
 		);
 	}
 }

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -109,8 +109,8 @@ class Yoast_WooCommerce_SEO {
 			return false;
 		}
 
-		// Make sure Yoast SEO is at least 8.1, including the RC versions.
-		if ( ! version_compare( $wordpress_seo_version, '8.1-RC0', '>=' ) ) {
+		// At least 10.1, in which we've removed the License Manager code from this addon. With older YoastSEO versions, this addon won't get any updates.
+		if ( ! version_compare( $wordpress_seo_version, '10.1-beta0', '>=' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_upgrade_error' );
 
 			return false;

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -94,7 +94,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return bool True whether the dependencies are okay.
 	 */
 	protected function check_dependencies( $wp_version ) {
-		if ( ! version_compare( $wp_version, '4.8', '>=' ) ) {
+		if ( ! version_compare( $wp_version, '5.0', '>=' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_wordpress_upgrade_error' );
 
 			return false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not sure if this needs to be in the changelog] Sets the minimum required WordPress version to 5.0.
* [not sure if this needs to be in the changelog] Sets the minimum required Yoast SEO version to 10.1.

## Relevant technical choices:

* Also sets PHPCS "minimum_supported_wp_version" to "4.8"

## Test instructions

This PR can be tested by following these steps:

* Install this branch on a WP site with a version below 5.0. See a notification.
* Install this branch on an installation with a Yoast SEO version lower than 10.1. See a notification.
* Install this branch on a WP site with a version >=5.0 and Yoast SEO version >= 10.1. See no notifications.

NB. The failing tests are not related to this PR.

Fixes [Yoast/wordpress-seo#12331](https://github.com/Yoast/wordpress-seo/issues/12331)