### PR TITLE
PHPCS: Revert exclusion of test directory

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -17,7 +17,6 @@
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>languages/*</exclude-pattern>
-	<exclude-pattern>tests/*</exclude-pattern>
 
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>

--- a/tools/grunt/config/shell.js
+++ b/tools/grunt/config/shell.js
@@ -2,7 +2,7 @@
 module.exports = function() {
 	return {
 		phpcs: {
-			command: "php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+			command: "composer check-cs",
 		},
 	};
 };


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Revert the exclusion of the `tests` directory from the CS run.
* Use the right command in `grunt` to call PHPCS.

The Composer script was already correctly set up to allow for different minimum PHP requirements for the `tests` directory, it just needs to be used. 

## Test instructions

This PR can be tested by following these steps:

@andizer Got a feeling you already know how to test this.

Fixes #408
