### PR TITLE
Disable schema when YoastSEO schema is disabled.

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -37,12 +37,22 @@ class WPSEO_WooCommerce_Schema {
 	}
 
 	/**
+	 * Should the yoast schema output be used.
+	 *
+	 * @return boolean Whether or not the Yoast SEO schema should be output.
+	 */
+	public static function should_output_yoast_schema() {
+		return apply_filters( 'wpseo_json_ld_output', true );
+	}
+
+	/**
 	 * Outputs the Woo Schema blob in the footer.
 	 */
 	public function output_schema_footer() {
 		if ( empty( $this->data ) || $this->data === array() ) {
 			return;
 		}
+
 		WPSEO_Utils::schema_output( array( $this->data ), 'yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer' );
 	}
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -144,8 +144,6 @@ class Yoast_WooCommerce_SEO {
 			$this->register_i18n_promo_class();
 		}
 
-		new WPSEO_WooCommerce_Schema();
-
 		// Initialize the options.
 		$this->option_instance = WPSEO_Option_Woo::get_instance();
 		$this->short_name      = $this->option_instance->option_name;
@@ -176,33 +174,34 @@ class Yoast_WooCommerce_SEO {
 			}
 		}
 		else {
-			if ( class_exists( 'WooCommerce', false ) ) {
-				$wpseo_options = WPSEO_Options::get_all();
+			$wpseo_options = WPSEO_Options::get_all();
 
-				// Add metadescription filter.
-				add_filter( 'wpseo_metadesc', array( $this, 'metadesc' ) );
+			// Initialize schema.
+			add_action( 'init', array( $this, 'initialize_schema' ) );
 
-				// OpenGraph.
-				add_filter( 'language_attributes', array( $this, 'og_product_namespace' ), 11 );
-				add_filter( 'wpseo_opengraph_type', array( $this, 'return_type_product' ) );
-				add_filter( 'wpseo_opengraph_desc', array( $this, 'og_desc_enhancement' ) );
-				add_action( 'wpseo_opengraph', array( $this, 'og_enhancement' ), 50 );
-				add_action( 'wpseo_register_extra_replacements', array( $this, 'register_replacements' ) );
+			// Add metadescription filter.
+			add_filter( 'wpseo_metadesc', array( $this, 'metadesc' ) );
 
-				if ( class_exists( 'WPSEO_OpenGraph_Image' ) ) {
-					add_action( 'wpseo_add_opengraph_additional_images', array( $this, 'set_opengraph_image' ) );
-				}
+			// OpenGraph.
+			add_filter( 'language_attributes', array( $this, 'og_product_namespace' ), 11 );
+			add_filter( 'wpseo_opengraph_type', array( $this, 'return_type_product' ) );
+			add_filter( 'wpseo_opengraph_desc', array( $this, 'og_desc_enhancement' ) );
+			add_action( 'wpseo_opengraph', array( $this, 'og_enhancement' ), 50 );
+			add_action( 'wpseo_register_extra_replacements', array( $this, 'register_replacements' ) );
 
-				add_filter( 'wpseo_sitemap_exclude_post_type', array( $this, 'xml_sitemap_post_types' ), 10, 2 );
-				add_filter( 'wpseo_sitemap_post_type_archive_link', array( $this, 'xml_sitemap_taxonomies' ), 10, 2 );
+			if ( class_exists( 'WPSEO_OpenGraph_Image' ) ) {
+				add_action( 'wpseo_add_opengraph_additional_images', array( $this, 'set_opengraph_image' ) );
+			}
 
-				add_filter( 'post_type_archive_link', array( $this, 'xml_post_type_archive_link' ), 10, 2 );
-				add_filter( 'wpseo_sitemap_urlimages', array( $this, 'add_product_images_to_xml_sitemap' ), 10, 2 );
+			add_filter( 'wpseo_sitemap_exclude_post_type', array( $this, 'xml_sitemap_post_types' ), 10, 2 );
+			add_filter( 'wpseo_sitemap_post_type_archive_link', array( $this, 'xml_sitemap_taxonomies' ), 10, 2 );
 
-				// Fix breadcrumbs.
-				if ( $this->options['breadcrumbs'] === true && $wpseo_options['breadcrumbs-enable'] === true ) {
-					$this->handle_breadcrumbs_replacements();
-				}
+			add_filter( 'post_type_archive_link', array( $this, 'xml_post_type_archive_link' ), 10, 2 );
+			add_filter( 'wpseo_sitemap_urlimages', array( $this, 'add_product_images_to_xml_sitemap' ), 10, 2 );
+
+			// Fix breadcrumbs.
+			if ( $this->options['breadcrumbs'] === true && $wpseo_options['breadcrumbs-enable'] === true ) {
+				$this->handle_breadcrumbs_replacements();
 			}
 		} // End if.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -220,6 +219,15 @@ class Yoast_WooCommerce_SEO {
 
 		add_filter( 'wpseo_sitemap_entry', array( $this, 'filter_hidden_product' ), 10, 3 );
 		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_woocommerce_pages' ) );
+	}
+
+	/**
+	 * Initializes the schema functionality.
+	 */
+	public function initialize_schema() {
+		if ( WPSEO_WooCommerce_Schema::should_output_yoast_schema() ) {
+			new WPSEO_WooCommerce_Schema();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Don't initialize wpseo-woocommerce schema class when wordpress-seo schema is disabled

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast SEO WooCommerce schema was output when the `wpseo_json_ld_output` filter was set to false.

## Relevant technical choices:

* Moved Schema initialization from `plugins_loaded` hook to `init` to make sure `functions.php` from theme's is loaded when initializing schema.

## Test instructions

This PR can be tested by following these steps:

* Activate `WooCommerce` and `Yoast SEO`.
* Disable Yoast SEO schema output using `add_filter( 'wpseo_json_ld_output', '__return_false' );`. You can put that in the `functions.php` of your theme for example.
* Make sure the Yoast SEO schema is fully disabled. You can identify the Yoast SEO Woocommerce schema by the classname on the `<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">` element.
* If Yoast SEO Schema is disabled, there should still be a `<script type="application/ld+json">` element but this contains structured data output from `WooCommerce` itself. This schema should be untouched by Yoast SEO Woocommerce.

Fixes Yoast/bugreports#359
