### PR TITLE
QA: use the most specific test assertion

### DIFF
--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -48,14 +48,14 @@ class OpenGraph_Test extends TestCase {
 		);
 
 		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertEquals( 'product', $og->return_type_product( 'article' ) );
+		$this->assertSame( 'product', $og->return_type_product( 'article' ) );
 
 		Functions\stubs(
 			[
 				'is_singular' => false,
 			]
 		);
-		$this->assertEquals( 'article', $og->return_type_product( 'article' ) );
+		$this->assertSame( 'article', $og->return_type_product( 'article' ) );
 	}
 
 	/**
@@ -71,7 +71,7 @@ class OpenGraph_Test extends TestCase {
 		);
 
 		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertEquals( 'example description', $og->product_taxonomy_desc_enhancement( 'example description' ) );
+		$this->assertSame( 'example description', $og->product_taxonomy_desc_enhancement( 'example description' ) );
 
 		$expected = 'This is our expected description';
 
@@ -83,7 +83,7 @@ class OpenGraph_Test extends TestCase {
 				'strip_shortcodes'    => null,
 			]
 		);
-		$this->assertEquals( $expected, $og->product_taxonomy_desc_enhancement( 'example description' ) );
+		$this->assertSame( $expected, $og->product_taxonomy_desc_enhancement( 'example description' ) );
 	}
 
 	/**
@@ -101,14 +101,14 @@ class OpenGraph_Test extends TestCase {
 		);
 
 		$input = 'prefix="fn: https://yoast.com/bla"';
-		$this->assertEquals( $input, $og->product_namespace( $input ) );
+		$this->assertSame( $input, $og->product_namespace( $input ) );
 
 		Functions\stubs(
 			[
 				'is_singular' => true,
 			]
 		);
-		$this->assertEquals( 'prefix="fn: https://yoast.com/bla product: http://ogp.me/ns/product#"', $og->product_namespace( $input ) );
+		$this->assertSame( 'prefix="fn: https://yoast.com/bla product: http://ogp.me/ns/product#"', $og->product_namespace( $input ) );
 	}
 
 	/**
@@ -156,7 +156,7 @@ class OpenGraph_Test extends TestCase {
 		$og->price( $product );
 
 		$expected = '<meta property="product:price:amount" content="' . \number_format( ( $base_price * $tax_rate ), 2 ) . '" />' . "\n" . '<meta property="product:price:currency" content="USD" />' . "\n";
-		$this->assertEquals( $expected, \ob_get_clean() );
+		$this->assertSame( $expected, \ob_get_clean() );
 	}
 
 	/**
@@ -194,7 +194,7 @@ class OpenGraph_Test extends TestCase {
 		\ob_start();
 		$og->brand( $product );
 
-		$this->assertEquals( '<meta property="product:brand" content="Apple"/>' . "\n", \ob_get_clean() );
+		$this->assertSame( '<meta property="product:brand" content="Apple"/>' . "\n", \ob_get_clean() );
 	}
 
 	/**
@@ -216,7 +216,7 @@ class OpenGraph_Test extends TestCase {
 		\ob_start();
 		$og->product_condition( $product );
 
-		$this->assertEquals( '<meta property="product:condition" content="used" />' . "\n", \ob_get_clean() );
+		$this->assertSame( '<meta property="product:condition" content="used" />' . "\n", \ob_get_clean() );
 	}
 
 	/**
@@ -238,7 +238,7 @@ class OpenGraph_Test extends TestCase {
 		\ob_start();
 		$og->retailer_item_id( $product );
 
-		$this->assertEquals( '<meta property="product:retailer_item_id" content="sku123" />' . "\n", \ob_get_clean() );
+		$this->assertSame( '<meta property="product:retailer_item_id" content="sku123" />' . "\n", \ob_get_clean() );
 	}
 
 	/**
@@ -254,7 +254,7 @@ class OpenGraph_Test extends TestCase {
 		\ob_start();
 		$og->in_stock( $product );
 
-		$this->assertEquals( '<meta property="product:availability" content="in stock" />' . "\n", \ob_get_clean() );
+		$this->assertSame( '<meta property="product:availability" content="in stock" />' . "\n", \ob_get_clean() );
 	}
 
 	/**
@@ -417,7 +417,7 @@ class OpenGraph_Test extends TestCase {
 		$primary_term_mock->expects( 'get_primary_term' )->once()->with()->andReturn( '' );
 
 		$og = new OpenGraph_Double();
-		$this->assertEquals( 'Apple', $og->get_brand_term_name( 'brand', $product ) );
+		$this->assertSame( 'Apple', $og->get_brand_term_name( 'brand', $product ) );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -76,7 +76,7 @@ class Schema_Test extends TestCase {
 
 		$schema->data = $data;
 		$schema->output_schema_footer();
-		$this->assertEquals( $data, $utils->output );
+		$this->assertSame( $data, $utils->output );
 	}
 
 	/**
@@ -97,7 +97,7 @@ class Schema_Test extends TestCase {
 			'@type' => 'WebPage',
 		];
 		$schema = new WPSEO_WooCommerce_Schema();
-		$this->assertEquals( $input, $schema->filter_webpage( $input ) );
+		$this->assertSame( $input, $schema->filter_webpage( $input ) );
 
 		Functions\stubs(
 			[
@@ -111,7 +111,7 @@ class Schema_Test extends TestCase {
 			'@type' => 'CheckoutPage',
 		];
 		$schema   = new WPSEO_WooCommerce_Schema();
-		$this->assertEquals( $expected, $schema->filter_webpage( $input ) );
+		$this->assertSame( $expected, $schema->filter_webpage( $input ) );
 
 		Functions\stubs(
 			[
@@ -125,7 +125,7 @@ class Schema_Test extends TestCase {
 			'@type' => 'ItemPage',
 		];
 		$schema   = new WPSEO_WooCommerce_Schema();
-		$this->assertEquals( $expected, $schema->filter_webpage( $input ) );
+		$this->assertSame( $expected, $schema->filter_webpage( $input ) );
 	}
 
 	/**
@@ -152,8 +152,8 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$this->assertEquals( $expected_output, $output );
-		$this->assertEquals( $expected_data, $schema->data );
+		$this->assertSame( $expected_output, $output );
+		$this->assertSame( $expected_data, $schema->data );
 	}
 
 	/**
@@ -219,7 +219,7 @@ class Schema_Test extends TestCase {
 
 		$output = $schema->filter_offers( $input, $product );
 
-		$this->assertEquals( $expected_output, $output );
+		$this->assertSame( $expected_output, $output );
 	}
 
 	/**
@@ -481,7 +481,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_name' )->once()->andReturn( 'Customizable responsive toolset' );
 		$output = $schema->filter_offers( $input, $product );
 
-		$this->assertEquals( $expected_output, $output['offers'][0] );
+		$this->assertSame( $expected_output, $output['offers'][0] );
 	}
 
 	/**
@@ -494,7 +494,7 @@ class Schema_Test extends TestCase {
 		$expected = [ 'webpage' ];
 
 		$class = new WPSEO_WooCommerce_Schema();
-		$this->assertEquals( $expected, $class->remove_woo_breadcrumbs( $input ) );
+		$this->assertSame( $expected, $class->remove_woo_breadcrumbs( $input ) );
 	}
 
 	/**
@@ -552,7 +552,7 @@ class Schema_Test extends TestCase {
 		$schema   = new Schema_Double();
 		$output   = $schema->change_seller_in_offers( $input );
 
-		$this->assertEquals( $expected, $output );
+		$this->assertSame( $expected, $output );
 	}
 
 	/**
@@ -614,7 +614,7 @@ class Schema_Test extends TestCase {
 		$schema                          = new Schema_Double();
 		$output                          = $schema->change_seller_in_offers( $input );
 
-		$this->assertEquals( $expected, $output );
+		$this->assertSame( $expected, $output );
 	}
 
 	/**
@@ -631,7 +631,7 @@ class Schema_Test extends TestCase {
 
 		$output = $schema->filter_reviews( $input, $product );
 
-		$this->assertEquals( $input, $output );
+		$this->assertSame( $input, $output );
 	}
 
 	/**
@@ -676,7 +676,7 @@ class Schema_Test extends TestCase {
 		$schema = new Schema_Double();
 		$schema->add_global_identifier( $product );
 
-		$this->assertEquals( $data, $schema->data );
+		$this->assertSame( $data, $schema->data );
 	}
 
 	/**
@@ -705,7 +705,7 @@ class Schema_Test extends TestCase {
 			'@type' => [ 'Book', 'Product' ],
 			'isbn'  => '978-3-16-148410-0',
 		];
-		$this->assertEquals( $expected, $schema->data );
+		$this->assertSame( $expected, $schema->data );
 	}
 
 	/**
@@ -793,7 +793,7 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$this->assertEquals( $expected, $output );
+		$this->assertSame( $expected, $output );
 	}
 
 	/**
@@ -974,7 +974,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertEquals( $expected, $instance->data );
+		$this->assertSame( $expected, $instance->data );
 	}
 
 	/**
@@ -1146,7 +1146,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertEquals( $expected, $instance->data );
+		$this->assertSame( $expected, $instance->data );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -433,7 +433,7 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - l',
 					'price'              => 10,
 					'priceSpecification' => [
-						'price'                 => '10',
+						'price'                 => 10,
 						'priceCurrency'         => 'GBP',
 						'valueAddedTaxIncluded' => false,
 					],
@@ -444,7 +444,7 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - m',
 					'price'              => 8,
 					'priceSpecification' => [
-						'price'                 => '8',
+						'price'                 => 8,
 						'priceCurrency'         => 'GBP',
 						'valueAddedTaxIncluded' => false,
 					],
@@ -455,7 +455,7 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - xl',
 					'price'              => 12,
 					'priceSpecification' => [
-						'price'                 => '12',
+						'price'                 => 12,
 						'priceCurrency'         => 'GBP',
 						'valueAddedTaxIncluded' => false,
 					],
@@ -702,8 +702,8 @@ class Schema_Test extends TestCase {
 		$schema->add_global_identifier( $product );
 
 		$expected = [
-			'@type' => [ 'Book', 'Product' ],
 			'isbn'  => '978-3-16-148410-0',
+			'@type' => [ 'Book', 'Product' ],
 		];
 		$this->assertSame( $expected, $schema->data );
 	}
@@ -764,7 +764,7 @@ class Schema_Test extends TestCase {
 					'@type'         => 'Review',
 					'reviewRating'  => [
 						'@type'       => 'Rating',
-						'ratingValue' => 2,
+						'ratingValue' => '2',
 					],
 					'author'        => [
 						'@type' => 'Person',
@@ -779,7 +779,7 @@ class Schema_Test extends TestCase {
 					'@type'         => 'Review',
 					'reviewRating'  => [
 						'@type'       => 'Rating',
-						'ratingValue' => 5,
+						'ratingValue' => '5',
 					],
 					'author'        => [
 						'@type' => 'Person',
@@ -926,23 +926,22 @@ class Schema_Test extends TestCase {
 			'@id'              => $canonical . '#product',
 			'name'             => $product_name,
 			'url'              => $canonical,
-			'image'            => [ '@id' => $canonical . '#primaryimage' ],
 			'description'      => '',
 			'sku'              => 'sku1234',
 			'offers'           => [
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
-					'priceSpecification' => [
-						'price'                 => '1.00',
-						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
-					],
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $canonical . '#organization',
 					],
 					'@id'                => $base_url . '/#/schema/offer/1-0',
+					'priceSpecification' => [
+						'price'                 => '1.00',
+						'priceCurrency'         => 'GBP',
+						'valueAddedTaxIncluded' => false,
+					],
 				],
 			],
 			'review'           => [
@@ -963,6 +962,7 @@ class Schema_Test extends TestCase {
 				],
 			],
 			'mainEntityOfPage' => [ '@id' => $canonical . '#webpage' ],
+			'image'            => [ '@id' => $canonical . '#primaryimage' ],
 			'brand'            => [
 				'@type' => 'Organization',
 				'name'  => $product_name,
@@ -1092,13 +1092,6 @@ class Schema_Test extends TestCase {
 			'@id'              => $canonical . '#product',
 			'name'             => $product_name,
 			'url'              => $canonical,
-			'image'            => [
-				'@id'    => $canonical . '#woocommerceimageplaceholder',
-				'@type'  => 'ImageObject',
-				'url'    => $base_url . '/example_image.jpg',
-				'width'  => 50,
-				'height' => 50,
-			],
 			'description'      => '',
 			'sku'              => 'sku1234',
 			'offers'           => [
@@ -1135,6 +1128,13 @@ class Schema_Test extends TestCase {
 				],
 			],
 			'mainEntityOfPage' => [ '@id' => $canonical . '#webpage' ],
+			'image'            => [
+				'@type'  => 'ImageObject',
+				'@id'    => $canonical . '#woocommerceimageplaceholder',
+				'url'    => $base_url . '/example_image.jpg',
+				'width'  => 50,
+				'height' => 50,
+			],
 			'brand'            => [
 				'@type' => 'Organization',
 				'name'  => $product_name,

--- a/tests/classes/utils-test.php
+++ b/tests/classes/utils-test.php
@@ -34,7 +34,7 @@ class Utils_Test extends TestCase {
 			]
 		);
 
-		$this->assertEquals( 'Apple', WPSEO_WooCommerce_Utils::search_primary_term( [ 'brand' ], $product ) );
+		$this->assertSame( 'Apple', WPSEO_WooCommerce_Utils::search_primary_term( [ 'brand' ], $product ) );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Utils_Test extends TestCase {
 		$primary_term_mock->expects( '__construct' )->once()->with( 'brand', $product_id )->andReturnSelf();
 		$primary_term_mock->expects( 'get_primary_term' )->once()->with()->andReturn( false );
 
-		$this->assertEquals( '', WPSEO_WooCommerce_Utils::search_primary_term( [ 'brand' ], $product ) );
+		$this->assertSame( '', WPSEO_WooCommerce_Utils::search_primary_term( [ 'brand' ], $product ) );
 	}
 
 	/**
@@ -91,7 +91,7 @@ class Utils_Test extends TestCase {
 			]
 		);
 
-		$this->assertEquals( ( $price * $tax_rate ), WPSEO_WooCommerce_Utils::get_product_display_price( $product ) );
+		$this->assertSame( ( $price * $tax_rate ), WPSEO_WooCommerce_Utils::get_product_display_price( $product ) );
 	}
 
 	/**

--- a/tests/classes/utils-test.php
+++ b/tests/classes/utils-test.php
@@ -91,7 +91,9 @@ class Utils_Test extends TestCase {
 			]
 		);
 
-		$this->assertSame( ( $price * $tax_rate ), WPSEO_WooCommerce_Utils::get_product_display_price( $product ) );
+		$expected = \number_format( ( $price * $tax_rate ), 2 );
+
+		$this->assertSame( $expected, WPSEO_WooCommerce_Utils::get_product_display_price( $product ) );
 	}
 
 	/**

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -38,7 +38,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 				'target' => 'yoast_seo',
 			],
 		];
-		$this->assertEquals( $expected, $instance->yoast_seo_tab( [] ) );
+		$this->assertSame( $expected, $instance->yoast_seo_tab( [] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* [Unit tests only] QA: use the most specific test assertion

## Relevant technical choices:

### QA: use the most specific PHPUnit assertion possible

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available has been extended hugely over the years.

To have the most reliable tests, the most specific assertion should be used.

This implements this for the Clicky plugin, while keeping in mind that at this time, PHPUnit 4.x should still be supported.

Refs:
* https://phpunit.de/manual/4.8/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame

### Tests: account for test bugs now exposed

Using `assertSame()` exposed a number of bugs in the tests.

The bugs can be classified as:
1. Array order - this is a barely relevant difference in the test cases affected, but does impact any code iterating over an array using `foreach()` instead of directly accessing the array indexes.
2. Type differences in the output - `string` vs `int` etc.

**I've fixed this based on the premise that these are bugs in the _tests_, not bugs in the code.**

**If these are bugs in the _code_, this commit should be partially reverted and the code fixes should be added instead.** /cc @jdevalk 


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality. If the unit tests still pass, we're good.