### PR TITLE
CS: enforce consistent array format

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -130,4 +130,21 @@
 		<exclude-pattern>/tests/TestCase\.php$</exclude-pattern>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	TEMPORARY TWEAK
+	YoastCS will demand short arrays, but until support for WP < 5.2 has been
+	dropped, this can - for now - only be allowed (and enforced) for the folders
+	containing PHP 5.6+ code.
+	#############################################################################
+	-->
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
+		<include-pattern>/tests/*</include-pattern>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

WordPressCS will demand long arrays and forbid the use of short arrays as of WPCS 2.2.0.
See: https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/

For YoastCS, however, a choice has been made to demand short arrays.

For now, while WP 4.9, and therefore PHP 5.2 still needs to be supported, this is only possible in the directories containing files with PHP 5.6+ code.
So in this interim period, we will enforce short arrays in the PHP 5.6+ code and long arrays everywhere else.

Once the minimum supported WP version has moved up to WP 5.2 / PHP 5.6, short arrays will be enforced for all code and the change-over can be done automatically using the auto-fixer included in the relevant sniff.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
