### PR TITLE
Fix a notice for empty image

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -199,7 +199,7 @@ class WPSEO_WooCommerce_Schema {
 		 *
 		 * See https://github.com/woocommerce/woocommerce/issues/24188.
 		 */
-		if ( $this->data['image'] === false ) {
+		if ( isset( $this->data['image'] ) && $this->data['image'] === false ) {
 			unset( $this->data['image'] );
 		}
 


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a notice in the code that could happen on products with variations where a variation lacked an image.

## Test instructions

This PR can be tested by following these steps:

* See reproduction steps in #466 

Fixes #466
Fixes https://github.com/Yoast/bugreports/issues/714
