### PR TITLE
QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/classes/option-woo-test.php
+++ b/tests/classes/option-woo-test.php
@@ -33,7 +33,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 */
 	public function test_constructor() {
 		$option = new WPSEO_Option_Woo_Double();
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'price' => 'Price',
 				'stock' => 'Stock',
@@ -70,14 +70,13 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 		$dirty = ( $dirty !== null ) ? array( $field_name => $dirty ) : array();
 		$old   = ( $old !== null ) ? array( $field_name => $old ) : array();
 
-		$this->assertEquals(
-			array( $field_name => $expected ),
-			$option->validate_option(
-				array_merge( array( 'short_form' => $short ), $dirty ),
-				array( $field_name => $clean ),
-				$old
-			)
+		$result = $option->validate_option(
+			array_merge( array( 'short_form' => $short ), $dirty ),
+			array( $field_name => $clean ),
+			$old
 		);
+
+		$this->assertSame( array( $field_name => $expected ), $result );
 	}
 
 	/**

--- a/tests/classes/woocommerce-beacon-setting-test.php
+++ b/tests/classes/woocommerce-beacon-setting-test.php
@@ -32,10 +32,10 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_suggestions()
 	 */
 	public function test_get_suggestions_for_the_woocommerce_seo_page() {
-		$this->assertNotEquals(
-			array(),
-			$this->beacon_settings->get_suggestions( 'wpseo_woo' )
-		);
+		$result = $this->beacon_settings->get_suggestions( 'wpseo_woo' );
+
+		$this->assertInternalType( 'array', $result );
+		$this->assertNotEmpty( $result );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_suggestions()
 	 */
 	public function test_get_suggestions_for_a_non_woocommerce_seo_page() {
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			$this->beacon_settings->get_suggestions( 'wpseo_another_one' )
 		);
@@ -56,10 +56,15 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_products()
 	 */
 	public function test_get_products_for_the_woocommerce_seo_page() {
-		$this->assertEquals(
-			array( new Yoast_Product_WPSEO_WooCommerce() ),
-			$this->beacon_settings->get_products( 'wpseo_woo' )
-		);
+		$expected = array( new Yoast_Product_WPSEO_WooCommerce() );
+		$result   = $this->beacon_settings->get_products( 'wpseo_woo' );
+
+		if ( method_exists( $this, 'assertContainsOnlyInstancesOf' ) ) {
+			// The method assertContainsOnlyInstancesOf() was added in PHPUnit 4.x.
+			$this->assertContainsOnlyInstancesOf( 'Yoast_Product_WPSEO_WooCommerce', $result );
+		}
+
+		$this->assertEquals( $expected, $result );
 	}
 
 	/**
@@ -68,7 +73,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_products()
 	 */
 	public function test_get_products_for_a_non_woocommerce_seo_page() {
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			$this->beacon_settings->get_products( 'wpseo_another_page' )
 		);
@@ -80,7 +85,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_config()
 	 */
 	public function test_get_config() {
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			$this->beacon_settings->get_config( 'wpseo_woo' )
 		);

--- a/tests/framework/woocommerce-unittestcase.php
+++ b/tests/framework/woocommerce-unittestcase.php
@@ -45,6 +45,6 @@ class WPSEO_WooCommerce_UnitTestCase extends WP_UnitTestCase {
 	protected function expectOutput( $string ) {
 		$output = ob_get_contents();
 		ob_clean();
-		$this->assertEquals( $output, $string );
+		$this->assertSame( $output, $string );
 	}
 }

--- a/tests/woocommerce-seo-test.php
+++ b/tests/woocommerce-seo-test.php
@@ -27,7 +27,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 		);
 		$expected = array( 'another-column' => '' );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->will( $this->returnValue( $wordpress_seo_version ) );
 
 
-		$this->assertEquals( $expected, $class_instance->check_dependencies( $wordpress_version ), $message );
+		$this->assertSame( $expected, $class_instance->check_dependencies( $wordpress_version ), $message );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->method( 'excluded_from_catalog' )
 			->will( $this->returnValue( array() ) );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'loc' => 'http://shop.site/product' ),
 			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
 		);
@@ -134,7 +134,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'excluded_from_catalog' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'loc' => 'http://shop.site/product' ),
 			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
 		);
@@ -155,7 +155,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'excluded_from_catalog' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'loc' => 'http://shop.site/product' ),
 			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', null )
 		);
@@ -176,7 +176,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->expects( $this->never() )
 			->method( 'excluded_from_catalog' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'no-loc' => 'http://shop.site/product' ),
 			$instance->filter_hidden_product( array( 'no-loc' => 'http://shop.site/product' ), 'post', null )
 		);


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available have been extended hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

This implements this for the Yoast WooCommerce plugin.

Refs:
* https://phpunit.de/manual/4.8/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame

Note that this change has not been made for the `WPSEO_WooCommerce_Beacon_Setting_Test::test_get_products_for_the_woocommerce_seo_page()` test as two different instances of the same class will not be the _same_, though they can be _equal_.


## Test instructions

This PR can be tested by following these steps:
* As long as the unit tests pass in the Travis builds, we are good.