### PR TITLE
PHPUnit: make (new) unit tests compatible with higher PHPUnit versions

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,13 @@
 
 namespace Yoast\WP\Woocommerce\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Brain\Monkey;
 
 /**
  * TestCase base class.
  */
-abstract class TestCase extends PHPUnit_Framework_TestCase {
+abstract class TestCase extends PHPUnit_TestCase {
 
 	/**
 	 * Test setup.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

As these new tests will only be run on PHP 5.6+ in combination with PHPUnit 5.4+, use the newer namespaced PHPUnit class name.

A class alias for BC is not needed as BrainMonkey is not available on PHP < 5.6, so older PHPUnit versions do not need to be supported.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ If the unit tests are still being run and pass, we're good.
