### PR TITLE
QA: use FQN functions in namespaced files

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -38,7 +38,7 @@ abstract class TestCase extends PHPUnit_TestCase {
 				},
 				'wp_slash'       => null,
 				'absint'         => function( $value ) {
-					return abs( intval( $value ) );
+					return \abs( \intval( $value ) );
 				},
 			]
 		);

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -19,8 +19,8 @@ class Schema_Test extends TestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		if ( ! defined( 'WC_VERSION' ) ) {
-			define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+		if ( ! \defined( 'WC_VERSION' ) ) {
+			\define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Use fully qualified names for global functions to bypass PHP searching within the namespace first.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.