### PR TITLE
Test documentation: fix @covers tags

### DIFF
--- a/tests/classes/option-woo-test.php
+++ b/tests/classes/option-woo-test.php
@@ -29,7 +29,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the constructor.
 	 *
-	 * @covers WPSEO_Option_Woo::__construct()
+	 * @covers WPSEO_Option_Woo::__construct
 	 */
 	public function test_constructor() {
 		$option = new WPSEO_Option_Woo_Double();
@@ -54,7 +54,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * @param string|bool|null $old        The value for the old argument.
 	 * @param string           $short      Determines whether the short form should set or not.
 	 *
-	 * @covers WPSEO_Option_Woo::validate_option()
+	 * @covers WPSEO_Option_Woo::validate_option
 	 */
 	public function test_validate_option( $field_name, $expected, $dirty, $clean, $old, $short = 'off' ) {
 		$option = $this

--- a/tests/classes/woocommerce-beacon-setting-test.php
+++ b/tests/classes/woocommerce-beacon-setting-test.php
@@ -29,7 +29,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	/**
 	 * Tests the situation where we get a non empty array when calling get_suggestions for the WooCommerce SEO page.
 	 *
-	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_suggestions()
+	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_suggestions
 	 */
 	public function test_get_suggestions_for_the_woocommerce_seo_page() {
 		$result = $this->beacon_settings->get_suggestions( 'wpseo_woo' );
@@ -41,7 +41,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	/**
 	 * Tests the situation where an empty array is returned when calling get_suggestions for the WooCommerce SEO page.
 	 *
-	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_suggestions()
+	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_suggestions
 	 */
 	public function test_get_suggestions_for_a_non_woocommerce_seo_page() {
 		$this->assertSame(
@@ -53,7 +53,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	/**
 	 * Tests the situations where an array with the product will be returned on the WooCommerce SEO Page.
 	 *
-	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_products()
+	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_products
 	 */
 	public function test_get_products_for_the_woocommerce_seo_page() {
 		$expected = array( new Yoast_Product_WPSEO_WooCommerce() );
@@ -70,7 +70,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	/**
 	 * Tests the situations where an empty array will be returned on a non WooCommerce SEO Page.
 	 *
-	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_products()
+	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_products
 	 */
 	public function test_get_products_for_a_non_woocommerce_seo_page() {
 		$this->assertSame(
@@ -82,7 +82,7 @@ class WPSEO_WooCommerce_Beacon_Setting_Test extends WPSEO_WooCommerce_UnitTestCa
 	/**
 	 * Tests the situations where an empty array will be returned.
 	 *
-	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_config()
+	 * @covers WPSEO_WooCommerce_Beacon_Setting::get_config
 	 */
 	public function test_get_config() {
 		$this->assertSame(

--- a/tests/woocommerce-seo-test.php
+++ b/tests/woocommerce-seo-test.php
@@ -13,7 +13,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the filtering of Yoast SEO columns.
 	 *
-	 * @covers Yoast_WooCommerce_SEO::column_heading()
+	 * @covers Yoast_WooCommerce_SEO::column_heading
 	 */
 	public function test_column_heading() {
 		$woocommerce = new Yoast_WooCommerce_SEO();
@@ -40,7 +40,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * @param string $wordpress_version     The WordPress version to check.
 	 * @param string $message               Message given by PHPUnit after assertion.
 	 *
-	 * @covers Yoast_WooCommerce_SEO::check_dependencies()
+	 * @covers Yoast_WooCommerce_SEO::check_dependencies
 	 */
 	public function test_check_dependencies( $expected, $wordpress_seo_version, $wordpress_version, $message ) {
 		$class_instance = $this
@@ -61,7 +61,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the sitemap filtering of a product that is not hidden.
 	 *
-	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product
 	 */
 	public function test_filter_hidden_product_for_product_that_is_visible() {
 		$product = self::factory()->post->create_and_get(
@@ -89,7 +89,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the sitemap filtering of a product that is hidden from the catalog.
 	 *
-	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product
 	 */
 	public function test_filter_hidden_product_for_product_that_is_hidden() {
 		$product = self::factory()->post->create_and_get(
@@ -116,7 +116,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the sitemap filtering of a product that is not a product
 	 *
-	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product
 	 */
 	public function test_filter_hidden_product_for_a_non_product() {
 		$product = self::factory()->post->create_and_get(
@@ -143,7 +143,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the sitemap filtering of a product when a invalid post object is given.
 	 *
-	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product
 	 */
 	public function test_filter_hidden_product_when_invalid_post_object_is_given() {
 		$instance = $this
@@ -164,7 +164,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	/**
 	 * Tests the sitemap filtering when no url loc is given to the url data.
 	 *
-	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product()
+	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product
 	 */
 	public function test_filter_hidden_product_when_no_url_loc_is_present() {
 		$instance = $this


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:
`@covers` tags are used to indicate what class/method/function a test covers when calculating code coverage of the tests and should follow the specifications of PHPUnit.

Ref:
* https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.covers
* https://github.com/Yoast/yoastcs/issues/123

## Test instructions

This PR can be tested by following these steps:

* N/A
