### PR TITLE
QA: consistent use of `use` statements

### DIFF
--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -2,9 +2,7 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Classes;
 
-use Brain\Monkey;
 use Brain\Monkey\Functions;
-use Mockery;
 use Yoast\WP\Woocommerce\Tests\Doubles\Yoast_Tab_Double;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes;
 use Brain\Monkey\Functions;
 use Yoast\WP\Woocommerce\Tests\Doubles\Yoast_Tab_Double;
 use Yoast\WP\Woocommerce\Tests\TestCase;
+use WPSEO_WooCommerce_Yoast_Tab;
 
 /**
  * Class WooCommerce_Schema_Test.
@@ -17,7 +18,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::__construct
 	 */
 	public function test_construct() {
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 		$this->assertTrue( \has_filter( 'woocommerce_product_data_tabs', [ $instance, 'yoast_seo_tab' ] ) );
 		$this->assertTrue( \has_action( 'woocommerce_product_data_panels', [ $instance, 'add_yoast_seo_fields' ] ) );
 		$this->assertTrue( \has_action( 'save_post', [ $instance, 'save_data' ] ) );
@@ -29,7 +30,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::yoast_seo_tab
 	 */
 	public function test_yoast_seo_tab() {
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 		$expected = [
 			'yoast_tab' => [
 				'label'  => 'Yoast SEO',
@@ -63,7 +64,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			]
 		);
 
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 		$instance->add_yoast_seo_fields();
 
 		$output = \ob_get_contents();
@@ -85,7 +86,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			]
 		);
 
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 		$this->assertFalse( $instance->save_data( 123 ) );
 	}
 
@@ -102,7 +103,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			]
 		);
 
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 		$this->assertFalse( $instance->save_data( 123 ) );
 	}
 
@@ -125,7 +126,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			]
 		);
 
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 
 		// No $_POST data, so nothing to save.
 		$this->assertTrue( $instance->save_data( 123 ) );
@@ -152,7 +153,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			]
 		);
 
-		$instance = new \WPSEO_WooCommerce_Yoast_Tab();
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 
 		$_POST = [
 			'yoast_seo' => [

--- a/tests/doubles/opengraph-double.php
+++ b/tests/doubles/opengraph-double.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Doubles;
 
-use WC_Product;
-use WPSEO_OpenGraph_Image;
 use WPSEO_WooCommerce_OpenGraph;
 
 /**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* QA: remove unused `use` statements
* QA: add missing class `use` import statement 

## Relevant technical choices:

* QA: remove unused `use` statements
* QA: add missing class `use` import statement 



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.