### PR TITLE
Remove the deprecated function

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -1299,19 +1299,6 @@ class Yoast_WooCommerce_SEO {
 
 		add_filter( 'wpseo_breadcrumb_links', array( $this, 'add_attribute_to_breadcrumbs' ) );
 	}
-
-	/* ********************* DEPRECATED METHODS ********************* */
-
-	/**
-	 * Registers the settings page in the WP SEO menu.
-	 *
-	 * @since 1.0
-	 *
-	 * @deprecated 5.6
-	 * @codeCoverageIgnore
-	 */
-	public function register_settings_page() {
-	}
 }
 
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Removed an empty method that has been deprecated since version 5.6

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* The test should pass.

Fixes #329
