### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,13 +34,19 @@
 	-->
 
 	<rule ref="Yoast">
-		<!-- Set the custom test class whitelist for all sniffs which use it in one go.
-			 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
-		-->
 		<properties>
+			<!-- Set the custom test class whitelist for all sniffs which use it in one go.
+				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+			-->
 			<property name="custom_test_class_whitelist" type="array">
 				<element value="WPSEO_UnitTestCase"/>
 				<element value="WPSEO_WooCommerce_UnitTestCase"/>
+			</property>
+
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\Woocommerce"/>
+				<element value="yoast_woocommerce"/>
 			</property>
 		</properties>
 	</rule>
@@ -63,37 +69,17 @@
 
 	<rule ref="Yoast.Files.FileName">
 		<properties>
-			<property name="exclude" type="array">
+			<property name="excluded_files_strict_check" type="array">
 				<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
 				<element value="wpseo-woocommerce.php"/>
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="wpseo"/>
 				<element value="yoast"/>
 			</property>
 		</properties>
-	</rule>
-
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<!-- Temporarily allowed until the prefixes are fixed. -->
-				<element value="wpseo"/>
-				<element value="yoast"/>
-				<element value="initialize_yoast"/>
-				<!-- These are the new prefixes which all code should comply with in the future. -->
-				<element value="yoast_woocommerce"/>
-				<element value="Yoast\WP\Woocommerce"/>
-			</property>
-		</properties>
-
-		<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
-		<exclude-pattern>/integration-tests/bootstrap\.php$</exclude-pattern>
-		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
 	</rule>
 
 	<!-- Temporary work-around for upstream bug: squizlabs/PHP_CodeSniffer#2228 -->
@@ -105,6 +91,7 @@
 			</property>
 		</properties>
 	</rule>
+
 
 	<!--
 	#############################################################################
@@ -128,6 +115,31 @@
 	<!-- Disable filename sniff for TestCase.php for consistency with wordpress-seo -->
 	<rule ref="Yoast.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>/tests/TestCase\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/integration-tests/bootstrap\.php$</exclude-pattern>
+		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	TEMPORARY ADJUSTMENTS
+	Adjustments which should be removed once the associated issue has been resolved.
+	#############################################################################
+	-->
+
+	<!-- Until all prefixes are fixed, some exceptions are allowed to the PrefixAllGlobals sniff. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" extend="true">
+				<element value="wpseo"/>
+				<element value="yoast"/>
+				<element value="initialize_yoast"/>
+			</property>
+		</properties>
 	</rule>
 
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -142,21 +142,4 @@
 		</properties>
 	</rule>
 
-
-	<!--
-	#############################################################################
-	TEMPORARY TWEAK
-	YoastCS will demand short arrays, but until support for WP < 5.2 has been
-	dropped, this can - for now - only be allowed (and enforced) for the folders
-	containing PHP 5.6+ code.
-	#############################################################################
-	-->
-
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
-		<exclude-pattern>/tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
-		<include-pattern>/tests/*</include-pattern>
-	</rule>
-
 </ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,7 @@ install:
   elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "deploy" ]]; then
     composer install --no-dev --no-interaction
   fi
-- |
-  if [[ "$PHPCS" == "1" ]]; then
-    composer config-yoastcs
-  fi
+
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
 
 before_script:

--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 		 *
 		 * @var array
 		 */
-		protected $defaults = array(
+		protected $defaults = [
 			// Non-form fields, set via validation routine.
 			'dbversion'           => 0, // Leave default as 0 to ensure activation/upgrade works.
 
@@ -80,14 +80,14 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			'breadcrumbs'         => true,
 			'hide_columns'        => true,
 			'metabox_woo_top'     => true,
-		);
+		];
 
 		/**
 		 * Array of pre-defined valid data types, will be enriched with taxonomies.
 		 *
 		 * @var array
 		 */
