### PR TITLE
Travis: don't allow builds against PHP 7.4 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,15 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=5.2 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1 PHPCS=1 SECURITY=1
+      env: WP_VERSION=5.3 WP_MULTISITE=1 PHPUNIT=1 PHPCS=1 SECURITY=1
     - php: 5.6
       env: WP_VERSION=5.2 PHPLINT=1 PHPUNIT=1
+    - php: "7.4snapshot"
+      env: WP_VERSION=5.3 PHPLINT=1 PHPUNIT=1
     - php: 7.0
       env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
-    - php: "7.4snapshot"
-      env: WP_VERSION=master PHPUNIT=1
+    - php: "nightly"
+      env: PHPLINT=1
     - stage: deploy
       env: WP_VERSION=5.2
       if: tag IS present
@@ -51,8 +53,9 @@ jobs:
           all_branches: true
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
-    - env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
+    - php: "nightly"
+    - php: 7.0
+      env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
 
 cache:
   directories:


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Includes:
* Adjusting the Travis matrix now WP 5.3 has been released
* Removing the build against PHP 7.4 from `allowed failures`.
* Adding (back) a build against PHP `nightly` (PHP 8) and adding it to  `allowed_failures`.
    For now, this build will only lint the code. Unit testing is not yet possible with  the current setup.

## Test instructions

This PR can be tested by following these steps:
* Check the detailed travis script output
