### PR TITLE
When a product has an ISBN, it's Schema technically a Book

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -203,6 +203,9 @@ class WPSEO_WooCommerce_Schema {
 
 		foreach ( $global_identifier_values as $type => $value ) {
 			$this->data[ $type ] = $value;
+			if ( $type === 'isbn' ) {
+				$this->data['@type'] = [ 'Book', 'Product' ];
+			}
 		}
 		return true;
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -681,6 +681,35 @@ class Schema_Test extends TestCase {
 	}
 
 	/**
+	 * Test adding an ISBN number.
+	 *
+	 * @covers WPSEO_WooCommerce_Schema::add_global_identifier
+	 */
+	public function test_add_global_identifier_isbn() {
+		$product = Mockery::mock( 'WC_Product' );
+		$product->expects( 'get_id' )->once()->andReturn( 123 );
+
+		$data = [
+			'isbn' => '978-3-16-148410-0',
+		];
+
+		Functions\stubs(
+			[
+				'get_post_meta' => $data,
+			]
+		);
+
+		$schema = new Schema_Double();
+		$schema->add_global_identifier( $product );
+
+		$expected = [
+			'@type' => [ 'Book', 'Product' ],
+			'isbn'  => '978-3-16-148410-0',
+		];
+		$this->assertEquals( $expected, $schema->data );
+	}
+
+	/**
 	 * Test if our review filtering works.
 	 *
 	 * @covers WPSEO_WooCommerce_Schema::filter_reviews


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* When adding an ISBN number to a product, we double "type" it to `Book / Product`. By double typing it, the Product can have the attributes of both [schema.org/Book](https://schema.org/Book) _and_ [schema.org/Product](https://schema.org/Product), and thus it can have an `isbn` attribute and a `price` etc.

## Test instructions

This PR can be tested by following these steps:

* Add an ISBN number to a product, see that the Schema output now contains `[ 'Book', 'Product' ]` as `@type`.