-		public $valid_data_types = array();
+		public $valid_data_types = [];
 
 		/**
 		 * Add the actions and filters for the option.
@@ -98,10 +98,10 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			parent::__construct();
 
 			// Set and translate the valid data types.
-			$this->valid_data_types = array(
+			$this->valid_data_types = [
 				'price' => __( 'Price', 'yoast-woo-seo' ),
 				'stock' => __( 'Stock', 'yoast-woo-seo' ),
-			);
+			];
 		}
 
 		/**
@@ -233,10 +233,10 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			$taxonomies = get_object_taxonomies( 'product', 'objects' );
 
 			if ( ! is_array( $taxonomies ) || empty( $taxonomies ) ) {
-				return array();
+				return [];
 			}
 
-			$processed_taxonomies = array();
+			$processed_taxonomies = [];
 			foreach ( $taxonomies as $taxonomy ) {
 				$processed_taxonomies[] = strtolower( $taxonomy->name );
 			}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -47,6 +47,7 @@ class WPSEO_WooCommerce_Schema {
 	 * @return boolean Whether or not the Yoast SEO schema should be output.
 	 */
 	public static function should_output_yoast_schema() {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WPSEO hook.
 		return apply_filters( 'wpseo_json_ld_output', true );
 	}
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -30,14 +30,14 @@ class WPSEO_WooCommerce_Schema {
 	public function __construct() {
 		$this->options = get_option( 'wpseo_woo' );
 
-		add_filter( 'woocommerce_structured_data_product', array( $this, 'change_product' ), 10, 2 );
-		add_filter( 'woocommerce_structured_data_type_for_page', array( $this, 'remove_woo_breadcrumbs' ) );
-		add_filter( 'wpseo_schema_webpage', array( $this, 'filter_webpage' ) );
-		add_action( 'wp_footer', array( $this, 'output_schema_footer' ) );
+		add_filter( 'woocommerce_structured_data_product', [ $this, 'change_product' ], 10, 2 );
+		add_filter( 'woocommerce_structured_data_type_for_page', [ $this, 'remove_woo_breadcrumbs' ] );
+		add_filter( 'wpseo_schema_webpage', [ $this, 'filter_webpage' ] );
+		add_action( 'wp_footer', [ $this, 'output_schema_footer' ] );
 
 		// Only needed for WooCommerce versions before 3.8.1.
 		if ( version_compare( WC_VERSION, '3.8.1' ) < 0 ) {
-			add_filter( 'woocommerce_structured_data_review', array( $this, 'change_reviewed_entity' ) );
+			add_filter( 'woocommerce_structured_data_review', [ $this, 'change_reviewed_entity' ] );
 		}
 	}
 
@@ -55,11 +55,11 @@ class WPSEO_WooCommerce_Schema {
 	 * Outputs the Woo Schema blob in the footer.
 	 */
 	public function output_schema_footer() {
-		if ( empty( $this->data ) || $this->data === array() ) {
+		if ( empty( $this->data ) || $this->data === [] ) {
 			return;
 		}
 
-		WPSEO_Utils::schema_output( array( $this->data ), 'yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer' );
+		WPSEO_Utils::schema_output( [ $this->data ], 'yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer' );
 	}
 
 	/**
@@ -93,7 +93,7 @@ class WPSEO_WooCommerce_Schema {
 
 		$this->data['review'][] = $data;
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -110,22 +110,22 @@ class WPSEO_WooCommerce_Schema {
 		// Make seller refer to the Organization.
 		if ( ! empty( $data['offers'] ) ) {
 			foreach ( $data['offers'] as $key => $val ) {
-				$data['offers'][ $key ]['seller'] = array(
+				$data['offers'][ $key ]['seller'] = [
 					'@id' => trailingslashit( WPSEO_Utils::get_home_url() ) . WPSEO_Schema_IDs::ORGANIZATION_HASH,
-				);
+				];
 			}
 		}
 
 		// Only needed for WooCommerce versions before 3.8.1.
 		if ( version_compare( WC_VERSION, '3.8.1' ) < 0 ) {
 			// We're going to replace the single review here with an array of reviews taken from the other filter.
-			$data['review'] = array();
+			$data['review'] = [];
 		}
 
 		// This product is the main entity of this page, so we set it as such.
-		$data['mainEntityOfPage'] = array(
+		$data['mainEntityOfPage'] = [
 			'@id' => $canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
-		);
+		];
 
 		// Now let's add this data to our overall output.
 		$this->data = $data;
@@ -134,7 +134,7 @@ class WPSEO_WooCommerce_Schema {
 		$this->add_brand( $product );
 		$this->add_manufacturer( $product );
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -187,10 +187,10 @@ class WPSEO_WooCommerce_Schema {
 		$term = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
 
 		if ( $term !== null ) {
-			$this->data[ $attribute ] = array(
+			$this->data[ $attribute ] = [
 				'@type' => 'Organization',
 				'name'  => $term->name,
-			);
+			];
 		}
 	}
 
@@ -211,9 +211,9 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		if ( has_post_thumbnail() ) {
-			$this->data['image'] = array(
+			$this->data['image'] = [
 				'@id' => $canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
-			);
+			];
 
 			return;
 		}

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
-        "yoast/yoastcs": "^1.3.0",
+        "yoast/yoastcs": "^2.0.0",
         "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
         "brain/monkey": "^2.4"
     },
@@ -46,8 +46,7 @@
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/tests/*",
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/ --runtime-set testVersion 5.6-"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "fix-cs": [
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82f40098a402db1255fcc79c5852e2fc",
+    "content-hash": "acd223f12974f5dee483e3ba7f177f3d",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -444,16 +444,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.1",
+            "version": "9.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196"
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9999344e47e7af6b00e1a898eacc4e4368fb7196",
-                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
                 "shasum": ""
             },
             "require": {
@@ -498,20 +498,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-09-05T18:36:49+00:00"
+            "time": "2019-11-15T04:12:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936"
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
                 "shasum": ""
             },
             "require": {
@@ -550,7 +550,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-08-28T15:58:19+00:00"
+            "time": "2019-11-04T15:17:54+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -1717,16 +1717,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.2",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
-                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
@@ -1764,7 +1764,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-04-10T23:49:02+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1936,16 +1936,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
                 "shasum": ""
             },
             "require": {
@@ -1968,7 +1968,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -1977,30 +1977,32 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2019-11-11T12:34:03+00:00"
         },
         {
             "name": "yoast/yoastcs",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca"
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-                "squizlabs/php_codesniffer": "^3.4.2",
-                "wp-coding-standards/wpcs": "^2.1.1"
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
+                "jakub-onderka/php-console-highlighter": "^0.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -2025,7 +2027,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2019-07-31T12:06:40+00:00"
+            "time": "2019-12-17T07:40:59+00:00"
         }
     ],
     "aliases": [],

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -13,11 +13,11 @@ if ( function_exists( 'xdebug_disable' ) ) {
 echo 'Welcome to the WordPress SEO WooCommerce test suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 
-if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
+if ( getenv( 'WP_DEVELOP_DIR' ) !== false ) {
 	define( 'WP_DEVELOP_DIR', getenv( 'WP_DEVELOP_DIR' ) );
 }
 
-if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
+if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
 

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -21,9 +21,9 @@ if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
 
-$GLOBALS['wp_tests_options'] = array(
-	'active_plugins' => array( 'wpseo-woocommerce/wpseo-woocommerce.php', 'wordpress-seo/wp-seo.php' ),
-);
+$GLOBALS['wp_tests_options'] = [
+	'active_plugins' => [ 'wpseo-woocommerce/wpseo-woocommerce.php', 'wordpress-seo/wp-seo.php' ],
+];
 
 if ( defined( 'WP_DEVELOP_DIR' ) ) {
 	if ( file_exists( WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php' ) ) {

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -34,10 +34,10 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	public function test_constructor() {
 		$option = new WPSEO_Option_Woo_Double();
 		$this->assertSame(
-			array(
+			[
 				'price' => 'Price',
 				'stock' => 'Stock',
-			),
+			],
 			$option->valid_data_types
 		);
 	}
@@ -59,24 +59,24 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	public function test_validate_option( $field_name, $expected, $dirty, $clean, $old, $short = 'off' ) {
 		$option = $this
 			->getMockBuilder( 'WPSEO_Option_Woo_Double' )
-			->setMethods( array( 'get_taxonomies' ) )
+			->setMethods( [ 'get_taxonomies' ] )
 			->getMock();
 
 		$option
 			->expects( $this->once() )
 			->method( 'get_taxonomies' )
-			->will( $this->returnValue( array( 'yoast' ) ) );
+			->will( $this->returnValue( [ 'yoast' ] ) );
 
-		$dirty = ( $dirty !== null ) ? array( $field_name => $dirty ) : array();
-		$old   = ( $old !== null ) ? array( $field_name => $old ) : array();
+		$dirty = ( $dirty !== null ) ? [ $field_name => $dirty ] : [];
+		$old   = ( $old !== null ) ? [ $field_name => $old ] : [];
 
 		$result = $option->validate_option(
-			array_merge( array( 'short_form' => $short ), $dirty ),
-			array( $field_name => $clean ),
+			array_merge( [ 'short_form' => $short ], $dirty ),
+			[ $field_name => $clean ],
 			$old
 		);
 
-		$this->assertSame( array( $field_name => $expected ), $result );
+		$this->assertSame( [ $field_name => $expected ], $result );
 	}
 
 	/**
@@ -88,63 +88,63 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * @return array
 	 */
 	public function validate_option_values() {
-		return array(
+		return [
 			// Tests a non defined value.
-			array( 'test', null, 123, null, null ),
+			[ 'test', null, 123, null, null ],
 
 			// Tests the validation of the dbversion option.
-			array( 'dbversion', 2, 1, 3, '' ),
+			[ 'dbversion', 2, 1, 3, '' ],
 
 			// Tests the validation of the fields where the dirty value exists in the validate data types.
-			array( 'data1_type', 'price', 'price', 'price', null ),
-			array( 'data2_type', 'price', 'price', 'price', null ),
-			array( 'schema_brand', 'yoast', 'yoast', 'yoast', null ),
-			array( 'schema_manufacturer', 'yoast', 'yoast', 'yoast', null ),
-			array( 'breadcrumbs', true, true, true, '' ),
-			array( 'hide_columns', true, true, true, '' ),
-			array( 'metabox_woo_top', true, true, true, '' ),
+			[ 'data1_type', 'price', 'price', 'price', null ],
+			[ 'data2_type', 'price', 'price', 'price', null ],
+			[ 'schema_brand', 'yoast', 'yoast', 'yoast', null ],
+			[ 'schema_manufacturer', 'yoast', 'yoast', 'yoast', null ],
+			[ 'breadcrumbs', true, true, true, '' ],
+			[ 'hide_columns', true, true, true, '' ],
+			[ 'metabox_woo_top', true, true, true, '' ],
 
 			// Validation where the dirty value is not in the validate data types.
-			array( 'data1_type', 'foo', 'foo', 'price', null ),
-			array( 'data2_type', 'foo', 'foo', 'price', null ),
-			array( 'schema_brand', 'bar', 'bar', 'yoast', null ),
-			array( 'schema_manufacturer', 'bar', 'bar', 'yoast', null ),
-			array( 'breadcrumbs', false, null, true, '' ),
-			array( 'hide_columns', false, null, true, '' ),
-			array( 'metabox_woo_top', false, null, true, '' ),
+			[ 'data1_type', 'foo', 'foo', 'price', null ],
+			[ 'data2_type', 'foo', 'foo', 'price', null ],
+			[ 'schema_brand', 'bar', 'bar', 'yoast', null ],
+			[ 'schema_manufacturer', 'bar', 'bar', 'yoast', null ],
+			[ 'breadcrumbs', false, null, true, '' ],
+			[ 'hide_columns', false, null, true, '' ],
+			[ 'metabox_woo_top', false, null, true, '' ],
 
 			// Validation where the old value is in the validate data types with short form enabled.
-			array( 'data1_type', 'price', null, 'price', 'price', 'on' ),
-			array( 'data2_type', 'price', null, 'price', 'price', 'on' ),
-			array( 'schema_brand', 'yoast', null, 'yoast', 'yoast,', 'on' ),
-			array( 'schema_manufacturer', 'yoast', null, 'yoast', 'yoast', 'on' ),
+			[ 'data1_type', 'price', null, 'price', 'price', 'on' ],
+			[ 'data2_type', 'price', null, 'price', 'price', 'on' ],
+			[ 'schema_brand', 'yoast', null, 'yoast', 'yoast,', 'on' ],
+			[ 'schema_manufacturer', 'yoast', null, 'yoast', 'yoast', 'on' ],
 
 			// Validation where the old value isn't in the validate data types with short form enabled.
-			array( 'data1_type', 'foo', null, 'price', 'foo', 'on' ),
-			array( 'data2_type', 'foo', null, 'price', 'foo', 'on' ),
-			array( 'schema_brand', 'bar', null, 'yoast', 'bar', 'on' ),
-			array( 'schema_manufacturer', 'bar', null, 'yoast', 'bar', 'on' ),
+			[ 'data1_type', 'foo', null, 'price', 'foo', 'on' ],
+			[ 'data2_type', 'foo', null, 'price', 'foo', 'on' ],
+			[ 'schema_brand', 'bar', null, 'yoast', 'bar', 'on' ],
+			[ 'schema_manufacturer', 'bar', null, 'yoast', 'bar', 'on' ],
 
 			// Validation where the old value isn't in the validate data types with short form not enabled.
-			array( 'data1_type', 'price', null, 'price', 'foo', 'off' ),
-			array( 'data2_type', 'price', null, 'price', 'foo', 'off' ),
-			array( 'schema_brand', 'yoast', null, 'yoast', 'bar', 'off' ),
-			array( 'schema_manufacturer', 'yoast', null, 'yoast', 'bar', 'off' ),
+			[ 'data1_type', 'price', null, 'price', 'foo', 'off' ],
+			[ 'data2_type', 'price', null, 'price', 'foo', 'off' ],
+			[ 'schema_brand', 'yoast', null, 'yoast', 'bar', 'off' ],
+			[ 'schema_manufacturer', 'yoast', null, 'yoast', 'bar', 'off' ],
 
 			// Validation where the boolean old value is set with short form enabled.
-			array( 'breadcrumbs', true, null, true, true, 'on' ),
-			array( 'hide_columns', true, null, true, true, 'on' ),
-			array( 'metabox_woo_top', true, null, true, true, 'on' ),
+			[ 'breadcrumbs', true, null, true, true, 'on' ],
+			[ 'hide_columns', true, null, true, true, 'on' ],
+			[ 'metabox_woo_top', true, null, true, true, 'on' ],
 
 			// Validation where the boolean old value is not set with short form enabled.
-			array( 'breadcrumbs', false, null, true, null, 'on' ),
-			array( 'hide_columns', false, null, true, null, 'on' ),
-			array( 'metabox_woo_top', false, null, true, null, 'on' ),
+			[ 'breadcrumbs', false, null, true, null, 'on' ],
+			[ 'hide_columns', false, null, true, null, 'on' ],
+			[ 'metabox_woo_top', false, null, true, null, 'on' ],
 
 			// Validation where the boolean old value is not set with short form not enabled.
-			array( 'breadcrumbs', false, null, true, true, 'off' ),
-			array( 'hide_columns', false, null, true, true, 'off' ),
-			array( 'metabox_woo_top', false, null, true, true, 'off' ),
-		);
+			[ 'breadcrumbs', false, null, true, true, 'off' ],
+			[ 'hide_columns', false, null, true, true, 'off' ],
+			[ 'metabox_woo_top', false, null, true, true, 'off' ],
+		];
 	}
 }

--- a/integration-tests/woocommerce-seo-test.php
+++ b/integration-tests/woocommerce-seo-test.php
@@ -19,13 +19,13 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 		$woocommerce = new Yoast_WooCommerce_SEO();
 
 		$actual   = $woocommerce->column_heading(
-			array(
+			[
 				'wpseo-title'    => '',
 				'another-column' => '',
 				'wpseo-focuskw'  => '',
-			)
+			]
 		);
-		$expected = array( 'another-column' => '' );
+		$expected = [ 'another-column' => '' ];
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -46,7 +46,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 		$class_instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'get_wordpress_seo_version' ) )
+			->setMethods( [ 'get_wordpress_seo_version' ] )
 			->getMock();
 
 		$class_instance
