### PR TITLE
Fix missing features in product editor

### DIFF
--- a/js/src/yoastseo-woo-handle-excerpt-editors.js
+++ b/js/src/yoastseo-woo-handle-excerpt-editors.js
@@ -41,7 +41,7 @@ function getTextEditorContent( elementID ) {
  *
  * @returns {boolean} Whether TinyMCE is available.
  */
-function isTinyMCEAvailable( editorID ) {
+export function isTinyMCEAvailable( editorID ) {
 	if ( ! isTinyMCELoaded() ) {
 		return false;
 	}

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -1,6 +1,6 @@
 /* global YoastSEO, wpseoWooL10n */
 
-import { getExcerpt, addExcerptEventHandlers } from "./yoastseo-woo-handle-excerpt-editors";
+import { getExcerpt, addExcerptEventHandlers, isTinyMCEAvailable } from "./yoastseo-woo-handle-excerpt-editors";
 
 const PLUGIN_NAME = "YoastWooCommerce";
 


### PR DESCRIPTION
## Summary
I know the fix seems silly, but the problem is that instead of throwing an error the code execution just stopped at the point where the function was called. This made it hard to pinpoint the exact point of failure.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the internal linking and additional keyphrase functionality are missing from the product edit page.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Make sure the Additional keyphrases and internal linking are visible and working correctly.

Fixes Yoast/Bugreports#881
