### PR TITLE
CS: use the correct namespace name

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\WooCommerce\Tests;
+namespace Yoast\WP\Woocommerce\Tests;
 
 use PHPUnit_Framework_TestCase;
 use Brain\Monkey;

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Yoast\WP\WooComerce\Tests\Classes;
+namespace Yoast\WP\Woocommerce\Tests\Classes;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_WooCommerce_Schema;
-use Yoast\WP\WooCommerce\Tests\Doubles\Schema_Double;
-use Yoast\WP\WooCommerce\Tests\TestCase;
+use Yoast\WP\Woocommerce\Tests\Doubles\Schema_Double;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class WooCommerce_Schema_Test.

--- a/tests/doubles/schema-double.php
+++ b/tests/doubles/schema-double.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\WooCommerce\Tests\Doubles;
+namespace Yoast\WP\Woocommerce\Tests\Doubles;
 
 use WPSEO_WooCommerce_Schema;
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Fixes one namespace declaration containing a typo.
* Fixes spelling of `Woocommerce` in namespace declarations + use statements to the agreed upon form.


## Test instructions

This PR can be tested by following these steps:

* _N/A_ these fixes are in the unit test code, not the plugin code. As long as the tests still run as expected, we're good.