### PR TITLE
Allow saving empty value for GTIN etc.

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -203,7 +203,7 @@ class WPSEO_WooCommerce_Schema {
 
 		foreach ( $global_identifier_values as $type => $value ) {
 			$this->data[ $type ] = $value;
-			if ( $type === 'isbn' ) {
+			if ( $type === 'isbn' && ! empty( $value ) ) {
 				$this->data['@type'] = [ 'Book', 'Product' ];
 			}
 		}

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -104,10 +104,6 @@ class WPSEO_WooCommerce_Yoast_Tab {
 	 * @return bool True when safe and not empty, false when it's not.
 	 */
 	protected function validate_data( $value ) {
-		if ( empty( $value ) ) {
-			return false;
-		}
-
 		if ( wp_strip_all_tags( $value ) !== $value ) {
 			return false;
 		}

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -118,13 +118,19 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			[
 				'wp_is_post_revision' => false,
 				'wp_verify_nonce'     => true,
+				'update_post_meta'    => true,
+				'wp_strip_all_tags'   => function ( $value ) {
+					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
+					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
+					return strip_tags( $value );
+				},
 			]
 		);
 
 		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
 
 		// No $_POST data, so nothing to save.
-		$this->assertFalse( $instance->save_data( 123 ) );
+		$this->assertTrue( $instance->save_data( 123 ) );
 	}
 
 	/**
@@ -177,7 +183,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 		$instance = new Yoast_Tab_Double();
 		$this->assertTrue( $instance->validate_data( '12345' ) );
 		$this->assertFalse( $instance->validate_data( '12345<script>' ) );
-		$this->assertFalse( $instance->validate_data( '' ) );
+		$this->assertTrue( $instance->validate_data( '' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->

Allow saving empty value, issue existed only in non-released functionality, no changelog line needed.

This PR can be summarized in the following changelog entry:

* None needed.

## Test instructions

This PR can be tested by following these steps:

* Set a GTIN8 or other value, save it. Then empty it, save again. See that it's saved as empty.

Fixes #495
