### PR TITLE
Tests: fix compatibility with PHP 7.4

### DIFF
--- a/integration-tests/woocommerce-seo-test.php
+++ b/integration-tests/woocommerce-seo-test.php
@@ -72,6 +72,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->disableOriginalConstructor()
 			->setMethods( array( 'excluded_from_catalog' ) )
 			->getMock();
 
@@ -100,6 +101,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->disableOriginalConstructor()
 			->setMethods( array( 'excluded_from_catalog' ) )
 			->getMock();
 
@@ -127,6 +129,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->disableOriginalConstructor()
 			->setMethods( array( 'excluded_from_catalog' ) )
 			->getMock();
 
@@ -148,6 +151,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	public function test_filter_hidden_product_when_invalid_post_object_is_given() {
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->disableOriginalConstructor()
 			->setMethods( array( 'excluded_from_catalog' ) )
 			->getMock();
 
@@ -169,6 +173,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	public function test_filter_hidden_product_when_no_url_loc_is_present() {
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
+			->disableOriginalConstructor()
 			->setMethods( array( 'excluded_from_catalog' ) )
 			->getMock();
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

On PHP 7.4, these five unit tests are running into a `Trying to access array offset on value of type bool` error.

Analysis of the error shows the following:

When the MockBuilder is used to call `Yoast_WooCommerce_SEO`, the options framework is not correctly initialized.
As in a test situation, the `wpseo_woo` option will not have been saved to the database yet, this means that the `get_option()` call in the `Yoast_WooCommerce_SEO::initialize()` method will return `false` instead of the expected option defaults.

https://github.com/Yoast/wpseo-woocommerce/blob/98194c61fa09d1eed958fcf0906b71ace436faa8/wpseo-woocommerce.php#L150

When subsequently, array access is attempted on the option - as happens numerous times in the rest of that function -, this causes the above mentioned error.

Example:
https://github.com/Yoast/wpseo-woocommerce/blob/98194c61fa09d1eed958fcf0906b71ace436faa8/wpseo-woocommerce.php#L157

Based on this analysis, this shouldn't be possible to happen in a "real life" situation, but only when using the MockBuilder during unit tests.

This is confirmed by the `Yoast_WooCommerce_SEO_Test::test_column_heading()` test method in the same test class, which doesn't use the MockBuilder, but instantiates the real class and correctly receives the options defaults.

So to conclude, I don't believe there is anything wrong with the actual plugin code for compatibility with PHP 7.4.

As the unit tests in question aren't testing the `Yoast_WooCommerce_SEO::initialize()` method, disabling the original constructor should not adversely affect the tests and will allow the tests to run without PHP errors on PHP 7.4.


## Test instructions

This PR can be tested by following these steps:

* Run the integration tests against `trunk` on PHP 7.4 and see them fail.
* Run the integration tests against this branch on PHP 7.4 and see them pass.

If you want to confirm the above analysis - add a `var_dump( $this->options )` just below the following line before running the unit tests against `trunk`:
https://github.com/Yoast/wpseo-woocommerce/blob/98194c61fa09d1eed958fcf0906b71ace436faa8/wpseo-woocommerce.php#L150
