### PR TITLE
Remove productID from schema output

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -124,7 +124,6 @@ class WPSEO_WooCommerce_Schema {
 		$this->add_image( $canonical );
 		$this->add_brand( $product );
 		$this->add_manufacturer( $product );
-		$this->add_sku( $product );
 		$this->add_global_identifier( $product );
 
 		return [];
@@ -172,18 +171,6 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		return $types;
-	}
-
-	/**
-	 * Add productID to our output.
-	 *
-	 * @param \WC_Product $product Product object.
-	 */
-	protected function add_sku( $product ) {
-		$sku = $product->get_sku();
-		if ( ! empty( $sku ) ) {
-			$this->data['productID'] = $sku;
-		}
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -469,36 +469,6 @@ class Schema_Test extends TestCase {
 	}
 
 	/**
-	 * Test that adding the SKU as the productID works.
-	 *
-	 * @covers WPSEO_WooCommerce_Schema::add_sku
-	 */
-	public function test_add_sku() {
-		$class   = new Schema_Double();
-		$product = Mockery::mock( 'WC_Product' );
-		$product->expects( 'get_sku' )->once()->andReturn( 'sku123' );
-
-		$expected = [ 'productID' => 'sku123' ];
-		$class->add_sku( $product );
-		$this->assertEquals( $expected, $class->data );
-	}
-
-	/**
-	 * Test that adding the SKU as the productID works.
-	 *
-	 * @covers WPSEO_WooCommerce_Schema::add_sku
-	 */
-	public function test_empty_sku() {
-		$class   = new Schema_Double();
-		$product = Mockery::mock( 'WC_Product' );
-		$product->expects( 'get_sku' )->once()->andReturn( '' );
-
-		$expected = null;
-		$class->add_sku( $product );
-		$this->assertEquals( $expected, $class->data );
-	}
-
-	/**
 	 * Changing the seller in offers to point to our Organization ID when there's no org.
 	 *
 	 * @covers WPSEO_WooCommerce_Schema::change_seller_in_offers
@@ -836,7 +806,6 @@ class Schema_Test extends TestCase {
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 5 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
-		$product->expects( 'get_sku' )->once()->with()->andReturn( 'sku1234' );
 
 		Mockery::getConfiguration()->setConstantsMap(
 			[
@@ -950,7 +919,6 @@ class Schema_Test extends TestCase {
 				'@type' => 'Organization',
 				'name'  => $product_name,
 			],
-			'productID'        => 'sku1234',
 		];
 
 		$instance->change_product( $data, $product );


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove `productID` from schema output. It adds complexity that isn't needed.

## Test instructions

This PR can be tested by following these steps:

* See that `productID` no longer apears in schema output.

Fixes #500
Fixes #498 
