### PR TITLE
Add explanatory copy above product identifiers

### DIFF
--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -60,6 +60,8 @@ class WPSEO_WooCommerce_Yoast_Tab {
 
 		echo '<div id="yoast_seo" class="panel woocommerce_options_panel">';
 		echo '<div class="options_group">';
+		echo '<h2>' . __( 'Product identifiers', 'yoast-woo-seo' ) . '</h2>';
+		echo '<p>' . __( 'If you have any of these unique identifiers for your products, please add them here. Yoast SEO will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ) . '</p>';
 		wp_nonce_field( 'yoast_woo_seo_identifiers', '_wpnonce_yoast_seo_woo' );
 
 		foreach ( $this->global_identifier_types as $type => $label ) {

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -61,7 +61,12 @@ class WPSEO_WooCommerce_Yoast_Tab {
 		echo '<div id="yoast_seo" class="panel woocommerce_options_panel">';
 		echo '<div class="options_group">';
 		echo '<h2>' . esc_html__( 'Product identifiers', 'yoast-woo-seo' ) . '</h2>';
-		echo '<p>' . esc_html__( 'If you have any of these unique identifiers for your products, please add them here. Yoast SEO will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ) . '</p>';
+		echo '<p>' . sprintf(
+			/* translators: %1$s resolves to Yoast SEO */
+			esc_html__( 'If you have any of these unique identifiers for your products, please add them here. %1$s will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ),
+			'Yoast SEO'
+		) . '</p>';
+
 		wp_nonce_field( 'yoast_woo_seo_identifiers', '_wpnonce_yoast_seo_woo' );
 
 		foreach ( $this->global_identifier_types as $type => $label ) {

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -60,8 +60,8 @@ class WPSEO_WooCommerce_Yoast_Tab {
 
 		echo '<div id="yoast_seo" class="panel woocommerce_options_panel">';
 		echo '<div class="options_group">';
-		echo '<h2>' . __( 'Product identifiers', 'yoast-woo-seo' ) . '</h2>';
-		echo '<p>' . __( 'If you have any of these unique identifiers for your products, please add them here. Yoast SEO will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ) . '</p>';
+		echo '<h2>' . esc_html( __( 'Product identifiers', 'yoast-woo-seo' ) ) . '</h2>';
+		echo '<p>' . esc_html( __( 'If you have any of these unique identifiers for your products, please add them here. Yoast SEO will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ) ) . '</p>';
 		wp_nonce_field( 'yoast_woo_seo_identifiers', '_wpnonce_yoast_seo_woo' );
 
 		foreach ( $this->global_identifier_types as $type => $label ) {

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -60,8 +60,8 @@ class WPSEO_WooCommerce_Yoast_Tab {
 
 		echo '<div id="yoast_seo" class="panel woocommerce_options_panel">';
 		echo '<div class="options_group">';
-		echo '<h2>' . esc_html( __( 'Product identifiers', 'yoast-woo-seo' ) ) . '</h2>';
-		echo '<p>' . esc_html( __( 'If you have any of these unique identifiers for your products, please add them here. Yoast SEO will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ) ) . '</p>';
+		echo '<h2>' . esc_html__( 'Product identifiers', 'yoast-woo-seo' ) . '</h2>';
+		echo '<p>' . esc_html__( 'If you have any of these unique identifiers for your products, please add them here. Yoast SEO will use them in your Schema and OpenGraph output.', 'yoast-woo-seo' ) . '</p>';
 		wp_nonce_field( 'yoast_woo_seo_identifiers', '_wpnonce_yoast_seo_woo' );
 
 		foreach ( $this->global_identifier_types as $type => $label ) {


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add explanatory copy above the input fields for GTIN, ISBN etc.

## Test instructions

This PR can be tested by following these steps:

* Open the Yoast SEO tab in the WooCommerce product data metabox, see that there is now explanatory copy above the input fields.

FYI: the description is not 100% aligned with the title and field names. It's a conscious decision to not fix this by adding CSS to WooCommerce's page.