### PR TITLE
Don't output empty graphs

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -40,6 +40,9 @@ class WPSEO_WooCommerce_Schema {
 	 * Outputs the Woo Schema blob in the footer.
 	 */
 	public function output_schema_footer() {
+		if ( empty( $this->data ) || $this->data === array() ) {
+			return;
+		}
 		WPSEO_Utils::schema_output( array( $this->data ), 'yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer' );
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Don't output a schema graph tag when there's nothing to output in it.

## Test instructions

This PR can be tested by following these steps:

* Go to a page without a product, see there's no script tag needed.
