### PR TITLE
QA: review test bootstrap file / show friendly errors

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -122,8 +122,9 @@
 		<exclude-pattern>/tests/doubles/*\.php$</exclude-pattern>
 	</rule>
 
-	<!-- Allow for the unit test case file to make changes to the superglobals. -->
+	<!-- Allow for select unit test files to use less secure code. -->
 	<rule ref="WordPress.Security">
+		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
 		<exclude-pattern>/tests/framework/woocommerce-unittestcase\.php$</exclude-pattern>
 	</rule>
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,10 @@ if ( function_exists( 'xdebug_disable' ) ) {
 echo 'Welcome to the WordPress SEO WooCommerce test suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 
+if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
+	define( 'WP_DEVELOP_DIR', getenv( 'WP_DEVELOP_DIR' ) );
+}
+
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
@@ -21,8 +25,8 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'wpseo-woocommerce/wpseo-woocommerce.php', 'wordpress-seo/wp-seo.php' ),
 );
 
-if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
-	require getenv( 'WP_DEVELOP_DIR' ) . 'tests/phpunit/includes/bootstrap.php';
+if ( defined( 'WP_DEVELOP_DIR' ) ) {
+	require WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php';
 }
 else {
 	require '../../../../tests/phpunit/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,10 +26,30 @@ $GLOBALS['wp_tests_options'] = array(
 );
 
 if ( defined( 'WP_DEVELOP_DIR' ) ) {
-	require WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php';
+	if ( file_exists( WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php' ) ) {
+		require WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php';
+	}
+	else {
+		echo PHP_EOL, 'ERROR: Please check the WP_DEVELOP_DIR environment variable. Based on the current value ', WP_DEVELOP_DIR, ' the WordPress native unit test bootstrap file could not be found.', PHP_EOL;
+		exit( 1 );
+	}
+}
+elseif ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
+	require '../../../../tests/phpunit/includes/bootstrap.php';
 }
 else {
-	require '../../../../tests/phpunit/includes/bootstrap.php';
+	echo PHP_EOL, 'ERROR: The WordPress native unit test bootstrap file could not be found. Please set the WP_DEVELOP_DIR environment variable either in your OS or in a custom phpunit.xml file.', PHP_EOL;
+	exit( 1 );
+}
+
+if ( file_exists( dirname( dirname( __FILE__ ) ) . '/vendor/autoload_52.php' ) === false ) {
+	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
+	exit( 1 );
+}
+
+if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-woocommerce/wpseo-woocommerce.php' ) === false ) {
+	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
+	exit( 1 );
 }
 
 // Include unit test base class.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,8 +28,5 @@ else {
 	require '../../../../tests/phpunit/includes/bootstrap.php';
 }
 
-// Load WordPress SEO.
-require dirname( __FILE__ ) . '/../../wordpress-seo/wp-seo.php';
-
 // Include unit test base class.
 require_once dirname( __FILE__ ) . '/framework/woocommerce-unittestcase.php';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

### Test bootstrap: remove unnecessary require

WP will load the active plugins automatically, there is no need to require YoastSEO explicitly.

### Test bootstrap: remove duplicate function calls

### Test bootstrap: show friendly error message on failure

Do more rigorous checking whether the environment is correctly set up for the unit tests to be run and if not, show an instructive error message.

Include disabling the security sniffs for the bootstrap file.

## Test instructions

This PR can be tested by following these steps:

On `trunk`:
1. If applicable: remove the `WP_DEVELOP_DIR` environment variable from your OS or custom `phpunit.xml` file and make sure that this plugin is not in the `wp-content/plugins` directory of a WP install. Run the unit tests and see them fail with a PHP error.
2. Bring back the `WP_DEVELOP_DIR` environment variable, but set it to an invalid value. Run the unit tests and see them fail with a PHP error.
3. Revert the change(s) made in [1] and [2].
4. Remove the `WP_PLUGIN_DIR` environment variable from your OS or custom `phpunit.xml` file and make sure that this plugin is not in the `wp-content/plugins` directory of a WP install. Run the unit tests and see them fail with a PHP error.
5. Revert the change(s) made in [4].
6. Rename the `vendor` directory to `vendorx`. Run the unit tests and see them fail with a PHP error.
7. Revert the change(s) made in [6].

Now check out this branch, follow the same steps as above, but instead of PHP errors, you should see instructive error message for each of the above situations.