### PR TITLE
Use surface for getting value

### DIFF
--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -5,6 +5,8 @@
  * @package WPSEO/WooCommerce
  */
 
+use Yoast\WP\SEO\Values\Open_Graph\Images;
+
 /**
  * Class WPSEO_WooCommerce_OpenGraph
  */
@@ -257,12 +259,12 @@ class WPSEO_WooCommerce_OpenGraph {
 	/**
 	 * Set the OpenGraph images for a product based on its gallery image IDs.
 	 *
-	 * @param WPSEO_OpenGraph_Image $opengraph_image The OpenGraph image class.
-	 * @param WC_Product            $product         The WooCommerce product.
+	 * @param Images     $opengraph_image The OpenGraph image class.
+	 * @param WC_Product $product         The WooCommerce product.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
-	protected function set_opengraph_image_product( WPSEO_OpenGraph_Image $opengraph_image, WC_Product $product ) {
+	protected function set_opengraph_image_product( Images $opengraph_image, WC_Product $product ) {
 		$img_ids = $product->get_gallery_image_ids();
 
 		if ( is_array( $img_ids ) && $img_ids !== [] ) {

--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -257,7 +257,7 @@ class WPSEO_WooCommerce_OpenGraph {
 	/**
 	 * Set the OpenGraph images for a product based on its gallery image IDs.
 	 *
-	 * @param mixed     $opengraph_image The OpenGraph image class.
+	 * @param mixed      $opengraph_image The OpenGraph image class.
 	 * @param WC_Product $product         The WooCommerce product.
 	 *
 	 * @return bool True on success, false on failure.

--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use Yoast\WP\SEO\Values\Open_Graph\Images;
-
 /**
  * Class WPSEO_WooCommerce_OpenGraph
  */
@@ -259,12 +257,12 @@ class WPSEO_WooCommerce_OpenGraph {
 	/**
 	 * Set the OpenGraph images for a product based on its gallery image IDs.
 	 *
-	 * @param Images     $opengraph_image The OpenGraph image class.
+	 * @param mixed     $opengraph_image The OpenGraph image class.
 	 * @param WC_Product $product         The WooCommerce product.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
-	protected function set_opengraph_image_product( Images $opengraph_image, WC_Product $product ) {
+	protected function set_opengraph_image_product( $opengraph_image, WC_Product $product ) {
 		$img_ids = $product->get_gallery_image_ids();
 
 		if ( is_array( $img_ids ) && $img_ids !== [] ) {

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -343,7 +343,7 @@ class WPSEO_WooCommerce_Schema {
 	 * @return string The canonical URL.
 	 */
 	protected function get_canonical() {
-		return YoastSEO()->current_page()->get_canonical();
+		return YoastSEO()->current_page->get_canonical();
 	}
 
 	/**

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -343,7 +343,7 @@ class WPSEO_WooCommerce_Schema {
 	 * @return string The canonical URL.
 	 */
 	protected function get_canonical() {
-		return yoastseo()->get_current_page_presentation()->canonical;
+		return YoastSEO()->current_page()->get_canonical();
 	}
 
 	/**


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Change the way we get the canonical by using the surface.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Please test this against the features/indexables-frontend branch in Yoast SEO free
* Have WooCommerce active and add a product
* View the product and verify the canonical is in the WooCommerce schema output.
   * In other words: there should be a Schema node with the type `ItemPage`, with an `@id` that is the same as the `<link rel="canonical>` on the page. 

Related to https://github.com/Yoast/wpseo-woocommerce/pull/439