@@ -65,25 +65,25 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 */
 	public function test_filter_hidden_product_for_product_that_is_visible() {
 		$product = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => 'product',
-			)
+			]
 		);
 
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'excluded_from_catalog' ) )
+			->setMethods( [ 'excluded_from_catalog' ] )
 			->getMock();
 
 		$instance
 			->expects( $this->once() )
 			->method( 'excluded_from_catalog' )
-			->will( $this->returnValue( array() ) );
+			->will( $this->returnValue( [] ) );
 
 		$this->assertSame(
-			array( 'loc' => 'http://shop.site/product' ),
-			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
+			[ 'loc' => 'http://shop.site/product' ],
+			$instance->filter_hidden_product( [ 'loc' => 'http://shop.site/product' ], 'post', $product )
 		);
 	}
 
@@ -94,24 +94,24 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 */
 	public function test_filter_hidden_product_for_product_that_is_hidden() {
 		$product = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => 'product',
-			)
+			]
 		);
 
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'excluded_from_catalog' ) )
+			->setMethods( [ 'excluded_from_catalog' ] )
 			->getMock();
 
 		$instance
 			->expects( $this->once() )
 			->method( 'excluded_from_catalog' )
-			->will( $this->returnValue( array( $product->ID ) ) );
+			->will( $this->returnValue( [ $product->ID ] ) );
 
 		$this->assertFalse(
-			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
+			$instance->filter_hidden_product( [ 'loc' => 'http://shop.site/product' ], 'post', $product )
 		);
 	}
 
