### PR TITLE
If the shop page isn't set in Woo, don't try to use it in the XML sitemap

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -922,7 +922,7 @@ class Yoast_WooCommerce_SEO {
 		if ( function_exists( 'wc_get_page_id' ) ) {
 			$shop_page_id = wc_get_page_id( 'shop' );
 			$home_page_id = (int) get_option( 'page_on_front' );
-			if ( $home_page_id === $shop_page_id ) {
+			if ( $shop_page_id === -1 || $home_page_id === $shop_page_id ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* When the shop page isn't set in WooCommerce, don't try to use it in the XML sitemap.

Fixes #401
