### PR TITLE
PHPUnit bootstrap: fix typo

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ define( 'DB_NAME', 'none' );
 define( 'DB_USER', 'nobody' );
 define( 'DB_PASSWORD', 'nothing' );
 
-if ( class_exists( 'opcache_reset' ) ) {
+if ( function_exists( 'opcache_reset' ) ) {
 	opcache_reset();
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

`opcache_reset()` is a function, not a class.

## Test instructions

This PR can be tested by following these steps:

* _N/A_
