### PR TITLE
Stop explicit support for PHP < 5.6 / WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 branches:
   only:
@@ -16,23 +15,15 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 SECURITY=1
-    - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1 PHPCS=1 SECURITY=1
     - php: 5.6
-      env: WP_VERSION=5.0 PHPUNIT=1
+      env: WP_VERSION=5.2 PHPLINT=1 PHPUNIT=1
     - php: 7.0
-      env: WP_VERSION=4.9
-    - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-      env: WP_VERSION=master
+      env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
     - php: "7.4snapshot"
-      env: WP_VERSION=master
+      env: WP_VERSION=master PHPUNIT=1
     - stage: deploy
-      env: WP_VERSION=4.9
+      env: WP_VERSION=5.2
       if: tag IS present
       before_install:
         - openssl aes-256-cbc -K $encrypted_2b922af4d08d_key -iv $encrypted_2b922af4d08d_iv -in ./deploy_keys/wpseo_woo_deploy.enc -out ./deploy_keys/wpseo_woo_deploy -d
@@ -61,7 +52,7 @@ jobs:
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-    - env: WP_VERSION=master
+    - env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
 
 cache:
   directories:
@@ -73,23 +64,16 @@ before_install:
 - export SECURITYCHECK_DIR=/tmp/security-checker
 
 install:
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then composer remove --dev --no-update --no-scripts yoast/yoastcs; fi
 - |
-  if [[ "$PHPCS" == "1" ]]; then
+  if [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" ]]; then
     composer install --no-interaction
-    composer config-yoastcs
-  elif [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" ]]; then
-    composer install --no-interaction
-  else
+  elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "deploy" ]]; then
     composer install --no-dev --no-interaction
   fi
 - |
-  if [[ "$PHPUNIT" == "1" ]]; then
-    composer install --no-interaction
+  if [[ "$PHPCS" == "1" ]]; then
+    composer config-yoastcs
   fi
-- composer dump-autoload
-- phpenv local --unset
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
 
 before_script:
@@ -100,37 +84,39 @@ before_script:
 - export -f travis_time_finish
 
 # Clone WordPress
-- git clone --depth=50 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+- |
+  if [[ "$PHPUNIT" == "1" ]]; then
+    git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+  fi
 
 # Clone WPSEO and its submodule
-- git clone --depth=50 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
-- cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
-- if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
-- composer install --no-dev --no-interaction --ignore-platform-reqs
-- phpenv local --unset
-- cd -
+- |
+  if [[ "$PHPUNIT" == "1" ]]; then
+    git clone --depth=1 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
+    cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
+    composer install --no-dev --no-interaction --ignore-platform-reqs
+    cd -
+  fi
 
 # Copy woocommerce seo to the test directory
-- cd ..
-- cp -r "$PLUGIN_SLUG" "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-- cd /tmp/wordpress/
-- cp wp-tests-config-sample.php wp-tests-config.php
-- sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-- sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-- sed -i "s/yourpasswordhere//" wp-tests-config.php
-- mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-- cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-- phpenv rehash
+- |
+  if [[ "$PHPUNIT" == "1" ]]; then
+    cd ..
+    cp -r "$PLUGIN_SLUG" "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    cd /tmp/wordpress/
+    cp wp-tests-config-sample.php wp-tests-config.php
+    sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    sed -i "s/yourusernamehere/travis/" wp-tests-config.php
+    sed -i "s/yourpasswordhere//" wp-tests-config.php
+    mysql -e "CREATE DATABASE wordpress_tests;" -uroot
+    cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    phpenv rehash
+  fi
 
 script:
 # PHP Linting
 - |
-  if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:3} < "5.6" ]]; then
-    travis_fold start "PHP.check" && travis_time_start
-    find -L . -path ./vendor -prune -o -path ./tests -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    travis_time_finish && travis_fold end "PHP.check"
-  fi
-  if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:3} > "5.5" ]]; then
+  if [[ "$PHPLINT" == "1" ]]; then
     travis_fold start "PHP.check" && travis_time_start
     find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     travis_time_finish && travis_fold end "PHP.check"
@@ -144,25 +130,17 @@ script:
   fi
 # PHP Tests
 - |
