### PR TITLE
Travis: use 7.4 not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       env: WP_VERSION=5.3 WP_MULTISITE=1 PHPUNIT=1 PHPCS=1 SECURITY=1
     - php: 5.6
       env: WP_VERSION=5.2 PHPLINT=1 PHPUNIT=1
-    - php: "7.4snapshot"
+    - php: 7.4
       env: WP_VERSION=5.3 PHPLINT=1 PHPUNIT=1
     - php: 7.0
       env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Since mid December, Travis now has a native PHP 7.4 image available.

## Test instructions

This PR can be tested by following these steps:

* As long as the Travis build passes and the detailed scripts look ok, we're good.

