### PR TITLE
Make Woo Schema work with our new Schema

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -6,12 +6,12 @@
  */
 
 /**
- * Class WPSEO_Schema_WooCommerce
+ * Class WPSEO_WooCommerce_Schema
  */
-class WPSEO_Schema_WooCommerce {
+class WPSEO_WooCommerce_Schema {
 
 	/**
-	 * WPSEO_Schema_WooCommerce constructor.
+	 * WPSEO_WooCommerce_Schema constructor.
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_structured_data_product', array( $this, 'change_main_entity' ) );

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -63,7 +63,7 @@ class WPSEO_WooCommerce_Schema {
 			$data['@type'] = 'ItemPage';
 		}
 		if ( is_checkout() || is_checkout_pay_page() ) {
-			$data['$type'] = 'CheckoutPage';
+			$data['@type'] = 'CheckoutPage';
 		}
 		return $data;
 	}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -9,6 +9,7 @@
  * Class WPSEO_Schema_WooCommerce
  */
 class WPSEO_Schema_WooCommerce {
+
 	/**
 	 * WPSEO_Schema_WooCommerce constructor.
 	 */

--- a/classes/wpseo-schema-woocommerce.php
+++ b/classes/wpseo-schema-woocommerce.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin.
+ *
+ * @package WPSEO/WooCommerce
+ *
+ * @wordpress-plugin
+ * Plugin Name: Yoast SEO: WooCommerce
+ * Version:     10.1-RC2
+ * Plugin URI:  https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/
+ * Description: This extension to WooCommerce and Yoast SEO makes sure there's perfect communication between the two plugins.
+ * Author:      Team Yoast
+ * Author URI:  https://yoast.com
+ * Depends:     Yoast SEO, WooCommerce
+ * Text Domain: yoast-woo-seo
+ * Domain Path: /languages/
+ *
+ * WC requires at least: 3.0
+ * WC tested up to: 3.5
+ *
+ * Copyright 2014-2018 Yoast BV (email: support@yoast.com)
+ */
+
+/**
+ * Class WPSEO_Schema_WooCommerce
+ */
+class WPSEO_Schema_WooCommerce {
+	/**
+	 * WPSEO_Schema_WooCommerce constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_structured_data_product', array( $this, 'change_main_entity' ) );
+		add_filter( 'woocommerce_structured_data_type_for_page', array( $this, 'remove_woo_breadcrumbs' ) );
+		add_filter( 'wpseo_schema_webpage', array( $this, 'change_page_type' ) );
+	}
+
+	/**
+	 * Changes the WebPage output to point to Product as the main entity.
+	 *
+	 * @param array $data Product Schema data.
+	 *
+	 * @return array $data Product Schema data.
+	 */
+	public function change_main_entity( $data ) {
+		$data['mainEntityOfPage'] = array(
+			'@id' => WPSEO_Frontend::get_instance()->canonical( false ) . WPSEO_Schema_IDs::WEBPAGE_HASH,
+		);
+
+		return $data;
+	}
+
+	/**
+	 * Removes the Woo Breadcrumbs from their Schema output.
+	 *
+	 * @param array $types Types of Schema Woo will render.
+	 *
+	 * @return array $types Types of Schema Woo will render.
+	 */
+	public function remove_woo_breadcrumbs( $types ) {
+		foreach ( $types as $key => $type ) {
+			if ( $type === 'breadcrumblist' ) {
+				unset( $types[ $key ] );
+			}
+		}
+
+		return $types;
+	}
+
+	/**
+	 * Change the page type on applicable pages.
+	 *
+	 * @param array $data WebPage Schema data.
+	 *
+	 * @return array $data WebPage Schema data.
+	 */
+	public function change_page_type( $data ) {
+		if ( is_product() ) {
+			$data['@type'] = 'ItemPage';
+		}
+		if ( is_checkout() || is_checkout_pay_page() ) {
+			$data['$type'] = 'CheckoutPage';
+		}
+		return $data;
+	}
+}

--- a/classes/wpseo-schema-woocommerce.php
+++ b/classes/wpseo-schema-woocommerce.php
@@ -1,24 +1,8 @@
 <?php
 /**
- * WooCommerce Yoast SEO plugin.
+ * WooCommerce Yoast SEO plugin file.
  *
  * @package WPSEO/WooCommerce
- *
- * @wordpress-plugin
- * Plugin Name: Yoast SEO: WooCommerce
- * Version:     10.1-RC2
- * Plugin URI:  https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/
- * Description: This extension to WooCommerce and Yoast SEO makes sure there's perfect communication between the two plugins.
- * Author:      Team Yoast
- * Author URI:  https://yoast.com
- * Depends:     Yoast SEO, WooCommerce
- * Text Domain: yoast-woo-seo
- * Domain Path: /languages/
- *
- * WC requires at least: 3.0
- * WC tested up to: 3.5
- *
- * Copyright 2014-2018 Yoast BV (email: support@yoast.com)
  */
 
 /**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -144,7 +144,7 @@ class Yoast_WooCommerce_SEO {
 			$this->register_i18n_promo_class();
 		}
 
-		$schema = new WPSEO_Schema_WooCommerce();
+		$schema = new WPSEO_WooCommerce_Schema();
 
 		// Initialize the options.
 		$this->option_instance = WPSEO_Option_Woo::get_instance();

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -144,6 +144,8 @@ class Yoast_WooCommerce_SEO {
 			$this->register_i18n_promo_class();
 		}
 
+		$schema = new WPSEO_Schema_WooCommerce();
+
 		// Initialize the options.
 		$this->option_instance = WPSEO_Option_Woo::get_instance();
 		$this->short_name      = $this->option_instance->option_name;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves integration of Woo & Yoast's Schema output, bringing it to a whole new level.
* Removes Woo breadcrumbs Schema output.
* Changes page type on Checkout to `CheckoutPage`.

## Relevant technical choices:

* Removes Woo breadcrumbs Schema output.

## Test instructions

This PR can be tested by following these steps:

* Look at a product, grab all the source, throw it through Google's Structured Data Testing Tool.
* Look at the checkout, grab all the source, throw it through Google's Structured Data Testing Tool.

Fixes #337
Fixes #289