-  travis_fold start "PHP.tests" && travis_time_start
-  if [[ ${TRAVIS_PHP_VERSION:0:3} < "7.2" && "$PHPUNIT" == "1" ]]; then
+  if [[ "$PHPUNIT" == "1" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
-    phpunit -c phpunit-integration.xml.dist
+    composer integration-test
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 - |
-  if [[ ${TRAVIS_PHP_VERSION:0:3} > "7.1" && "$PHPUNIT" == "1"  ]]; then
+  if [[ "$PHPUNIT" == "1"  ]]; then
     travis_fold start "PHP.tests" && travis_time_start
-    vendor/bin/phpunit -c phpunit-integration.xml.dist
+    composer test
     travis_time_finish && travis_fold end "PHP.tests"
   fi
-- |
-  if [[ ${TRAVIS_PHP_VERSION:0:3} > "5.5" && "$PHPUNIT" == "1"  ]]; then
-    travis_fold start "PHP.tests" && travis_time_start
-    phpunit -c phpunit.xml.dist
-    travis_time_finish && travis_fold end "PHP.tests"
-  fi
-  travis_time_finish && travis_fold end "PHP.tests"
 - if [[ $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 
 # Check for known security vulnerabilities in the currently locked-in dependencies.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WooCommerce Yoast SEO
 Requires at least: 5.2
 Tested up to: 5.3
 Stable tag: 12.3
-Requires PHP: 5.6.10
+Requires PHP: 5.6.20
 Depends: Yoast SEO, WooCommerce
 
 Description

--- a/composer.json
+++ b/composer.json
@@ -30,16 +30,14 @@
         }
     },
     "require": {
-        "php": ">=5.2",
-        "xrstf/composer-php52": "^1.0.20",
+        "php": ">=5.6",
         "yoast/wp-helpscout": "^1.0||^2.0",
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
         "yoast/yoastcs": "^1.3.0",
-        "phpunit/phpunit": "^4.5 || ^5.7 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
         "brain/monkey": "^2.2"
-
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -60,15 +58,6 @@
         ],
         "test": [
             "@php ./vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist"
-        ],
-        "post-install-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-update-cmd": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
-        ],
-        "post-autoload-dump": [
-            "xrstf\\Composer52\\Generator::onPostInstallCmd"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,39 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5196cfe4d53457c13688c1446d1c370",
+    "content-hash": "13365f8160341a4c9cf8747ab90c8e29",
     "packages": [
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2016-04-16T21:52:24+00:00"
-        },
         {
             "name": "yoast/i18n-module",
             "version": "3.1.1",
@@ -2096,7 +2065,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.2"
+        "php": ">=5.6"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -42,7 +42,7 @@ else {
 	exit( 1 );
 }
 
-if ( file_exists( dirname( dirname( __FILE__ ) ) . '/vendor/autoload_52.php' ) === false ) {
+if ( file_exists( dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -27,8 +27,8 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload_52.php' ) ) {
-	require dirname( __FILE__ ) . '/vendor/autoload_52.php';
+if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
+	require dirname( __FILE__ ) . '/vendor/autoload.php';
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Brief analysis of the Travis script shows me that:
* There are a number of builds _which do not do anything_.
    All the tasks in `script` are set up conditionally based on environment variables.
    Any build which did not have an environment variable, such as `PHPLINT`, `PHPCS` or `PHPUNIT` was basically completely useless.
* While the `PHPUNIT` task is set up to run conditionally, the _preparation of the environment_ for unit testing, i.e. downloading WordPress, cloning YoastSEO Free, setting up the database _is all done **unconditionally**_.

So, with that in mind, I have made the following changes to the Travis script - please read this carefully:
* Removing builds against PHP < 5.6.
* Changing the `WP_VERSION` environment variables in the matrix to use a minimum of `5.2`.
    Note: this will change again once WP 5.3 comes out.
* Actually running the unit tests on all current builds.
* Removing the PHP version/env condition toggle for a full/no-dev composer install.
    As a composer install was being run on all builds anyway in one way or another **and** there is a committed `composer.lock` file **and** Travis caching of the downloads is setup, doing a full install each time will not make the build significantly slower.
    Also: It is better to always test based on the dependencies we've set up than to rely on  a PHP image created by Travis which may fail unexpectedly (especially as Travis has seen some issues recently with incorrect PHPUnit versions on certain images).
    This also means the `composer dump-autoload` can be removed as it will now always have run whenever the autoload is needed.
    **Note**: this changes the `composer install` for the `deploy` stage from a full install to a `no-dev` install.
   That stage was currently being run against PHP 7.2, so was getting a full install, while AFAICS that shouldn't be needed.
* Making the environment preparations which are needed for the unit tests dependent on the `PHPUNIT` environment variable.
* Making the builds slightly faster by using lean git clones (`depth=1` instead of `depth=50`).
* Using the composer scripts to run the unit test tasks.
    As PHPUnit will now always be available in `vendor`, using the composer scripts simplifies things.

Includes:
* Adjusting the `Requires...` info in the `readme.md` file.
* Removing the `xrstf/composer-php52` dependency and references to the `vendor/autoload_52.php` file.
* Dropping PHPUnit < 5.7 from the Composer `require-dev`.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.

Related #425

Related to Yoast/wordpress-seo#13758

## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis scripts to verify that all is working as expected.

**_Please be extra critical reviewing this PR for any changes which may impact the `deploy` stage as those won't show up during the PR build._**