### PR TITLE
Show only public taxonomies in dropdown

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -477,7 +477,9 @@ class Yoast_WooCommerce_SEO {
 		$object_taxonomies = get_object_taxonomies( 'product', 'objects' );
 		$taxonomies        = [ '' => '-' ];
 		foreach ( $object_taxonomies as $object_taxonomy ) {
-			$taxonomies[ strtolower( $object_taxonomy->name ) ] = esc_html( $object_taxonomy->labels->name );
+			if ( is_taxonomy_viewable( $object_taxonomy ) ) {
+				$taxonomies[ strtolower( $object_taxonomy->name ) ] = esc_html( $object_taxonomy->labels->name );
+			}
 		}
 
 		echo '<h2>' . esc_html__( 'Schema & OpenGraph additions', 'yoast-woo-seo' ) . '</h2>


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Only show public taxonomies in the dropdown for Brand and Manufacturer.

## Relevant technical choices:

* Use `is_taxonomy_viewable` core function, which internally relies on `publicly_queryable`

## Test instructions

This PR can be tested by following these steps:

* See the dropdown for Brands and Manufacturers, see it contains non public taxonomies.
* Checkout this branch, see the non public taxonomies are gone.

Fixes #454
