### PR TITLE
Show all taxonomies in Brands & Manufacturer dropdowns

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -391,6 +391,7 @@ class Yoast_WooCommerce_SEO {
 	public function admin_panel() {
 		Yoast_Form::get_instance()->admin_header( true, 'wpseo_woo' );
 
+		// Do not make the mistake of thinking this should only be public taxonomies, see https://github.com/Yoast/bugreports/issues/872.
 		$object_taxonomies = get_object_taxonomies( 'product', 'objects' );
 		$taxonomies        = [ '' => '-' ];
 		foreach ( $object_taxonomies as $object_taxonomy ) {

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -391,7 +391,7 @@ class Yoast_WooCommerce_SEO {
 	public function admin_panel() {
 		Yoast_Form::get_instance()->admin_header( true, 'wpseo_woo' );
 
-		$object_taxonomies = array_filter( get_object_taxonomies( 'product', 'objects' ), 'is_taxonomy_viewable' );
+		$object_taxonomies = get_object_taxonomies( 'product', 'objects' );
 		$taxonomies        = [ '' => '-' ];
 		foreach ( $object_taxonomies as $object_taxonomy ) {
 			$taxonomies[ strtolower( $object_taxonomy->name ) ] = esc_html( $object_taxonomy->labels->name );


### PR DESCRIPTION
Make all product attributes available for Brands and Manufacturer dropdowns.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make all product attributes available for Brands and Manufacturer dropdowns instead of just product attributes with public archives.

## Test instructions

This PR can be tested by following these steps:

* Create a product attribute, add some terms to it. Do not check the "Enable archives" box. 
* Go to SEO → WooCommerce. See that you can still select your new product attribute under Brands & Manufacturer. 

Fixes https://github.com/Yoast/bugreports/issues/872
