### PR TITLE
Don't exclude product attributes from the XML sitemap by default

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -560,10 +560,6 @@ class Yoast_WooCommerce_SEO {
 			return true;
 		}
 
-		if ( substr( $taxonomy, 0, 3 ) === 'pa_' ) {
-			return true;
-		}
-
 		return $bool;
 	}
 


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Currently, no product attributes are ever added to the Yoast SEO XML sitemap. With this fix, attributes which have archives _are_ added to the XML sitemaps.

## Test instructions

This PR can be tested by following these steps:

* Create two product attributes. Set one to have archives, the other not to have archives. See that the former shows up in the XML sitemap while the latter doesn't.
