### PR TITLE
valueAddedTaxIncluded is not set to false when prices are added including tax

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -154,7 +154,7 @@ class WPSEO_WooCommerce_Schema {
 				$data['offers'][ $key ]['price'] = $price;
 				$data['offers'][ $key ]['priceSpecification']['price']                 = $price;
 				$data['offers'][ $key ]['priceSpecification']['priceCurrency']         = get_woocommerce_currency();
-				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_with_tax();
+				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
 				$data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -358,7 +358,7 @@ class WPSEO_WooCommerce_Schema {
 
 		$site_url           = trailingslashit( get_site_url() );
 		$currency           = get_woocommerce_currency();
-		$prices_include_tax = WPSEO_WooCommerce_Utils::prices_with_tax();
+		$prices_include_tax = WPSEO_WooCommerce_Utils::prices_have_tax_included();
 		$decimals           = wc_get_price_decimals();
 		$data               = [];
 		$product_id         = $product->get_id();

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -66,7 +66,7 @@ class WPSEO_WooCommerce_Utils {
 	public static function prices_with_tax() {
 		return (
 			wc_tax_enabled() &&
-			! wc_prices_include_tax() &&
+			wc_prices_include_tax() &&
 			get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
 			WPSEO_Options::get( 'woo_schema_og_prices_with_tax' )
 		);

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -79,8 +79,7 @@ class WPSEO_WooCommerce_Utils {
 	 */
 	public static function prices_have_tax_included() {
 		return (
-			wc_tax_enabled() &&
-			wc_prices_include_tax() &&
+			( wc_tax_enabled() || wc_prices_include_tax() ) &&
 			get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
 			WPSEO_Options::get( 'woo_schema_og_prices_with_tax' )
 		);

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -66,6 +66,20 @@ class WPSEO_WooCommerce_Utils {
 	public static function prices_with_tax() {
 		return (
 			wc_tax_enabled() &&
+			! wc_prices_include_tax() &&
+			get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
+			WPSEO_Options::get( 'woo_schema_og_prices_with_tax' )
+		);
+	}
+
+	/**
+	 * Determines if prices have tax included or not.
+	 *
+	 * @return bool True if prices have tax included, false if not.
+	 */
+	public static function prices_have_tax_included() {
+		return (
+			wc_tax_enabled() &&
 			wc_prices_include_tax() &&
 			get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
 			WPSEO_Options::get( 'woo_schema_og_prices_with_tax' )

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -209,6 +209,7 @@ class Schema_Test extends TestCase {
 					return number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
+				'wc_prices_include_tax'    => false,
 			]
 		);
 
@@ -869,6 +870,7 @@ class Schema_Test extends TestCase {
 					return number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
+				'wc_prices_include_tax'    => false,
 			]
 		);
 
@@ -1033,6 +1035,7 @@ class Schema_Test extends TestCase {
 					return number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
+				'wc_prices_include_tax'    => false,
 			]
 		);
 


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `valueAddedTaxIncluded` property of the `Product` schema was set to `false` when the 'Yes, I will enter prices inclusive of tax' option was selected in WooCommerce. 

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

### Make sure that the shop is set to display prices including tax.
* Go to the WooCommerce tax settings.
   * make sure that 'Display prices in the shop' is set to 'Including tax'.
* Go tot the WooCommerce SEO settings,
   * make sure that 'Prices in OpenGraph and Schema include tax' is checked.

### Check that `valueAddedTaxIncluded` is set to `true` when tax is automatically calculated by WooCommerce.
 * Go to the WooCommerce general settings,
   * make sure that 'Enable tax rates and calculations' is checked.
* Create a new WooCommerce product if you do not have one yet.
  * Enter a price.
* Visit the WooCommerce product page of the product.
  * Check the Schema code that is output in the source code.
    * **Note**: This is _not_ in the common Yoast SEO Schema block, but is located in a separate `script` block in the footer of the webpage.
  * The Schema code should include a `valueAddedTaxIncluded` property which is set to `true`. 

### Check that `valueAddedTaxIncluded` is set to `true` when tax is manually added by the user.
 * Go to the WooCommerce tax settings,
   * make sure that 'Yes, I will enter prices inclusive of tax' is selected.
* Create a new WooCommerce product if you do not have one yet.
  * Enter a price.
* Visit the WooCommerce product page of the product.
  * Check the Schema code that is output in the source code.
    * **Note**: This is _not_ in the common Yoast SEO Schema block, but is located in a separate `script` block in the footer of the webpage.
  * The Schema code should include a `valueAddedTaxIncluded` property which is set to `true`. 

Fixes https://github.com/Yoast/bugreports/issues/900
