### PR TITLE
Set minimum WP version to 5.2 and minimum YoastSEO version to 12.6

### DIFF
--- a/integration-tests/woocommerce-seo-test.php
+++ b/integration-tests/woocommerce-seo-test.php
@@ -199,12 +199,12 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 */
 	public function check_dependencies_data() {
 		return array(
-			array( false, '7.0', '3.0', 'WordPress is below the minimal required version.' ),
-			array( false, '7.0', '4.9', 'WordPress is below the minimal required version.' ),
-			array( false, false, '5.0', 'WordPress SEO is not installed.' ),
-			array( false, '8.1', '5.0', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '10.2-RC1', '4.9', 'WordPress and WordPress SEO have the minimal required versions.' ),
-			array( true, '10.2', '5.0', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( false, '12.7', '3.0', 'WordPress is below the minimal required version.' ),
+			array( false, '12.7', '5.1', 'WordPress is below the minimal required version.' ),
+			array( false, false, '5.3', 'WordPress SEO is not installed.' ),
+			array( false, '8.1', '5.1', 'WordPress SEO is below the minimal required version.' ),
+			array( true, '12.6-RC1', '5.2', 'WordPress and WordPress SEO have the minimal required versions.' ),
+			array( true, '12.7', '5.3', 'WordPress and WordPress SEO have the minimal required versions.' ),
 		);
 	}
 }

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -94,7 +94,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return bool True whether the dependencies are okay.
 	 */
 	protected function check_dependencies( $wp_version ) {
-		if ( ! version_compare( $wp_version, '4.9', '>=' ) ) {
+		if ( ! version_compare( $wp_version, '5.2', '>=' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_wordpress_upgrade_error' );
 
 			return false;
@@ -109,8 +109,8 @@ class Yoast_WooCommerce_SEO {
 			return false;
 		}
 
-		// At least 10.2, in which we've introduced the new WPSEO_Schema_IDs functionality.
-		if ( ! version_compare( $wordpress_seo_version, '10.2-rc0', '>=' ) ) {
+		// At least 12.6, in which we've implemented the new HelpScout Beacon.
+		if ( ! version_compare( $wordpress_seo_version, '12.6-RC0', '>=' ) ) {
 			add_action( 'all_admin_notices', 'yoast_wpseo_woocommerce_upgrade_error' );
 
 			return false;


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum WordPress version to 5.2 and the minimum YoastSEO version to 12.6.

## Relevant technical choices:

* We need the new HelpScout Beacon implementation that is in WPSEO 12.6.

## Test instructions

This PR can be tested by following these steps:

* Install and activate Yoast SEO 12.5 and WooCommers, and build this branch of WooCommerce SEO. 
* Try to activate WooCommerce SEO. 
* See a notification.
* Install and activate Yoast SEO 12.6.
* Activate WooCommerce SEO.
* See no notification and see that WooCommerce SEO can be activated.
* Build this branch on a WordPress installation < 5.2.
* See a notification about the WP version.

Fixes #
