### PR TITLE
Adds SKU to the output, fixes instock to be in stock

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -752,7 +752,7 @@ class Yoast_WooCommerce_SEO {
 			echo '<meta property="product:availability" content="in stock" />' . "\n";
 		}
 
-		echo '<meta property="product:retailer_item_id" content="' . $product->get_sku() . '" />' . "\n";
+		echo '<meta property="product:retailer_item_id" content="' . esc_attr( $product->get_sku() ) . '" />' . "\n";
 	}
 
 	/**

--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -716,7 +716,7 @@ class Yoast_WooCommerce_SEO {
 			if ( is_array( $terms ) && count( $terms ) > 0 ) {
 				$term_values = array_values( $terms );
 				$term        = array_shift( $term_values );
-				echo '<meta property="product:brand" content="' . esc_attr( $term->name ) . '"/>' . "\n";
+				echo '<meta property="product:brand" content="' . esc_attr( $term->name ) . '" />' . "\n";
 			}
 		}
 
@@ -744,13 +744,15 @@ class Yoast_WooCommerce_SEO {
 		$show_price = apply_filters( 'Yoast\WP\Woocommerce\og_price', $show_price );
 
 		if ( $show_price === true ) {
-			echo '<meta property="product:price:amount" content="' . esc_attr( $product->get_price() ) . '"/>' . "\n";
-			echo '<meta property="product:price:currency" content="' . esc_attr( get_woocommerce_currency() ) . '"/>' . "\n";
+			echo '<meta property="product:price:amount" content="' . esc_attr( $product->get_price() ) . '" />' . "\n";
+			echo '<meta property="product:price:currency" content="' . esc_attr( get_woocommerce_currency() ) . '" />' . "\n";
 		}
 
 		if ( $product->is_in_stock() ) {
-			echo '<meta property="product:availability" content="instock"/>' . "\n";
+			echo '<meta property="product:availability" content="in stock" />' . "\n";
 		}
+
+		echo '<meta property="product:retailer_item_id" content="' . $product->get_sku() . '" />' . "\n";
 	}
 
 	/**


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `product:retailer_item_id` to the plugins OpenGraph output for Facebook Catalog usage.
* Fixes a bug where `product:availability` was set to `instock` instead of the correct `in stock`.

## Test instructions

This PR can be tested by following these steps:

* Go to a product page, see the output now contains `product:retailer_item_id` and `product:availability` is set correctly.

Fixes #456 