@@ -122,15 +122,15 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 */
 	public function test_filter_hidden_product_for_a_non_product() {
 		$product = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => 'post',
-			)
+			]
 		);
 
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'excluded_from_catalog' ) )
+			->setMethods( [ 'excluded_from_catalog' ] )
 			->getMock();
 
 		$instance
@@ -138,8 +138,8 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->method( 'excluded_from_catalog' );
 
 		$this->assertSame(
-			array( 'loc' => 'http://shop.site/product' ),
-			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', $product )
+			[ 'loc' => 'http://shop.site/product' ],
+			$instance->filter_hidden_product( [ 'loc' => 'http://shop.site/product' ], 'post', $product )
 		);
 	}
 
@@ -152,7 +152,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'excluded_from_catalog' ) )
+			->setMethods( [ 'excluded_from_catalog' ] )
 			->getMock();
 
 		$instance
@@ -160,8 +160,8 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->method( 'excluded_from_catalog' );
 
 		$this->assertSame(
-			array( 'loc' => 'http://shop.site/product' ),
-			$instance->filter_hidden_product( array( 'loc' => 'http://shop.site/product' ), 'post', null )
+			[ 'loc' => 'http://shop.site/product' ],
+			$instance->filter_hidden_product( [ 'loc' => 'http://shop.site/product' ], 'post', null )
 		);
 	}
 
@@ -174,7 +174,7 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 		$instance = $this
 			->getMockBuilder( 'Yoast_WooCommerce_SEO_Double' )
 			->disableOriginalConstructor()
-			->setMethods( array( 'excluded_from_catalog' ) )
+			->setMethods( [ 'excluded_from_catalog' ] )
 			->getMock();
 
 		$instance
@@ -182,8 +182,8 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 			->method( 'excluded_from_catalog' );
 
 		$this->assertSame(
-			array( 'no-loc' => 'http://shop.site/product' ),
-			$instance->filter_hidden_product( array( 'no-loc' => 'http://shop.site/product' ), 'post', null )
+			[ 'no-loc' => 'http://shop.site/product' ],
+			$instance->filter_hidden_product( [ 'no-loc' => 'http://shop.site/product' ], 'post', null )
 		);
 	}
 
