### PR TITLE
Output priceValidUntil for products on sale with a set sale end date

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -146,11 +146,6 @@ class WPSEO_WooCommerce_Schema {
 		$data['offers'] = $this->filter_sales( $data['offers'], $product );
 
 		foreach ( $data['offers'] as $key => $offer ) {
-			/*
-			 * WooCommerce assumes all prices will be valid until the end of next year,
-			 * unless on sale and there is an end date. We keep the `priceValidUntil`
-			 * property only for products with a sale price and a sale end date.
-			 */
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {
@@ -187,6 +182,12 @@ class WPSEO_WooCommerce_Schema {
 	 */
 	protected function filter_sales( $offers, $product ) {
 		foreach ( $offers as $key => $offer ) {
+			/*
+			 * WooCommerce assumes all prices will be valid until the end of next year,
+			 * unless on sale and there is an end date. We keep the `priceValidUntil`
+			 * property only for products with a sale price and a sale end date.
+			 */
+
 			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
 				unset( $offers[ $key ]['priceValidUntil'] );
 			}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -105,8 +105,8 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Filter Schema Product data to work.
 	 *
-	 * @param array       $data    Schema Product data.
-	 * @param \WC_Product $product Product object.
+	 * @param array      $data    Schema Product data.
+	 * @param WC_Product $product Product object.
 	 *
 	 * @return array Schema Product data.
 	 */
@@ -136,22 +136,21 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Filters the offers array to enrich it.
 	 *
-	 * @param array       $data    Schema Product data.
-	 * @param \WC_Product $product The product.
+	 * @param array      $data    Schema Product data.
+	 * @param WC_Product $product The product.
 	 *
 	 * @return array Schema Product data.
 	 */
 	protected function filter_offers( $data, $product ) {
-		$home_url = trailingslashit( get_site_url() );
+		$home_url       = trailingslashit( get_site_url() );
+		$data['offers'] = $this->filter_sales( $data['offers'], $product );
+
 		foreach ( $data['offers'] as $key => $offer ) {
 			/*
 			 * WooCommerce assumes all prices will be valid until the end of next year,
 			 * unless on sale and there is an end date. We keep the `priceValidUntil`
 			 * property only for products with a sale price and a sale end date.
 			 */
-			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
-				unset( $data['offers'][ $key ]['priceValidUntil'] );
-			}
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {
@@ -169,6 +168,23 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Filters the offers array on sales, possibly unset them.
+	 *
+	 * @param array      $offers Schema Offer data.
+	 * @param WC_Product $product The product.
+	 *
+	 * @return array $offers    Schema Offer data.
+	 */
+	protected function filter_sales( $offers, $product ) {
+		foreach ( $offers as $key => $offer ) {
+			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
+				unset( $offers[ $key ]['priceValidUntil'] );
+			}
+		}
+		return $offers;
 	}
 
 	/**
@@ -191,7 +207,7 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Retrieve the global identifier type and value if we have one.
 	 *
-	 * @param \WC_Product $product Product object.
+	 * @param WC_Product $product Product object.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
@@ -242,7 +258,7 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Add brand to our output.
 	 *
-	 * @param \WC_Product $product Product object.
+	 * @param WC_Product $product Product object.
 	 */
 	private function add_brand( $product ) {
 		$schema_brand = WPSEO_Options::get( 'woo_schema_brand' );
@@ -254,7 +270,7 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Add manufacturer to our output.
 	 *
-	 * @param \WC_Product $product Product object.
+	 * @param WC_Product $product Product object.
 	 */
 	private function add_manufacturer( $product ) {
 		$schema_manufacturer = WPSEO_Options::get( 'woo_schema_manufacturer' );
@@ -266,9 +282,9 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Adds an attribute to our Product data array with the value from a taxonomy, as an Organization,
 	 *
-	 * @param string      $attribute The attribute we're adding to Product.
-	 * @param \WC_Product $product   The WooCommerce product we're working with.
-	 * @param string      $taxonomy  The taxonomy to get the attribute's value from.
+	 * @param string     $attribute The attribute we're adding to Product.
+	 * @param WC_Product $product   The WooCommerce product we're working with.
+	 * @param string     $taxonomy  The taxonomy to get the attribute's value from.
 	 */
 	private function add_organization_for_attribute( $attribute, $product, $taxonomy ) {
 		$term = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
@@ -355,7 +371,7 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Adds the individual product variants as variants of the offer.
 	 *
-	 * @param \WC_Product $product The WooCommerce product we're working with.
+	 * @param WC_Product $product The WooCommerce product we're working with.
 	 *
 	 * @return array Schema Offers data.
 	 */
@@ -392,8 +408,8 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Enhances the review data output by WooCommerce.
 	 *
-	 * @param array       $data    Review Schema data.
-	 * @param \WC_Product $product The WooCommerce product we're working with.
+	 * @param array      $data    Review Schema data.
+	 * @param WC_Product $product The WooCommerce product we're working with.
 	 *
 	 * @return array Review Schema data.
 	 */

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -142,10 +142,10 @@ class WPSEO_WooCommerce_Schema {
 	 * @return array Schema Product data.
 	 */
 	protected function filter_offers( $data, $product ) {
-		$home_url           = trailingslashit( get_site_url() );
-		$sale_filtered_data = $this->filter_sales( $data, $product );
+		$home_url       = trailingslashit( get_site_url() );
+		$data['offers'] = $this->filter_sales( $data['offers'], $product );
 
-		foreach ( $sale_filtered_data['offers'] as $key => $offer ) {
+		foreach ( $data['offers'] as $key => $offer ) {
 			/*
 			 * WooCommerce assumes all prices will be valid until the end of next year,
 			 * unless on sale and there is an end date. We keep the `priceValidUntil`
@@ -154,37 +154,37 @@ class WPSEO_WooCommerce_Schema {
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {
-				$price                                       = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
-				$sale_filtered_data['offers'][ $key ]['@id'] = $home_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
-				$sale_filtered_data['offers'][ $key ]['price']                                       = $price;
-				$sale_filtered_data['offers'][ $key ]['priceSpecification']['price']                 = $price;
-				$sale_filtered_data['offers'][ $key ]['priceSpecification']['priceCurrency']         = get_woocommerce_currency();
-				$sale_filtered_data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_with_tax();
+				$price                           = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
+				$data['offers'][ $key ]['@id']   = $home_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
+				$data['offers'][ $key ]['price'] = $price;
+				$data['offers'][ $key ]['priceSpecification']['price']                 = $price;
+				$data['offers'][ $key ]['priceSpecification']['priceCurrency']         = get_woocommerce_currency();
+				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_with_tax();
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
-				$sale_filtered_data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
-				$sale_filtered_data['offers'][ $key ]['offers'] = $this->add_individual_offers( $product );
+				$data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
+				$data['offers'][ $key ]['offers'] = $this->add_individual_offers( $product );
 			}
 		}
 
-		return $sale_filtered_data;
+		return $data;
 	}
 
 	/**
 	 * Filters the offers array on sales, possibly unset them.
-
-	 * @param array      $data    Schema Product data.
+	 *
+	 * @param array      $offers Schema Offer data.
 	 * @param WC_Product $product The product.
 	 *
-	 * @return array      $data    Schema Product data.
+	 * @return array $offers    Schema Offer data.
 	 */
-	protected function filter_sales( $data, $product ) {
-		foreach ( $data['offers'] as $key => $offer ) {
+	protected function filter_sales( $offers, $product ) {
+		foreach ( $offers as $key => $offer ) {
 			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
-				unset( $data['offers'][ $key ]['priceValidUntil'] );
+				unset( $offers[ $key ]['priceValidUntil'] );
 			}
 		}
-		return $data;
+		return $offers;
 	}
 
 	/**

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -144,8 +144,14 @@ class WPSEO_WooCommerce_Schema {
 	protected function filter_offers( $data, $product ) {
 		$home_url = trailingslashit( get_site_url() );
 		foreach ( $data['offers'] as $key => $offer ) {
-			// Remove this value as it makes no sense.
-			unset( $data['offers'][ $key ]['priceValidUntil'] );
+			/*
+			 * WooCommerce assumes all prices will be valid until the end of next year,
+			 * unless on sale and there is an end date. We keep the `priceValidUntil`
+			 * property only for products with a sale price and a sale end date.
+			 */
+			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
+				unset( $data['offers'][ $key ]['priceValidUntil'] );
+			}
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -142,10 +142,10 @@ class WPSEO_WooCommerce_Schema {
 	 * @return array Schema Product data.
 	 */
 	protected function filter_offers( $data, $product ) {
-		$home_url       = trailingslashit( get_site_url() );
-		$data['offers'] = $this->filter_sales( $data['offers'], $product );
+		$home_url           = trailingslashit( get_site_url() );
+		$sale_filtered_data = $this->filter_sales( $data, $product );
 
-		foreach ( $data['offers'] as $key => $offer ) {
+		foreach ( $sale_filtered_data['offers'] as $key => $offer ) {
 			/*
 			 * WooCommerce assumes all prices will be valid until the end of next year,
 			 * unless on sale and there is an end date. We keep the `priceValidUntil`
@@ -154,37 +154,37 @@ class WPSEO_WooCommerce_Schema {
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {
-				$price                           = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
-				$data['offers'][ $key ]['@id']   = $home_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
-				$data['offers'][ $key ]['price'] = $price;
-				$data['offers'][ $key ]['priceSpecification']['price']                 = $price;
-				$data['offers'][ $key ]['priceSpecification']['priceCurrency']         = get_woocommerce_currency();
-				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_with_tax();
+				$price                                       = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
+				$sale_filtered_data['offers'][ $key ]['@id'] = $home_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
+				$sale_filtered_data['offers'][ $key ]['price']                                       = $price;
+				$sale_filtered_data['offers'][ $key ]['priceSpecification']['price']                 = $price;
+				$sale_filtered_data['offers'][ $key ]['priceSpecification']['priceCurrency']         = get_woocommerce_currency();
+				$sale_filtered_data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_with_tax();
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
-				$data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
-				$data['offers'][ $key ]['offers'] = $this->add_individual_offers( $product );
+				$sale_filtered_data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
+				$sale_filtered_data['offers'][ $key ]['offers'] = $this->add_individual_offers( $product );
 			}
 		}
 
-		return $data;
+		return $sale_filtered_data;
 	}
 
 	/**
 	 * Filters the offers array on sales, possibly unset them.
-	 *
-	 * @param array      $offers Schema Offer data.
+
+	 * @param array      $data    Schema Product data.
 	 * @param WC_Product $product The product.
 	 *
-	 * @return array $offers    Schema Offer data.
+	 * @return array      $data    Schema Product data.
 	 */
-	protected function filter_sales( $offers, $product ) {
-		foreach ( $offers as $key => $offer ) {
+	protected function filter_sales( $data, $product ) {
+		foreach ( $data['offers'] as $key => $offer ) {
 			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
-				unset( $offers[ $key ]['priceValidUntil'] );
+				unset( $data['offers'][ $key ]['priceValidUntil'] );
 			}
 		}
-		return $offers;
+		return $data;
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -975,7 +975,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertSame( $expected, $instance->data );
+		$this->assertEquals( $expected, $instance->data );
 	}
 
 	/**
@@ -1251,7 +1251,6 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'price'                 => '49.00',
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 					'priceCurrency'      => 'GBP',
 					'availability'       => 'http://schema.org/InStock',

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -173,11 +173,9 @@ class Schema_Test extends TestCase {
 			],
 			'sku'         => '209643',
 			'offers'      => [
-
 				[
 					'@type'              => 'Offer',
 					'price'              => '49.00',
-					'priceValidUntil'    => '2021-12-31',
 					'priceSpecification' => [
 						'price'                 => '49.00',
 						'priceCurrency'         => 'GBP',
@@ -197,7 +195,6 @@ class Schema_Test extends TestCase {
 
 		$expected_output                     = $input;
 		$expected_output['offers'][0]['@id'] = 'http://example.com/#/schema/offer/209643-0';
-		unset( $expected_output['offers'][0]['priceValidUntil'] );
 
 		$base_url = 'http://example.com';
 		Functions\stubs(
@@ -216,6 +213,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
 		$product->expects( 'get_price' )->once()->andReturn( 49 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
+		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 
 		$output = $schema->filter_offers( $input, $product );
 
@@ -479,6 +477,8 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_id' )->twice()->andReturn( '209643' );
 		$product->expects( 'get_available_variations' )->once()->andReturn( $variants );
 		$product->expects( 'get_name' )->once()->andReturn( 'Customizable responsive toolset' );
+		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+
 		$output = $schema->filter_offers( $input, $product );
 
 		$this->assertSame( $expected_output, $output['offers'][0] );
@@ -837,6 +837,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
+		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 
 		Mockery::getConfiguration()->setConstantsMap(
 			[
@@ -1001,6 +1002,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_price' )->once()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
+		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 
 		Mockery::getConfiguration()->setConstantsMap(
 			[
@@ -1223,5 +1225,71 @@ class Schema_Test extends TestCase {
 		$actual   = $instance->get_primary_term_or_first_term( $taxonomy_name, $id );
 
 		$this->assertNull( $actual );
+	}
+
+	/**
+	 * Tests filtering offers with a product on sale and sale price dates should output a `priceValidUntil` property.
+	 *
+	 * @covers WPSEO_WooCommerce_Schema::filter_offers
+	 */
+	public function test_filter_offers_with_product_on_sale_should_output_price_valid_until() {
+		$schema = new Schema_Double();
+		$input  = [
+			'@type'       => 'Product',
+			'name'        => 'Customizable responsive toolset',
+			'url'         => 'https://example.com/product/customizable-responsive-toolset/',
+			'description' => 'Sit debitis reprehenderit non rem natus. Corporis quidem quos et sit similique. Et ad hic exercitationem repudiandae rem laborum.\n\n\n\n\n\n\n\n\nCumque iusto cum enim ut. Et ipsum tempore dolorem ullam aspernatur autem et. Aut molestiae dolor natus. Ducimus molestias perspiciatis magni in libero deleniti ut. Rerum perspiciatis autem et maiores hic ducimus.\n\n\nAut tenetur ducimus distinctio quaerat deserunt sed. Sint ullam ut deserunt deleniti velit et. Incidunt in molestiae voluptas corrupti qui facilis quia.\n\n\n\n\n\nIste asperiores voluptas expedita id cupiditate. Sed error corrupti quibusdam dolor facere enim tenetur. Asperiores error qui commodi dolorem veritatis aspernatur.',
+			'image'       => [
+				'@id' => 'https://example.com/product/customizable-responsive-toolset/#primaryimage',
+			],
+			'sku'         => '209643',
+			'offers'      => [
+				[
+					'@type'              => 'Offer',
+					'price'              => '49.00',
+					'priceValidUntil'    => '2020-03-24',
+					'priceSpecification' => [
+						'price'                 => '49.00',
+						'priceCurrency'         => 'GBP',
+						'valueAddedTaxIncluded' => false,
+					],
+					'priceCurrency'      => 'GBP',
+					'availability'       => 'http://schema.org/InStock',
+					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
+					'seller'             => [
+						'@type' => 'Organization',
+						'name'  => 'WooCommerce',
+						'url'   => 'https://example.com',
+					],
+				],
+			],
+		];
+
+		$expected_output                     = $input;
+		$expected_output['offers'][0]['@id'] = 'http://example.com/#/schema/offer/209643-0';
+
+		$base_url = 'http://example.com';
+		Functions\stubs(
+			[
+				'get_site_url'             => $base_url,
+				'wc_get_price_decimals'    => 2,
+				'wc_tax_enabled'           => false,
+				'wc_format_decimal'        => static function ( $number ) {
+					return \number_format( $number, 2 );
+				},
+				'get_woocommerce_currency' => 'GBP',
+			]
+		);
+
+		$product = Mockery::mock( 'WC_Product' );
+		$product->expects( 'get_id' )->once()->andReturn( '209643' );
+		$product->expects( 'get_price' )->once()->andReturn( 49 );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
+		$product->expects( 'is_on_sale' )->once()->andReturn( true );
+		$product->expects( 'get_date_on_sale_to' )->once()->andReturn( 'not-a-null-value' );
+
+		$output = $schema->filter_offers( $input, $product );
+
+		$this->assertSame( $expected_output, $output );
 	}
 }


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `priceValidUntil` schema property wasn't output for products on sale with an explicitly set sale end date.

## Relevant technical choices:

* Uses Woo methods `is_on_sale()` and `get_date_on_sale_to()`
* Unsets the `priceValidUntil` property except for products on sale with an explicitly set sale end date
* Adds a test

## Test instructions

This PR can be tested by following these steps:

- create a Woo product
- set a regular price and save
- inspect the Schema output on the front end
- see there's no `priceValidUntil` property in the product Schema
- set a sale price but do not set the sale dates yet
- see there's still no `priceValidUntil` property in the Schema
- set the sales dates
- see this time there's a `priceValidUntil` property output in the Schema

Fixes https://github.com/Yoast/wpseo-woocommerce/issues/526