### PR TITLE
Travis: minor tweak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ before_install:
 
 install:
 - if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs dealerdirect/phpcodesniffer-composer-installer; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
 - |
   if [[ "$PHPCS" == "1" ]]; then
     composer install --no-interaction


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Since #309, the DealerDirect Composer plugin is no longer a direct dependency for this plugin, so no need to explicitly remove it. It will automatically be removed with YoastCS.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a build-script-only change and should have no effect on the functionality.
