### PR TITLE
Don't output empty retailer_item_id

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -693,7 +693,10 @@ class Yoast_WooCommerce_SEO {
 			echo '<meta property="product:availability" content="in stock" />' . "\n";
 		}
 
-		echo '<meta property="product:retailer_item_id" content="' . esc_attr( $product->get_sku() ) . '" />' . "\n";
+		$sku = $product->get_sku();
+		if ( ! empty( $sku ) ) {
+			echo '<meta property="product:retailer_item_id" content="' . esc_attr( $sku ) . '" />' . "\n";
+		}
 
 		/**
 		 * Filter: Yoast\WP\Woocommerce\product_condition - Allow developers to prevent or change the output of the product condition in the OpenGraph tags.


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Do not output an empty `product:retailer_item_id` when there is no SKU.

## Test instructions

This PR can be tested by following these steps:

* Have a product without an SKU, see that `product:retailer_item_id` is not in the OpenGraph output.

Fixes #496 
