### PR TITLE
Docs: various improvements

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -104,7 +104,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 		 * @param array $clean Clean value for the option, normally the defaults.
 		 * @param array $old   Old value of the option.
 		 *
-		 * @return  array      Validated clean value for the option to be saved to the database.
+		 * @return array Validated clean value for the option to be saved to the database.
 		 */
 		protected function validate_option( $dirty, $clean, $old ) {
 

--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -98,12 +98,13 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 		/**
 		 * Validates the option.
 		 *
+		 * @todo remove code using $short, there is no "short form" anymore.
+		 *
 		 * @param array $dirty New value for the option.
 		 * @param array $clean Clean value for the option, normally the defaults.
 		 * @param array $old   Old value of the option.
 		 *
 		 * @return  array      Validated clean value for the option to be saved to the database.
-		 * @todo remove code using $short, there is no "short form" anymore.
 		 */
 		protected function validate_option( $dirty, $clean, $old ) {
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -58,7 +58,7 @@ class WPSEO_WooCommerce_Schema {
 	 *
 	 * @param array $data Product Schema data.
 	 *
-	 * @return array $data Product Schema data.
+	 * @return array Product Schema data.
 	 */
 	public function filter_webpage( $data ) {
 		if ( is_product() ) {
@@ -76,7 +76,7 @@ class WPSEO_WooCommerce_Schema {
 	 *
 	 * @param array $data Review Schema data.
 	 *
-	 * @return array $data Review Schema data.
+	 * @return array Review Schema data.
 	 */
 	public function change_reviewed_entity( $data ) {
 		unset( $data['@type'] );
@@ -93,7 +93,7 @@ class WPSEO_WooCommerce_Schema {
 	 * @param array       $data    Schema Product data.
 	 * @param \WC_Product $product Product object.
 	 *
-	 * @return array $data Schema Product data.
+	 * @return array Schema Product data.
 	 */
 	public function change_product( $data, $product ) {
 		$canonical = $this->get_canonical();
@@ -131,7 +131,7 @@ class WPSEO_WooCommerce_Schema {
 	 * @param array       $data    Schema Product data.
 	 * @param \WC_Product $product The product.
 	 *
-	 * @return array $data Schema Product data.
+	 * @return array Schema Product data.
 	 */
 	private function filter_offers( $data, $product ) {
 		$home_url = trailingslashit( home_url() );
@@ -157,7 +157,7 @@ class WPSEO_WooCommerce_Schema {
 	 *
 	 * @param array $types Types of Schema Woo will render.
 	 *
-	 * @return array $types Types of Schema Woo will render.
+	 * @return array Types of Schema Woo will render.
 	 */
 	public function remove_woo_breadcrumbs( $types ) {
 		foreach ( $types as $key => $type ) {
@@ -186,7 +186,7 @@ class WPSEO_WooCommerce_Schema {
 	 *
 	 * @param array $data Schema Product data.
 	 *
-	 * @return array $data Schema Product data.
+	 * @return array Schema Product data.
 	 */
 	private function change_seller_in_offers( $data ) {
 		$company_or_person = WPSEO_Options::get( 'company_or_person', false );
@@ -323,7 +323,7 @@ class WPSEO_WooCommerce_Schema {
 	 *
 	 * @param \WC_Product $product The WooCommerce product we're working with.
 	 *
-	 * @return array $data Schema Offers data.
+	 * @return array Schema Offers data.
 	 */
 	protected function add_individual_offers( $product ) {
 		$variations = $product->get_available_variations();
@@ -361,7 +361,7 @@ class WPSEO_WooCommerce_Schema {
 	 * @param array       $data    Review Schema data.
 	 * @param \WC_Product $product The WooCommerce product we're working with.
 	 *
-	 * @return array $data Review Schema data.
+	 * @return array Review Schema data.
 	 */
 	protected function filter_reviews( $data, $product ) {
 		if ( ! isset( $data['review'] ) || $data['review'] === [] ) {

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -35,7 +35,7 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Should the yoast schema output be used.
 	 *
-	 * @return boolean Whether or not the Yoast SEO schema should be output.
+	 * @return bool Whether or not the Yoast SEO schema should be output.
 	 */
 	public static function should_output_yoast_schema() {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WPSEO hook.

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -710,7 +710,7 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @since 4.3
 	 *
-	 * @return null|WC_Product
+	 * @return WC_Product|null
 	 */
 	private function get_product() {
 		if ( ! is_singular( 'product' ) || ! function_exists( 'wc_get_product' ) ) {
@@ -1021,7 +1021,7 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @param int $product_id The id to get the product for.
 	 *
-	 * @return null|WC_Product
+	 * @return WC_Product|null
 	 */
 	protected function get_product_for_id( $product_id ) {
 		if ( function_exists( 'wc_get_product' ) ) {

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -91,8 +91,8 @@ class Yoast_WooCommerce_SEO {
 
 			// Fix breadcrumbs.
 			$this->handle_breadcrumbs_replacements();
+		}
 
-		} // End if.
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
 		// Make sure the primary category will be used in the permalink.

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -333,9 +333,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Registers the settings page in the WP SEO menu.
 	 *
-	 * @param array $submenu_pages List of current submenus.
-	 *
 	 * @since 5.6
+	 *
+	 * @param array $submenu_pages List of current submenus.
 	 *
 	 * @return array All submenu pages including our own.
 	 */
@@ -485,9 +485,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Removes the Yoast SEO columns in the edit products page.
 	 *
-	 * @param array $columns List of registered columns.
-	 *
 	 * @since 1.0
+	 *
+	 * @param array $columns List of registered columns.
 	 *
 	 * @return array Array with the filtered columns.
 	 */
@@ -528,10 +528,10 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Make sure product variations and shop coupons are not included in the XML sitemap.
 	 *
+	 * @since 1.0
+	 *
 	 * @param bool   $bool      Whether or not to include this post type in the XML sitemap.
 	 * @param string $post_type The post type of the post.
-	 *
-	 * @since 1.0
 	 *
 	 * @return bool
 	 */
@@ -546,10 +546,10 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Make sure product attribute taxonomies are not included in the XML sitemap.
 	 *
+	 * @since 1.0
+	 *
 	 * @param bool   $bool     Whether or not to include this post type in the XML sitemap.
 	 * @param string $taxonomy The taxonomy to check against.
-	 *
-	 * @since 1.0
 	 *
 	 * @return bool
 	 */
@@ -585,9 +585,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Adds the opengraph images.
 	 *
-	 * @param WPSEO_OpenGraph_Image $opengraph_image The OpenGraph image to use.
-	 *
 	 * @since 4.3
+	 *
+	 * @param WPSEO_OpenGraph_Image $opengraph_image The OpenGraph image to use.
 	 */
 	public function set_opengraph_image( WPSEO_OpenGraph_Image $opengraph_image ) {
 
@@ -723,9 +723,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Make sure the OpenGraph description is put out.
 	 *
-	 * @param string $desc The current description, will be overwritten if we're on a product page.
-	 *
 	 * @since 1.0
+	 *
+	 * @param string $desc The current description, will be overwritten if we're on a product page.
 	 *
 	 * @return string
 	 */
@@ -747,9 +747,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Return 'product' when current page is, well... a product.
 	 *
-	 * @param string $type Passed on without changing if not a product.
-	 *
 	 * @since 1.0
+	 *
+	 * @param string $type Passed on without changing if not a product.
 	 *
 	 * @return string
 	 */
@@ -805,9 +805,9 @@ class Yoast_WooCommerce_SEO {
 	 * Checks if product class has a short description method. Otherwise it returns the value of the post_excerpt from
 	 * the post attribute.
 	 *
-	 * @param WC_Product $product The product.
-	 *
 	 * @since 4.9
+	 *
+	 * @param WC_Product $product The product.
 	 *
 	 * @return string
 	 */
@@ -822,9 +822,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Checks if product class has a description method. Otherwise it returns the value of the post_content.
 	 *
-	 * @param WC_Product $product The product.
-	 *
 	 * @since 4.9
+	 *
+	 * @param WC_Product $product The product.
 	 *
 	 * @return string
 	 */
@@ -999,9 +999,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Returns the set image ids for the given product.
 	 *
-	 * @param WC_Product $product The product to get the image ids for.
-	 *
 	 * @since 4.9
+	 *
+	 * @param WC_Product $product The product to get the image ids for.
 	 *
 	 * @return array
 	 */
@@ -1017,9 +1017,9 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Returns the product for given product_id.
 	 *
-	 * @param integer $product_id The id to get the product for.
-	 *
 	 * @since 4.9
+	 *
+	 * @param int $product_id The id to get the product for.
 	 *
 	 * @return null|WC_Product
 	 */

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -840,7 +840,7 @@ class Yoast_WooCommerce_SEO {
 	 * Checks if product class has a short description method. Otherwise it returns the value of the post_excerpt from
 	 * the post attribute.
 	 *
-	 * @param WC_Product $product The product.
+	 * @param WC_Product|null $product The product.
 	 *
 	 * @return string
 	 */

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -24,14 +24,14 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 *
 	 * @dataProvider validate_option_values
 	 *
+	 * @covers WPSEO_Option_Woo::validate_option
+	 *
 	 * @param string           $field_name The field name to validate.
 	 * @param string|bool      $expected   The expected value.
 	 * @param string|bool|null $dirty      The value for the dirty argument.
 	 * @param string|bool      $clean      The value for the clean argument.
 	 * @param string|bool|null $old        The value for the old argument.
 	 * @param string           $short      Determines whether the short form should set or not.
-	 *
-	 * @covers WPSEO_Option_Woo::validate_option
 	 */
 	public function test_validate_option( $field_name, $expected, $dirty, $clean, $old, $short = 'off' ) {
 		$option = new WPSEO_Option_Woo_Double();

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -54,7 +54,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * Formatting of each record that is provided:
 	 * field, expected, dirty, clean, old and short-form.
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function validate_option_values() {
 		return [


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

### Docs: fix tag order

### Docs: use short form types

### Docs: fix return tags

PHP has no concept of named return variables, so the name of the variable has no value in the `@return` tag.

### Docs: remove stray `// end` tag

### Docs: null should be last when there are multiple types

### Docs: improve specificity for array types

### Docs: minor tag alignment fix

### Docs: fix missing type in param comment

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.