### PR TITLE
Remove filters for WC 3.8.1 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ WooCommerce Yoast SEO
 =====================
 Requires at least: 5.2
 Tested up to: 5.3
-Stable tag: 12.4
+Stable tag: 12.4.1
 Requires PHP: 5.6.20
 Depends: Yoast SEO, WooCommerce
 
@@ -29,6 +29,11 @@ Frequently Asked Questions
 You can find the FAQ [online here](https://kb.yoast.com/kb/category/woocommerce-seo/).
 
 Changelog
+
+### 12.4.1: December 17th, 2019
+
+Bugfixes:
+* In 3.8.1 WooCommerce tweaked the Product Schema output, this tweak broke our Schema integration, this release fixes that.
 
 ### 12.4: November 26th, 2019
 Other:

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -30,11 +30,15 @@ class WPSEO_WooCommerce_Schema {
 	public function __construct() {
 		$this->options = get_option( 'wpseo_woo' );
 
-		add_filter( 'woocommerce_structured_data_review', array( $this, 'change_reviewed_entity' ) );
 		add_filter( 'woocommerce_structured_data_product', array( $this, 'change_product' ), 10, 2 );
 		add_filter( 'woocommerce_structured_data_type_for_page', array( $this, 'remove_woo_breadcrumbs' ) );
 		add_filter( 'wpseo_schema_webpage', array( $this, 'filter_webpage' ) );
 		add_action( 'wp_footer', array( $this, 'output_schema_footer' ) );
+
+		// Only needed for WooCommerce versions before 3.8.1.
+		if ( version_compare( WC_VERSION, '3.8.1' ) < 0 ) {
+			add_filter( 'woocommerce_structured_data_review', array( $this, 'change_reviewed_entity' ) );
+		}
 	}
 
 	/**
@@ -88,7 +92,7 @@ class WPSEO_WooCommerce_Schema {
 
 		$this->data['review'][] = $data;
 
-		return array();
+		return $data;
 	}
 
 	/**
@@ -111,8 +115,11 @@ class WPSEO_WooCommerce_Schema {
 			}
 		}
 
-		// We're going to replace the single review here with an array of reviews taken from the other filter.
-		$data['review'] = array();
+		// Only needed for WooCommerce versions before 3.8.1.
+		if ( version_compare( WC_VERSION, '3.8.1' ) < 0 ) {
+			// We're going to replace the single review here with an array of reviews taken from the other filter.
+			$data['review'] = array();
+		}
 
 		// This product is the main entity of this page, so we set it as such.
 		$data['mainEntityOfPage'] = array(

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -92,7 +92,7 @@ class WPSEO_WooCommerce_Schema {
 
 		$this->data['review'][] = $data;
 
-		return $data;
+		return array();
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -19,8 +19,9 @@ class Schema_Test extends TestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		// This constant is always defined by WooCommerce.
-		define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		if ( ! defined( 'WC_VERSION' ) ) {
+			define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		}
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -18,6 +18,7 @@ class Schema_Test extends TestCase {
 	 * Test setup.
 	 */
 	public function setUp() {
+		parent::setUp();
 		// This constant is always defined by WooCommerce.
 		define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -19,7 +19,7 @@ class Schema_Test extends TestCase {
 	 */
 	public function setUp() {
 		// This constant is always defined by WooCommerce.
-		define( 'WC_VERSION', '3.8.1' );
+		define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -133,7 +133,6 @@ class Schema_Test extends TestCase {
 					],
 				],
 			],
-			'review'           => [],
 			'mainEntityOfPage' => [ '@id' => $canonical . '#webpage' ],
 			'brand'            => [
 				'@type' => 'Organization',

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -15,6 +15,14 @@ use Yoast\WP\Woocommerce\Tests\TestCase;
 class Schema_Test extends TestCase {
 
 	/**
+	 * Test setup.
+	 */
+	public function setUp() {
+		// This constant is always defined by WooCommerce.
+		define( 'WC_VERSION', '3.8.1' );
+	}
+
+	/**
 	 * Tests that should_output_yoast_schema returns the right value.
 	 *
 	 * @covers \WPSEO_WooCommerce_Schema::should_output_yoast_schema

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -6,7 +6,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast SEO: WooCommerce
- * Version:     12.4
+ * Version:     12.4.1
  * Plugin URI:  https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/
  * Description: This extension to WooCommerce and Yoast SEO makes sure there's perfect communication between the two plugins.
  * Author:      Team Yoast
@@ -41,7 +41,7 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @var string
 	 */
-	const VERSION = '12.4';
+	const VERSION = '12.4.1';
 
 	/**
 	 * Instance of the WooCommerce_SEO option management class.


### PR DESCRIPTION
# Do not click 'merge'. This is already the release branch!

This removes our review filters in the Schema class, that are no longer needed after Woo's fix for them in WooCommerce 3.8.1.

This PR can be summarized in the following changelog entry:

* In 3.8.1 WooCommerce tweaked the Product Schema output, this tweak broke our Schema integration, this release fixes that.

## Relevant technical choices:

* Introduced two version checks to maintain backwards compatibility.

## Test instructions

This PR can be tested by following these steps:

* Set up WooCommerce, set up a product, make sure to give the product a price.
* Activate Yoast SEO and Yoast SEO WooCommerce.
* Copy the `Product` schema output to the Code section of the [Rich Results Eligibility Checker](https://search.google.com/test/rich-results)
* Make sure the output passes as "Page is eligible for rich results".

Fixes https://github.com/Yoast/bugreports/issues/782
