### PR TITLE
Add color property to the product schema output.

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -61,6 +61,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			// Form fields.
 			'woo_schema_brand'              => '',
 			'woo_schema_manufacturer'       => '',
+			'woo_schema_color'              => '',
 			'woo_breadcrumbs'               => true,
 			'woo_hide_columns'              => true,
 			'woo_metabox_top'               => true,
@@ -123,6 +124,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 
 					case 'woo_schema_brand':
 					case 'woo_schema_manufacturer':
+					case 'woo_schema_color':
 						if ( isset( $dirty[ $key ] ) ) {
 							if ( in_array( $dirty[ $key ], $valid_taxonomies, true ) ) {
 								$clean[ $key ] = $dirty[ $key ];

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -128,6 +128,7 @@ class WPSEO_WooCommerce_Schema {
 		$this->add_image( $canonical );
 		$this->add_brand( $product );
 		$this->add_manufacturer( $product );
+		$this->add_color( $product );
 		$this->add_global_identifier( $product );
 
 		return [];
@@ -304,6 +305,30 @@ class WPSEO_WooCommerce_Schema {
 			$image_schema        = new WPSEO_Schema_Image( $canonical . '#woocommerceimageplaceholder' );
 			$placeholder_img_src = wc_placeholder_img_src();
 			$this->data['image'] = $image_schema->generate_from_url( $placeholder_img_src );
+		}
+	}
+
+	/**
+	 * Adds the product color property to the Schema output.
+	 *
+	 * @param \WC_Product $product The product object.
+	 *
+	 * @return void
+	 */
+	private function add_color( $product ) {
+		$schema_color = WPSEO_Options::get( 'woo_schema_color' );
+
+		if ( ! empty( $schema_color ) ) {
+			$terms = get_the_terms( $product->get_id(), $schema_color );
+
+			if ( is_array( $terms ) ) {
+				$colors = [];
+				foreach ( $terms as $term ) {
+					$colors[] = strtolower( $term->name );
+				}
+
+				$this->data['color'] = $colors;
+			}
 		}
 	}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -402,6 +402,7 @@ class Yoast_WooCommerce_SEO {
 
 		Yoast_Form::get_instance()->select( 'woo_schema_manufacturer', esc_html__( 'Manufacturer', 'yoast-woo-seo' ), $taxonomies );
 		Yoast_Form::get_instance()->select( 'woo_schema_brand', esc_html__( 'Brand', 'yoast-woo-seo' ), $taxonomies );
+		Yoast_Form::get_instance()->select( 'woo_schema_color', esc_html__( 'Color', 'yoast-woo-seo' ), $taxonomies );
 
 		if ( wc_tax_enabled() && get_option( 'woocommerce_tax_display_shop' ) === 'incl' ) {
 			Yoast_Form::get_instance()->checkbox(

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -67,6 +67,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 			// Tests the validation of the fields where the dirty value exists in the validate data types.
 			[ 'woo_schema_brand', 'yoast', 'yoast', 'yoast', null ],
 			[ 'woo_schema_manufacturer', 'yoast', 'yoast', 'yoast', null ],
+			[ 'woo_schema_color', 'yoast', 'yoast', 'yoast', null ],
 			[ 'woo_breadcrumbs', true, true, true, '' ],
 			[ 'woo_hide_columns', true, true, true, '' ],
 			[ 'woo_metabox_top', true, true, true, '' ],
@@ -74,6 +75,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 			// Validation where the dirty value is not in the validate data types.
 			[ 'woo_schema_brand', 'bar', 'bar', 'yoast', null ],
 			[ 'woo_schema_manufacturer', 'bar', 'bar', 'yoast', null ],
+			[ 'woo_schema_color', 'bar', 'bar', 'yoast', null ],
 			[ 'woo_breadcrumbs', false, null, true, '' ],
 			[ 'woo_hide_columns', false, null, true, '' ],
 			[ 'woo_metabox_top', false, null, true, '' ],
@@ -81,14 +83,17 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 			// Validation where the old value is in the validate data types with short form enabled.
 			[ 'woo_schema_brand', 'yoast', null, 'yoast', 'yoast,', 'on' ],
 			[ 'woo_schema_manufacturer', 'yoast', null, 'yoast', 'yoast', 'on' ],
+			[ 'woo_schema_color', 'yoast', null, 'yoast', 'yoast', 'on' ],
 
 			// Validation where the old value isn't in the validate data types with short form enabled.
 			[ 'woo_schema_brand', 'bar', null, 'yoast', 'bar', 'on' ],
 			[ 'woo_schema_manufacturer', 'bar', null, 'yoast', 'bar', 'on' ],
+			[ 'woo_schema_color', 'bar', null, 'yoast', 'bar', 'on' ],
 
 			// Validation where the old value isn't in the validate data types with short form not enabled.
 			[ 'woo_schema_brand', 'yoast', null, 'yoast', 'bar', 'off' ],
 			[ 'woo_schema_manufacturer', 'yoast', null, 'yoast', 'bar', 'off' ],
+			[ 'woo_schema_color', 'yoast', null, 'yoast', 'bar', 'off' ],
 
 			// Validation where the boolean old value is set with short form enabled.
 			[ 'woo_breadcrumbs', true, null, true, true, 'on' ],


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `color` attribute to the `Product` Schema output.

## Relevant technical choices:

Product attributes in WooCommerce are custom attributes users may want to set. As far as I can tell, only `weight` and `dimensions` are default attributes and are part of the product _shipping_. Thus, the only way I could think of to get a product color is by doing the same thing we're doing for `brand` and `manufacturer`.
- adds a `Color` schema addition in SEO > WooCommerce SEO > Schema & OpenGraph additions
- users can create a product attribute and set it to be used as the Color addition
- the color Schema property is output as an array of colors, with lowercase color names
- adds a test for the product color output
- adjust existing tests

## Test instructions

This PR can be tested by following these steps:

- install and activate Yoast SEO, WooCommerce, and Yoast SEO: WooCommerce
- go to Products > Attributes
- create a new attribute: the attribute name is not relevant, could be "Color" or even "Papede papede"
- click "Configure terms" for the attribute you just created
- create a few attribute terms: these are the actual colors (the color names are not relevant)
- for testing purposes, create also a color with an uppercase name
- go to SEO > WooCommerce SEO
- under "Schema & OpenGraph additions" set the attribute you created as value for the "Color" addition, e.g.:

<img width="689" alt="Screenshot 2020-02-25 at 16 17 02" src="https://user-images.githubusercontent.com/1682452/75260746-5b109a80-57ea-11ea-9626-6880d1ba1a33.png">


**Simple product:**

- create a new product of type "Simple product"
- set at least its price and make sure it's in stock so that it's visible in the front end when published
- in the "Product data" meta box under "Attributes" add "Color" as custom product attribute
- click "Select all" under the "Value" textarea to add all the colors
- check the "Visible on the product page" checkbox
- inspect the schema output in the front end
- see the product schema has a `color` property with the colors within an array e.g.:
```
"color": [
    "green",
    "red",
    "uppercasecolor",
    "white"
],
```
- see the color you created with an uppercase name gets output lowercase
- edit the product attributes and remove all colors but one and save
- see the schema output has now just one color
- edit the product, remove all colors and save: Woo removes the Color attribute as well
- see the schema output doesn't have a color property

**Variable product:**

- create a new product of type "Variable product"
- the exact steps are a bit out of the scope of this PR but basically you need to set the color attribute to be used as "product variation" and then set each color as variation
- inspect the schema output in the front end
- see there's a `color` property for the `Product`
- the `Offer` product type will change to `AggregateOffer`
- NOTE: hopefully this is OK otherwise setting the specific color for each `Offer` under `AggregateOffer` would be a bit more complicated /Cc @jono-alderson 

**Grouped product:**

- create a new product of type "Grouped product"
- the exact steps are a bit out of the scope of this PR but basically you need to link the product to another existing product
- inspect the schema output in the front end
- see there's a `color` property for the `Product`

**External/Affiliate product:**
- create a new product of type "External/Affiliate product"
- the exact steps are a bit out of the scope of this PR but basically you need to insert a URL to an external product site 
- inspect the schema output in the front end
- see there's a `color` property for the `Product`


Fixes https://github.com/Yoast/featurerequests/issues/418