### PR TITLE
Remove all hidden products from XML sitemap

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -271,10 +271,11 @@ class Yoast_WooCommerce_SEO {
 		if ( $excluded_from_catalog === null ) {
 			$query                 = new WP_Query(
 				array(
-					'fields'    => 'ids',
-					'post_type' => 'product',
+					'fields'         => 'ids',
+					'posts_per_page' => '-1',
+					'post_type'      => 'product',
 					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-					'tax_query' => array(
+					'tax_query'      => array(
 						array(
 							'taxonomy' => 'product_visibility',
 							'field'    => 'name',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where hidden products could show in XML sitemap.

## Relevant technical choices:

* Used an unbounded query, as it only grabs the IDs, not more data, I think this won't lead to any problems.

## Test instructions

This PR can be tested by following these steps:

* See reproduction steps in https://github.com/Yoast/bugreports/issues/697

Props to @Djennez for the solution.

Fixes https://github.com/Yoast/bugreports/issues/697