### PR TITLE
QA: declare static closures as static

### DIFF
--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -129,10 +129,10 @@ class OpenGraph_Test extends TestCase {
 				'wc_get_price_decimals'      => 2,
 				'wc_tax_enabled'             => true,
 				'wc_prices_include_tax'      => false,
-				'wc_get_price_including_tax' => function ( $product, $args ) {
+				'wc_get_price_including_tax' => static function ( $product, $args ) {
 					return ( $args['price'] * 1.1 );
 				},
-				'wc_format_decimal'          => function ( $number ) {
+				'wc_format_decimal'          => static function ( $number ) {
 					return \number_format( $number, 2 );
 				},
 			]
@@ -180,7 +180,7 @@ class OpenGraph_Test extends TestCase {
 				'wp_strip_all_tags'     => null,
 				'strip_shortcodes'      => null,
 				'get_the_terms'         => [ 'Apple' => (object) [ 'name' => 'Apple' ] ],
-				'get_term_by'           => function ( $thing, $term, $taxonomy ) {
+				'get_term_by'           => static function ( $thing, $term, $taxonomy ) {
 					return (object) [ 'name' => 'Apple' ];
 				},
 			]

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -205,7 +205,7 @@ class Schema_Test extends TestCase {
 				'get_site_url'             => $base_url,
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => function ( $number ) {
+				'wc_format_decimal'        => static function ( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -864,7 +864,7 @@ class Schema_Test extends TestCase {
 				'wc_placeholder_img_src'   => $base_url . '/example_image.jpg',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => function ( $number ) {
+				'wc_format_decimal'        => static function ( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -1028,7 +1028,7 @@ class Schema_Test extends TestCase {
 				'wc_placeholder_img_src'   => $base_url . '/example_image.jpg',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => function ( $number ) {
+				'wc_format_decimal'        => static function ( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',

--- a/tests/classes/utils-test.php
+++ b/tests/classes/utils-test.php
@@ -82,10 +82,10 @@ class Utils_Test extends TestCase {
 				'wc_get_price_decimals'      => 2,
 				'wc_tax_enabled'             => true,
 				'wc_prices_include_tax'      => false,
-				'wc_format_decimal'          => function ( $number, $decimals ) {
+				'wc_format_decimal'          => static function ( $number, $decimals ) {
 					return \number_format( $number, $decimals );
 				},
-				'wc_get_price_including_tax' => function ( $product, $args ) {
+				'wc_get_price_including_tax' => static function ( $product, $args ) {
 					return ( $args['price'] * 1.1 );
 				},
 			]

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -59,7 +59,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 				'_e'              => null,
 				'esc_attr'        => null,
 				'esc_html_e'      => null,
-				'wp_nonce_field'  => function ( $action, $name ) {
+				'wp_nonce_field'  => static function ( $action, $name ) {
 					return '<input type="hidden" id="" name="' . $name . '" value="' . $action . '" />';
 				},
 			]
@@ -119,7 +119,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 				'wp_is_post_revision' => false,
 				'wp_verify_nonce'     => true,
 				'update_post_meta'    => true,
-				'wp_strip_all_tags'   => function ( $value ) {
+				'wp_strip_all_tags'   => static function ( $value ) {
 					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
 					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 					return \strip_tags( $value );
@@ -146,7 +146,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 				'wp_verify_nonce'     => true,
 				'update_post_meta'    => true,
 				'wp_unslash'          => null,
-				'wp_strip_all_tags'   => function ( $value ) {
+				'wp_strip_all_tags'   => static function ( $value ) {
 					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
 					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 					return \strip_tags( $value );
@@ -172,7 +172,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	public function test_validate_data() {
 		Functions\stubs(
 			[
-				'wp_strip_all_tags' => function ( $value ) {
+				'wp_strip_all_tags' => static function ( $value ) {
 					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
 					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 					return \strip_tags( $value );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* QA: declare static closures as static

## Relevant technical choices:

* No functional changes.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.