### PR TITLE
Fix depricated function get_woocommerce_term_meta

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -741,7 +741,7 @@ class Yoast_WooCommerce_SEO {
 		if ( ! function_exists( 'is_product_category' ) || is_product_category() ) {
 			global $wp_query;
 			$cat          = $wp_query->get_queried_object();
-			$thumbnail_id = get_woocommerce_term_meta( $cat->term_id, 'thumbnail_id', true );
+			$thumbnail_id = get_term_meta( $cat->term_id, 'thumbnail_id', true );
 			$img_url      = wp_get_attachment_url( $thumbnail_id );
 			if ( $img_url ) {
 				$opengraph_image->add_image( $img_url );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the deprecation notice of `get_woocommerce_term_meta`.

## Relevant technical choices:

* To prevent notices in users' PHP error logs we should avoid using deprecated functions.

## Test instructions

This PR can be tested by following these steps:

**Without this PR:**
1. Install `woocommerce` and `wpseo-woocommerce`
2. Create a Woocommerce product category and add an image to this category
3. Visit the front-facing product category page
4. Notice the "PHP Notice:  get_woocommerce_term_meta is <strong>deprecated</strong> since version 3.6!" message in your logs (depending on log level of PHP).

**With this PR:**
1. Perform steps 1 through 3 of previous list.
2. Notice no messages in your error log.

To debug, set a breakpoint on [line 744](https://github.com/Yoast/wpseo-woocommerce/blob/424cd186660de1a064930141d3149e3538c29224/wpseo-woocommerce.php#L744) or var_dump `$thumbnail_id` on line 755. With and without this PR they should return the same value.

Fixes https://github.com/Yoast/bugreports/issues/312
