### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "yoast/wpseo-woocommerce",
     "description": "This extension to WooCommerce and WordPress SEO by Yoast makes sure there's perfect communication between the two plugins.",
     "type": "wordpress-plugin",
+    "homepage": "https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/",
     "license": "GPL-2.0-or-later",
     "authors": [
         {
@@ -10,6 +11,10 @@
             "homepage": "https://yoast.com"
         }
     ],
+    "support": {
+        "issues": "https://github.com/Yoast/wpseo-woocommerce/issues",
+        "source": "https://github.com/Yoast/wpseo-woocommerce"
+    },
     "autoload": {
         "classmap": [ "classes/" ]
     },
@@ -24,6 +29,7 @@
         }
     },
     "require": {
+        "php": ">=5.2",
         "xrstf/composer-php52": "^1.0.20",
         "yoast/wp-helpscout": "^1.0||^2.0",
         "yoast/i18n-module": "^3.1.1"
@@ -32,10 +38,21 @@
         "yoast/yoastcs": "^1.2.2",
         "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "config-yoastcs": [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-            "\"vendor/bin/phpcs\" --config-set default_standard Yoast"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+        ],
+        "check-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "fix-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+        ],
+        "test": [
+            "@php ./vendor/phpunit/phpunit/phpunit"
         ],
         "post-install-cmd": [
             "xrstf\\Composer52\\Generator::onPostInstallCmd"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77be32b3b16b1bf198cbe5332fdc866d",
+    "content-hash": "092a31c70dbf5c42f7efa1b9cb70b8d3",
     "packages": [
         {
             "name": "xrstf/composer-php52",
@@ -2211,11 +2211,13 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.2"
+    },
     "platform-dev": [],
     "platform-overrides": {
         "php": "5.6.40"


### PR DESCRIPTION
I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version.
* Adds a dev dependency for PHPUnit.
* Adds `check-cs`, `fix-cs` and `test` scripts for use by devs.
* Makes the existing `config-yoastcs` script respect the PHP version Composer is run on.
     See Yoast/yoastcs 114 for a more detailed explanation.
    Note: the `config-yoastcs` script is not _needed_ as the DealerDirect plugin sorts this out automatically, however for consistency of the scripts between repos, this has been left in place anyway.
* Add a few miscellaneous other properties.

## Summary

This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
