### PR TITLE
Don't add image id if no thumbnail is available

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -193,7 +193,12 @@ class WPSEO_WooCommerce_Schema {
 	 * @param string $canonical The product canonical.
 	 */
 	private function add_image( $canonical ) {
-		// WooCommerce will set the image to false if non is available. This is incorrect schema.
+		/**
+		 * WooCommerce will set the image to false if non is available. This is incorrect schema and we should fix it
+		 * for our users for now.
+		 *
+		 * See https://github.com/woocommerce/woocommerce/issues/24188.
+		 */
 		if ( $this->data['image'] === false ) {
 			unset( $this->data['image'] );
 		}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -188,13 +188,13 @@ class WPSEO_WooCommerce_Schema {
 	}
 
 	/**
-	 * Add image schema.
+	 * Adds image schema.
 	 *
 	 * @param string $canonical The product canonical.
 	 */
 	private function add_image( $canonical ) {
 		/**
-		 * WooCommerce will set the image to false if non is available. This is incorrect schema and we should fix it
+		 * WooCommerce will set the image to false if none is available. This is incorrect schema and we should fix it
 		 * for our users for now.
 		 *
 		 * See https://github.com/woocommerce/woocommerce/issues/24188.
@@ -207,6 +207,8 @@ class WPSEO_WooCommerce_Schema {
 			$this->data['image'] = array(
 				'@id' => $canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
 			);
+
+			return;
 		}
 
 		// Fallback to WooCommerce placeholder image.

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -203,12 +203,16 @@ class WPSEO_WooCommerce_Schema {
 			unset( $this->data['image'] );
 		}
 
-		if ( ! has_post_thumbnail() ) {
-			return;
+		if ( has_post_thumbnail() ) {
+			$this->data['image'] = array(
+				'@id' => $canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
+			);
 		}
 
-		$this->data['image'] = array(
-			'@id' => $canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
-		);
+		// Fallback to WooCommerce placeholder image.
+		if ( function_exists( 'wc_placeholder_img_src' ) ) {
+			$image_schema        = new WPSEO_Schema_Image( $canonical . '#woocommerceimageplaceholder' );
+			$this->data['image'] = $image_schema->generate_from_url( wc_placeholder_img_src() );
+		}
 	}
 }

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -110,10 +110,6 @@ class WPSEO_WooCommerce_Schema {
 			}
 		}
 
-		$data['image'] = array(
-			'@id' => $canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
-		);
-
 		// We're going to replace the single review here with an array of reviews taken from the other filter.
 		$data['review'] = array();
 
@@ -125,6 +121,7 @@ class WPSEO_WooCommerce_Schema {
 		// Now let's add this data to our overall output.
 		$this->data = $data;
 
+		$this->add_image( $canonical );
 		$this->add_brand( $product );
 		$this->add_manufacturer( $product );
 
@@ -188,5 +185,25 @@ class WPSEO_WooCommerce_Schema {
 				'name'  => $term->name,
 			);
 		}
+	}
+
+	/**
+	 * Add image schema.
+	 *
+	 * @param string $canonical The product canonical.
+	 */
+	private function add_image( $canonical ) {
+		// WooCommerce will set the image to false if non is available. This is incorrect schema.
+		if ( $this->data['image'] === false ) {
+			unset( $this->data['image'] );
+		}
+
+		if ( ! has_post_thumbnail() ) {
+			return;
+		}
+
+		$this->data['image'] = array(
+			'@id' => $canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
+		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Don't output image schema id if the product has no thumbnail.

## Relevant technical choices:

* Removes image schema if it is false. This is a bug from WooCommerce.
* If a product has no defined image, fallback to WooCommerce placeholder image.

## Test instructions

This PR can be tested by following these steps:

Enable `WooCommerce`, `Yoast SEO: WooCommerce` and `Yoast SEO`.

* Create a product without a product image.
* Inspect the product schema, it should not have an image node.
* Add a product image.
* Inspect the product schema, it should now have an `image` node with an `@id` property referring to the main image schema.

Fixes Yoast/bugreports#458