@@ -198,13 +198,13 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * @return array
 	 */
 	public function check_dependencies_data() {
-		return array(
-			array( false, '12.7', '3.0', 'WordPress is below the minimal required version.' ),
-			array( false, '12.7', '5.1', 'WordPress is below the minimal required version.' ),
-			array( false, false, '5.3', 'WordPress SEO is not installed.' ),
-			array( false, '8.1', '5.1', 'WordPress SEO is below the minimal required version.' ),
-			array( true, '12.6-RC1', '5.2', 'WordPress and WordPress SEO have the minimal required versions.' ),
-			array( true, '12.7', '5.3', 'WordPress and WordPress SEO have the minimal required versions.' ),
-		);
+		return [
+			[ false, '12.7', '3.0', 'WordPress is below the minimal required version.' ],
+			[ false, '12.7', '5.1', 'WordPress is below the minimal required version.' ],
+			[ false, false, '5.3', 'WordPress SEO is not installed.' ],
+			[ false, '8.1', '5.1', 'WordPress SEO is below the minimal required version.' ],
+			[ true, '12.6-RC1', '5.2', 'WordPress and WordPress SEO have the minimal required versions.' ],
+			[ true, '12.7', '5.3', 'WordPress and WordPress SEO have the minimal required versions.' ],
+		];
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,7 @@ abstract class TestCase extends PHPUnit_TestCase {
 				'is_multisite'   => false,
 				'site_url'       => 'https://www.example.org',
 				'wp_json_encode' => function( $data, $options = 0, $depth = 512 ) {
-					// phpcs:ignore Yoast.Yoast.AlternativeFunctions,PHPCompatibility.FunctionUse.NewFunctionParameters -- Mocks the wp_json_encode function.
+					// phpcs:ignore Yoast.Yoast.AlternativeFunctions -- Mocks the wp_json_encode function.
 					return \json_encode( $data, $options, $depth );
 				},
 				'wp_slash'       => null,

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -792,12 +792,31 @@ class Yoast_WooCommerce_SEO {
 				echo '<meta property="product:brand" content="' . esc_attr( $term->name ) . '"/>' . "\n";
 			}
 		}
+
 		/**
 		 * Filter: wpseo_woocommerce_og_price - Allow developers to prevent the output of the price in the OpenGraph tags.
 		 *
+		 * @deprecated 12.5.0. Use the {@see 'Yoast\WP\Woocommerce\og_price'} filter instead.
+		 *
 		 * @api bool unsigned Defaults to true.
 		 */
-		if ( apply_filters( 'wpseo_woocommerce_og_price', true ) ) {
+		$show_price = apply_filters_deprecated(
+			'wpseo_woocommerce_og_price',
+			array( true ),
+			'Yoast WooCommerce 12.5.0',
+			'Yoast\WP\Woocommerce\og_price'
+		);
+
+		/**
+		 * Filter: Yoast\WP\Woocommerce\og_price - Allow developers to prevent the output of the price in the OpenGraph tags.
+		 *
+		 * @since 12.5.0
+		 *
+		 * @api bool unsigned Defaults to true.
+		 */
+		$show_price = apply_filters( 'Yoast\WP\Woocommerce\og_price', $show_price );
+
+		if ( $show_price === true ) {
 			echo '<meta property="product:price:amount" content="' . esc_attr( $product->get_price() ) . '"/>' . "\n";
 			echo '<meta property="product:price:currency" content="' . esc_attr( get_woocommerce_currency() ) . '"/>' . "\n";
 		}

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -55,7 +55,7 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @var array
 	 */
-	protected $options = array();
+	protected $options = [];
 
 	/**
 	 * Name of the option to store plugins setting.
@@ -150,8 +150,8 @@ class Yoast_WooCommerce_SEO {
 		$this->options         = get_option( $this->short_name );
 
 		// Make sure the options property is always current.
-		add_action( 'add_option_' . $this->short_name, array( $this, 'refresh_options_property' ) );
-		add_action( 'update_option_' . $this->short_name, array( $this, 'refresh_options_property' ) );
+		add_action( 'add_option_' . $this->short_name, [ $this, 'refresh_options_property' ] );
+		add_action( 'update_option_' . $this->short_name, [ $this, 'refresh_options_property' ] );
 
 		// Enable Yoast usage tracking.
 		add_filter( 'wpseo_enable_tracking', '__return_true' );
@@ -163,62 +163,62 @@ class Yoast_WooCommerce_SEO {
 
 		if ( is_admin() || ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
 			// Add subitem to menu.
-			add_filter( 'wpseo_submenu_pages', array( $this, 'add_submenu_pages' ) );
-			add_action( 'admin_print_styles', array( $this, 'config_page_styles' ) );
+			add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_pages' ] );
+			add_action( 'admin_print_styles', [ $this, 'config_page_styles' ] );
 
 			// Products tab columns.
 			if ( $this->options['hide_columns'] === true ) {
-				add_filter( 'manage_product_posts_columns', array( $this, 'column_heading' ), 11, 1 );
+				add_filter( 'manage_product_posts_columns', [ $this, 'column_heading' ], 11, 1 );
 			}
 
 			// Move Woo box above SEO box.
 			if ( $this->options['metabox_woo_top'] === true ) {
-				add_action( 'admin_footer', array( $this, 'footer_js' ) );
+				add_action( 'admin_footer', [ $this, 'footer_js' ] );
 			}
 		}
 		else {
 			$wpseo_options = WPSEO_Options::get_all();
 
 			// Initialize schema.
-			add_action( 'init', array( $this, 'initialize_schema' ) );
+			add_action( 'init', [ $this, 'initialize_schema' ] );
 
 			// Add metadescription filter.
-			add_filter( 'wpseo_metadesc', array( $this, 'metadesc' ) );
+			add_filter( 'wpseo_metadesc', [ $this, 'metadesc' ] );
 
 			// OpenGraph.
-			add_filter( 'language_attributes', array( $this, 'og_product_namespace' ), 11 );
-			add_filter( 'wpseo_opengraph_type', array( $this, 'return_type_product' ) );
-			add_filter( 'wpseo_opengraph_desc', array( $this, 'og_desc_enhancement' ) );
-			add_action( 'wpseo_opengraph', array( $this, 'og_enhancement' ), 50 );
-			add_action( 'wpseo_register_extra_replacements', array( $this, 'register_replacements' ) );
+			add_filter( 'language_attributes', [ $this, 'og_product_namespace' ], 11 );
+			add_filter( 'wpseo_opengraph_type', [ $this, 'return_type_product' ] );
+			add_filter( 'wpseo_opengraph_desc', [ $this, 'og_desc_enhancement' ] );
+			add_action( 'wpseo_opengraph', [ $this, 'og_enhancement' ], 50 );
+			add_action( 'wpseo_register_extra_replacements', [ $this, 'register_replacements' ] );
 
 			if ( class_exists( 'WPSEO_OpenGraph_Image' ) ) {
-				add_action( 'wpseo_add_opengraph_additional_images', array( $this, 'set_opengraph_image' ) );
+				add_action( 'wpseo_add_opengraph_additional_images', [ $this, 'set_opengraph_image' ] );
 			}
 
-			add_filter( 'wpseo_sitemap_exclude_post_type', array( $this, 'xml_sitemap_post_types' ), 10, 2 );
-			add_filter( 'wpseo_sitemap_post_type_archive_link', array( $this, 'xml_sitemap_taxonomies' ), 10, 2 );
+			add_filter( 'wpseo_sitemap_exclude_post_type', [ $this, 'xml_sitemap_post_types' ], 10, 2 );
+			add_filter( 'wpseo_sitemap_post_type_archive_link', [ $this, 'xml_sitemap_taxonomies' ], 10, 2 );
 
-			add_filter( 'post_type_archive_link', array( $this, 'xml_post_type_archive_link' ), 10, 2 );
-			add_filter( 'wpseo_sitemap_urlimages', array( $this, 'add_product_images_to_xml_sitemap' ), 10, 2 );
+			add_filter( 'post_type_archive_link', [ $this, 'xml_post_type_archive_link' ], 10, 2 );
+			add_filter( 'wpseo_sitemap_urlimages', [ $this, 'add_product_images_to_xml_sitemap' ], 10, 2 );
 
 			// Fix breadcrumbs.
 			if ( $this->options['breadcrumbs'] === true && $wpseo_options['breadcrumbs-enable'] === true ) {
 				$this->handle_breadcrumbs_replacements();
 			}
 		} // End if.
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
 		// Make sure the primary category will be used in the permalink.
-		add_filter( 'wc_product_post_type_link_product_cat', array( $this, 'add_primary_category_permalink' ), 10, 3 );
+		add_filter( 'wc_product_post_type_link_product_cat', [ $this, 'add_primary_category_permalink' ], 10, 3 );
 
 		// Adds recommended replacevars.
-		add_filter( 'wpseo_recommended_replace_vars', array( $this, 'add_recommended_replacevars' ) );
+		add_filter( 'wpseo_recommended_replace_vars', [ $this, 'add_recommended_replacevars' ] );
 
-		add_action( 'admin_init', array( $this, 'init_beacon' ) );
+		add_action( 'admin_init', [ $this, 'init_beacon' ] );
 
-		add_filter( 'wpseo_sitemap_entry', array( $this, 'filter_hidden_product' ), 10, 3 );
-		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'filter_woocommerce_pages' ) );
+		add_filter( 'wpseo_sitemap_entry', [ $this, 'filter_hidden_product' ], 10, 3 );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'filter_woocommerce_pages' ] );
 	}
 
 	/**
@@ -270,19 +270,19 @@ class Yoast_WooCommerce_SEO {
 
 		if ( $excluded_from_catalog === null ) {
 			$query                 = new WP_Query(
-				array(
+				[
 					'fields'         => 'ids',
 					'posts_per_page' => '-1',
 					'post_type'      => 'product',
 					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-					'tax_query'      => array(
-						array(
+					'tax_query'      => [
+						[
 							'taxonomy' => 'product_visibility',
 							'field'    => 'name',
-							'terms'    => array( 'exclude-from-catalog' ),
-						),
-					),
-				)
+							'terms'    => [ 'exclude-from-catalog' ],
+						],
+					],
+				]
 			);
 			$excluded_from_catalog = $query->get_posts();
 		}
@@ -298,7 +298,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return array The post ids with the added page ids.
 	 */
 	public function filter_woocommerce_pages( $excluded_posts_ids ) {
-		$woocommerce_pages   = array();
+		$woocommerce_pages   = [];
 		$woocommerce_pages[] = wc_get_page_id( 'cart' );
 		$woocommerce_pages[] = wc_get_page_id( 'checkout' );
 		$woocommerce_pages[] = wc_get_page_id( 'myaccount' );
@@ -319,13 +319,13 @@ class Yoast_WooCommerce_SEO {
 			return $replacevars;
 		}
 
-		$replacevars['product']                = array( 'sitename', 'title', 'sep', 'primary_category' );
-		$replacevars['product_cat']            = array( 'sitename', 'term_title', 'sep' );
-		$replacevars['product_tag']            = array( 'sitename', 'term_title', 'sep' );
-		$replacevars['product_shipping_class'] = array( 'sitename', 'term_title', 'sep', 'page' );
-		$replacevars['product_brand']          = array( 'sitename', 'term_title', 'sep' );
-		$replacevars['pwb-brand']              = array( 'sitename', 'term_title', 'sep' );
-		$replacevars['product_archive']        = array( 'sitename', 'sep', 'page', 'pt_plural' );
+		$replacevars['product']                = [ 'sitename', 'title', 'sep', 'primary_category' ];
+		$replacevars['product_cat']            = [ 'sitename', 'term_title', 'sep' ];
+		$replacevars['product_tag']            = [ 'sitename', 'term_title', 'sep' ];
+		$replacevars['product_shipping_class'] = [ 'sitename', 'term_title', 'sep', 'page' ];
+		$replacevars['product_brand']          = [ 'sitename', 'term_title', 'sep' ];
+		$replacevars['pwb-brand']              = [ 'sitename', 'term_title', 'sep' ];
+		$replacevars['product_archive']        = [ 'sitename', 'sep', 'page', 'pt_plural' ];
 
 		return $replacevars;
 	}
@@ -403,9 +403,9 @@ class Yoast_WooCommerce_SEO {
 				$term = get_term( (int) $att, array_shift( $att_keys ) );
 
 				if ( is_object( $term ) ) {
-					$crumbs[] = array(
+					$crumbs[] = [
 						'term' => $term,
-					);
+					];
 				}
 			}
 		}
@@ -436,12 +436,12 @@ class Yoast_WooCommerce_SEO {
 
 			foreach ( $attachments as $attachment_id ) {
 				$image_src = wp_get_attachment_image_src( $attachment_id );
-				$image     = array(
+				$image     = [
 					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WPSEO hook.
 					'src'   => apply_filters( 'wpseo_xml_sitemap_img_src', $image_src[0], $post_id ),
 					'title' => get_the_title( $attachment_id ),
 					'alt'   => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
-				);
+				];
 				$images[]  = $image;
 
 				unset( $image, $image_src );
@@ -469,7 +469,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return array All submenu pages including our own.
 	 */
 	public function add_submenu_pages( $submenu_pages ) {
-		$submenu_pages[] = array(
+		$submenu_pages[] = [
 			'wpseo_dashboard',
 			sprintf(
 				/* translators: %1$s resolves to WooCommerce SEO */
@@ -479,8 +479,8 @@ class Yoast_WooCommerce_SEO {
 			'WooCommerce SEO',
 			'wpseo_manage_options',
 			$this->short_name,
-			array( $this, 'admin_panel' ),
-		);
+			[ $this, 'admin_panel' ],
+		];
 
 		return $submenu_pages;
 	}
@@ -522,7 +522,7 @@ class Yoast_WooCommerce_SEO {
 		<label class="select" for="schema_brand">' . esc_html__( 'Brand', 'yoast-woo-seo' ) . '</label>
 		<select class="select" id="schema_brand" name="' . esc_attr( $this->short_name . '[schema_brand]' ) . '">
 			<option value="">-</option>' . "\n";
-		if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
+		if ( is_array( $taxonomies ) && $taxonomies !== [] ) {
 			foreach ( $taxonomies as $tax ) {
 				echo '<option value="' . esc_attr( strtolower( $tax->name ) ) . '"'
 					. selected( strtolower( $tax->name ), $this->options['schema_brand'], false ) . '>'
@@ -537,7 +537,7 @@ class Yoast_WooCommerce_SEO {
 		<label class="select" for="schema_manufacturer">' . esc_html__( 'Manufacturer', 'yoast-woo-seo' ) . '</label>
 		<select class="select" id="schema_manufacturer" name="' . esc_attr( $this->short_name . '[schema_manufacturer]' ) . '">
 			<option value="">-</option>' . "\n";
-		if ( is_array( $taxonomies ) && $taxonomies !== array() ) {
+		if ( is_array( $taxonomies ) && $taxonomies !== [] ) {
 			foreach ( $taxonomies as $tax ) {
 				echo '<option value="' . esc_attr( strtolower( $tax->name ) ) . '"'
 					. selected( strtolower( $tax->name ), $this->options['schema_manufacturer'], false ) . '>'
@@ -659,7 +659,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return array Array with the filtered columns.
 	 */
 	public function column_heading( $columns ) {
-		$keys_to_remove = array( 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw', 'wpseo-score', 'wpseo-score-readability' );
+		$keys_to_remove = [ 'wpseo-title', 'wpseo-metadesc', 'wpseo-focuskw', 'wpseo-score', 'wpseo-score-readability' ];
 
 		if ( class_exists( 'WPSEO_Link_Columns' ) ) {
 			$keys_to_remove[] = 'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKS;
@@ -765,7 +765,7 @@ class Yoast_WooCommerce_SEO {
 
 		$img_ids = $this->get_image_ids( $product );
 
-		if ( is_array( $img_ids ) && $img_ids !== array() ) {
+		if ( is_array( $img_ids ) && $img_ids !== [] ) {
 			foreach ( $img_ids as $img_id ) {
 				$img_url = wp_get_attachment_url( $img_id );
 				$opengraph_image->add_image( $img_url );
@@ -802,7 +802,7 @@ class Yoast_WooCommerce_SEO {
 		 */
 		$show_price = apply_filters_deprecated(
 			'wpseo_woocommerce_og_price',
-			array( true ),
+			[ true ],
 			'Yoast WooCommerce 12.5.0',
 			'Yoast\WP\Woocommerce\og_price'
 		);
@@ -1009,8 +1009,8 @@ class Yoast_WooCommerce_SEO {
 	public function init_beacon() {
 		$helpscout = new WPSEO_HelpScout(
 			'8535d745-4e80-48b9-b211-087880aa857d',
-			array( 'wpseo_woo' ),
-			array( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG )
+			[ 'wpseo_woo' ],
+			[ WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ]
 		);
 
 		$helpscout->register_hooks();
@@ -1024,7 +1024,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return bool
 	 */
 	protected function is_woocommerce_page( $page ) {
-		$woo_pages = array( 'wpseo_woo' );
+		$woo_pages = [ 'wpseo_woo' ];
 
 		return in_array( $page, $woo_pages, true );
 	}
@@ -1041,8 +1041,8 @@ class Yoast_WooCommerce_SEO {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$version       = $asset_manager->flatten_version( self::VERSION );
 
-		wp_enqueue_script( 'wp-seo-woo', plugins_url( 'js/yoastseo-woo-plugin-' . $version . WPSEO_CSSJS_SUFFIX . '.js', __FILE__ ), array(), WPSEO_VERSION, true );
-		wp_enqueue_script( 'wp-seo-woo-replacevars', plugins_url( 'js/yoastseo-woo-replacevars-' . $version . WPSEO_CSSJS_SUFFIX . '.js', __FILE__ ), array(), WPSEO_VERSION, true );
+		wp_enqueue_script( 'wp-seo-woo', plugins_url( 'js/yoastseo-woo-plugin-' . $version . WPSEO_CSSJS_SUFFIX . '.js', __FILE__ ), [], WPSEO_VERSION, true );
+		wp_enqueue_script( 'wp-seo-woo-replacevars', plugins_url( 'js/yoastseo-woo-replacevars-' . $version . WPSEO_CSSJS_SUFFIX . '.js', __FILE__ ), [], WPSEO_VERSION, true );
 
 		wp_localize_script( 'wp-seo-woo', 'wpseoWooL10n', $this->localize_woo_script() );
 		wp_localize_script( 'wp-seo-woo-replacevars', 'wpseoWooReplaceVarsL10n', $this->localize_woo_replacevars_script() );
@@ -1054,28 +1054,28 @@ class Yoast_WooCommerce_SEO {
 	public function register_replacements() {
 		wpseo_register_var_replacement(
 			'wc_price',
-			array( $this, 'get_product_var_price' ),
+			[ $this, 'get_product_var_price' ],
 			'basic',
 			'The product\'s price.'
 		);
 
 		wpseo_register_var_replacement(
 			'wc_sku',
-			array( $this, 'get_product_var_sku' ),
+			[ $this, 'get_product_var_sku' ],
 			'basic',
 			'The product\'s SKU.'
 		);
 
 		wpseo_register_var_replacement(
 			'wc_shortdesc',
-			array( $this, 'get_product_var_short_description' ),
+			[ $this, 'get_product_var_short_description' ],
 			'basic',
 			'The product\'s short description.'
 		);
 
 		wpseo_register_var_replacement(
 			'wc_brand',
-			array( $this, 'get_product_var_brand' ),
+			[ $this, 'get_product_var_brand' ],
 			'basic',
 			'The product\'s brand.'
 		);
@@ -1088,7 +1088,7 @@ class Yoast_WooCommerce_SEO {
 	 */
 	protected function register_i18n_promo_class() {
 		new Yoast_I18n_v3(
-			array(
+			[
 				'textdomain'     => 'yoast-woo-seo',
 				'project_slug'   => 'woocommerce-seo',
 				'plugin_name'    => 'Yoast WooCommerce SEO',
@@ -1097,7 +1097,7 @@ class Yoast_WooCommerce_SEO {
 				'glotpress_name' => 'Yoast Translate',
 				'glotpress_logo' => 'http://translate.yoast.com/gp-templates/images/Yoast_Translate.svg',
 				'register_url'   => 'http://translate.yoast.com/gp/projects#utm_source=plugin&utm_medium=promo-box&utm_campaign=wpseo-woo-i18n-promo',
-			)
+			]
 		);
 	}
 
@@ -1204,10 +1204,10 @@ class Yoast_WooCommerce_SEO {
 			return '';
 		}
 
-		$brand_taxonomies = array(
+		$brand_taxonomies = [
 			'product_brand',
 			'pwb-brand',
-		);
+		];
 
 		$brand_taxonomies = array_filter( $brand_taxonomies, 'taxonomy_exists' );
 
@@ -1259,12 +1259,12 @@ class Yoast_WooCommerce_SEO {
 	 * @return array The localized values.
 	 */
 	protected function localize_woo_replacevars_script() {
-		return array(
+		return [
 			'currency'       => get_woocommerce_currency(),
 			'currencySymbol' => get_woocommerce_currency_symbol(),
 			'decimals'       => wc_get_price_decimals(),
 			'locale'         => str_replace( '_', '-', get_locale() ),
-		);
+		];
 	}
 
 	/**
@@ -1276,13 +1276,13 @@ class Yoast_WooCommerce_SEO {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$version       = $asset_manager->flatten_version( self::VERSION );
 
-		return array(
+		return [
 			'script_url'     => plugins_url( 'js/yoastseo-woo-worker-' . $version . WPSEO_CSSJS_SUFFIX . '.js', self::get_plugin_file() ),
 			'woo_desc_none'  => __( 'You should write a short description for this product.', 'yoast-woo-seo' ),
 			'woo_desc_short' => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
 			'woo_desc_good'  => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
 			'woo_desc_long'  => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
-		);
+		];
 	}
 
 	/**
@@ -1294,10 +1294,10 @@ class Yoast_WooCommerce_SEO {
 		// Replaces the WooCommerce breadcrumbs.
 		if ( has_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb' ) ) {
 			remove_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb', 20, 0 );
-			add_action( 'woocommerce_before_main_content', array( $this, 'show_yoast_breadcrumbs' ), 20, 0 );
+			add_action( 'woocommerce_before_main_content', [ $this, 'show_yoast_breadcrumbs' ], 20, 0 );
 		}
 
-		add_filter( 'wpseo_breadcrumb_links', array( $this, 'add_attribute_to_breadcrumbs' ) );
+		add_filter( 'wpseo_breadcrumb_links', [ $this, 'add_attribute_to_breadcrumbs' ] );
 	}
 }
 

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -437,6 +437,7 @@ class Yoast_WooCommerce_SEO {
 			foreach ( $attachments as $attachment_id ) {
 				$image_src = wp_get_attachment_image_src( $attachment_id );
 				$image     = array(
+					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WPSEO hook.
 					'src'   => apply_filters( 'wpseo_xml_sitemap_img_src', $image_src[0], $post_id ),
 					'title' => get_the_title( $attachment_id ),
 					'alt'   => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -988,7 +988,7 @@ class Yoast_WooCommerce_SEO {
 	 */
 	public function xml_post_type_archive_link( $link, $post_type ) {
 
-		if ( 'product' !== $post_type ) {
+		if ( $post_type !== 'product' ) {
 			return $link;
 		}
 
@@ -1034,7 +1034,7 @@ class Yoast_WooCommerce_SEO {
 	 */
 	public function enqueue_scripts() {
 		// Only do this on product pages.
-		if ( 'product' !== get_post_type() ) {
+		if ( get_post_type() !== 'product' ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* The `wpseo_woocommerce_og_price` filter hook has been deprecated in favour of the `Yoast\WP\Woocommerce\og_price` hook.


## Relevant technical choices:

### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes:
* A selective update of the `composer.lock` for just YoastCS and its dependencies.
* Removing the tweaks to the Composer `check-cs` script to allow for different PHP requirements in different directories.
    PHP 5.6 is now the minimum PHP version everywhere.
* Removing running the `config-yoastcs` script from the Travis script.
    This hasn't been needed since YoastCS 1.1.0.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### PHPCS: remove whitelist comment

... which is no longer needed now PHP 5.6 is the minimum PHP version.

### PHPCS: whitelist use of YoastSEO hooks

### CS: deprecated old-style hook and add new-style hook

This deprecates the `wpseo_woocommerce_og_price` filter hook in favour of the `Yoast\WP\Woocommerce\og_price` hook.

[This needs a changelog entry]

### CS: use short arrays (everywhere)

### CS: don't use Yoda conditions 

## Test instructions

This PR can be tested by following these steps:

### Test the updated composer script:
* Check out this branch
* Run `composer install`
* Run `composer check-cs` and see a clean result.

### Test the hook deprecation
* Start on `trunk` & make sure `WP_DEBUG`/PHP error logging is turned on.
* Add a minimal hook-in for the `wpseo_woocommerce_og_price` filter either in a custom plugin or the theme's `functions.php` file.
    Something along the lines of the below should do:
    ```php
    function test_deprecated_filter($input){
        return $input;
    }
    add_filter('wpseo_woocommerce_og_price', 'test_deprecated_filter');
    ```
* Open a Woocommerce product page with images. There should be no errors in the logs.
* Switch to this branch.
* Refresh the page. A deprecation notice along the lines of the following should show up in the error logs: _'wpseo_woocommerce_og_price is <strong>deprecated</strong> since version Yoast WooCommerce 12.5.0! Use Yoast\WP\Woocommerce\og_price instead.'_
* Now change the `add_filter()` call as added above to:
    ```php
    add_filter('Yoast\WP\Woocommerce\og_price', 'test_deprecated_filter');
    ```
* Refresh the page and the error should longer show up.
* Look at the OpenGraph tags of the page, particularly the `product:price:amount` and `product:price:currency` tags and take note of the price being included in the tags.
* Now, change the `return $input;` in the filter to `return false`.
* Refresh the page again and check that the above mentioned tags are no longer included in the OpenGraph tags anymore.