### PR TITLE
Fix tax schema woocommerce

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -64,7 +64,6 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			'woo_breadcrumbs'               => true,
 			'woo_hide_columns'              => true,
 			'woo_metabox_top'               => true,
-			'woo_schema_og_prices_with_tax' => false,
 		];
 
 		/**
@@ -153,7 +152,6 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 					case 'woo_breadcrumbs':
 					case 'woo_hide_columns':
 					case 'woo_metabox_top':
-					case 'woo_schema_og_prices_with_tax':
 						if ( isset( $dirty[ $key ] ) ) {
 							$clean[ $key ] = WPSEO_Utils::validate_bool( $dirty[ $key ] );
 						}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -152,9 +152,12 @@ class WPSEO_WooCommerce_Schema {
 				$price                           = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
 				$data['offers'][ $key ]['@id']   = $home_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
 				$data['offers'][ $key ]['price'] = $price;
-				$data['offers'][ $key ]['priceSpecification']['price']                 = $price;
-				$data['offers'][ $key ]['priceSpecification']['priceCurrency']         = get_woocommerce_currency();
-				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+				$data['offers'][ $key ]['priceSpecification']['price']         = $price;
+				$data['offers'][ $key ]['priceSpecification']['priceCurrency'] = get_woocommerce_currency();
+				if ( wc_tax_enabled() ) {
+					// Only show this property if tax calculation has been enabled in WooCommerce.
+					$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+				}
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
 				$data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
@@ -367,7 +370,7 @@ class WPSEO_WooCommerce_Schema {
 		foreach ( $variations as $key => $variation ) {
 			$variation_name = implode( ' / ', $variation['attributes'] );
 
-			$data[] = [
+			$offer = [
 				'@type'              => 'Offer',
 				'@id'                => $site_url . '#/schema/offer/' . $product_id . '-' . $key,
 				'name'               => $product_name . ' - ' . $variation_name,
@@ -375,9 +378,15 @@ class WPSEO_WooCommerce_Schema {
 				'priceSpecification' => [
 					'price'                 => wc_format_decimal( $variation['display_price'], $decimals ),
 					'priceCurrency'         => $currency,
-					'valueAddedTaxIncluded' => $prices_include_tax,
 				],
 			];
+
+			if ( wc_tax_enabled() ) {
+				// Only add this property if tax calculation has been enabled in WooCommerce.
+				$offer['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+			}
+
+			$data[] = $offer;
 		}
 
 		return $data;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -158,6 +158,10 @@ class WPSEO_WooCommerce_Schema {
 					// Only show this property if tax calculation has been enabled in WooCommerce.
 					$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
 				}
+				else {
+					// Remove `valueAddedTaxIncluded` property from Schema output by WooCommerce.
+					unset( $data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] );
+				}
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
 				$data['offers'][ $key ]['@id']    = $home_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -403,17 +403,6 @@ class Yoast_WooCommerce_SEO {
 		Yoast_Form::get_instance()->select( 'woo_schema_manufacturer', esc_html__( 'Manufacturer', 'yoast-woo-seo' ), $taxonomies );
 		Yoast_Form::get_instance()->select( 'woo_schema_brand', esc_html__( 'Brand', 'yoast-woo-seo' ), $taxonomies );
 
-		if ( wc_tax_enabled() && get_option( 'woocommerce_tax_display_shop' ) === 'incl' ) {
-			Yoast_Form::get_instance()->checkbox(
-				'woo_schema_og_prices_with_tax',
-				sprintf(
-				/* translators: %1$s resolves to WooCommerce */
-					esc_html__( 'Prices in OpenGraph and Schema include tax', 'yoast-woo-seo' ),
-					'WooCommerce'
-				)
-			);
-		}
-
 		if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
 			echo '<h2>' . esc_html__( 'Breadcrumbs', 'yoast-woo-seo' ) . '</h2>';
 			echo '<p>';

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -100,6 +100,8 @@ class WPSEO_WooCommerce_Utils {
 	 * Determines if prices have tax included or not.
 	 *
 	 * @return bool True if prices have tax included, false if not.
+	 *
+	 * @codeCoverageIgnore Wrapper method.
 	 */
 	public static function prices_have_tax_included() {
 		return get_option( 'woocommerce_tax_display_shop' ) === 'incl';

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -45,43 +45,59 @@ class WPSEO_WooCommerce_Utils {
 		$display_price = $product->get_price();
 		$quantity      = $product->get_min_purchase_quantity();
 
-		if ( self::prices_with_tax() ) {
-			$display_price = wc_get_price_including_tax(
-				$product,
-				[
-					'qty'   => $quantity,
-					'price' => $display_price,
-				]
-			);
+		if ( wc_tax_enabled() ) {
+			if ( self::prices_should_include_tax() ) {
+				$display_price = wc_get_price_including_tax(
+					$product,
+					[
+						'qty'   => $quantity,
+						'price' => $display_price,
+					]
+				);
+			} else if ( self::prices_should_exclude_tax() ) {
+				$display_price = wc_get_price_excluding_tax(
+					$product,
+					[
+						'qty'   => $quantity,
+						'price' => $display_price,
+					]
+				);
+			}
 		}
 
 		return wc_format_decimal( $display_price, $decimals );
 	}
 
 	/**
-	 * Determines if prices should be returned with or without tax included.
+	 * Determines if tax should be added to the price stored in WooCommerce.
 	 *
 	 * @return bool True if prices should be displayed with tax added, false if not.
 	 */
-	public static function prices_with_tax() {
+	public static function prices_should_include_tax() {
 		return (
-			wc_tax_enabled() &&
 			! wc_prices_include_tax() &&
 			get_option( 'woocommerce_tax_display_shop' ) === 'incl'
 		);
 	}
 
 	/**
+	 * Determines if tax should be subtracted from the price as stored in WooCommerce.
+	 *
+	 * @return bool True if prices should be displayed with tax subtracted, false if not.
+	 */
+	public static function prices_should_exclude_tax() {
+		return (
+			wc_prices_include_tax() &&
+			get_option( 'woocommerce_tax_display_shop' ) === 'excl'
+		);
+	}
+
+	/**
 	 * Determines if prices have tax included or not.
-	 * (It does not matter whether they have been automatically calculated by
-	 * WooCommerce or manually added).
 	 *
 	 * @return bool True if prices have tax included, false if not.
 	 */
 	public static function prices_have_tax_included() {
-		return (
-			wc_tax_enabled() &&
-			get_option( 'woocommerce_tax_display_shop' ) === 'incl'
-		);
+		return get_option( 'woocommerce_tax_display_shop' ) === 'incl';
 	}
 }

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -56,7 +56,8 @@ class WPSEO_WooCommerce_Utils {
 						'price' => $display_price,
 					]
 				);
-			} else if ( self::prices_should_exclude_tax() ) {
+			}
+			elseif ( self::prices_should_exclude_tax() ) {
 				// Prices are stored **with** tax, subtract tax.
 				$display_price = wc_get_price_excluding_tax(
 					$product,

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -46,7 +46,9 @@ class WPSEO_WooCommerce_Utils {
 		$quantity      = $product->get_min_purchase_quantity();
 
 		if ( wc_tax_enabled() ) {
+			// Taxes should be calculated.
 			if ( self::prices_should_include_tax() ) {
+				// Prices are stored **without** tax, add tax.
 				$display_price = wc_get_price_including_tax(
 					$product,
 					[
@@ -55,6 +57,7 @@ class WPSEO_WooCommerce_Utils {
 					]
 				);
 			} else if ( self::prices_should_exclude_tax() ) {
+				// Prices are stored **with** tax, subtract tax.
 				$display_price = wc_get_price_excluding_tax(
 					$product,
 					[

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -67,8 +67,7 @@ class WPSEO_WooCommerce_Utils {
 		return (
 			wc_tax_enabled() &&
 			! wc_prices_include_tax() &&
-			get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
-			WPSEO_Options::get( 'woo_schema_og_prices_with_tax' )
+			get_option( 'woocommerce_tax_display_shop' ) === 'incl'
 		);
 	}
 
@@ -82,8 +81,7 @@ class WPSEO_WooCommerce_Utils {
 	public static function prices_have_tax_included() {
 		return (
 			wc_tax_enabled() &&
-			get_option( 'woocommerce_tax_display_shop' ) === 'incl' &&
-			WPSEO_Options::get( 'woo_schema_og_prices_with_tax' )
+			get_option( 'woocommerce_tax_display_shop' ) === 'incl'
 		);
 	}
 }

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -143,9 +143,6 @@ class OpenGraph_Test extends TestCase {
 			->with( 'woocommerce_tax_display_shop' )
 			->andReturn( 'incl' );
 
-		$options = Mockery::mock( 'alias:WPSEO_Options' );
-		$options->expects( 'get' )->once()->with( 'woo_schema_og_prices_with_tax' )->andReturn( true );
-
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_price' )->once()->andReturn( $base_price );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -181,7 +181,6 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'price'                 => '49.00',
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 					'priceCurrency'      => 'GBP',
 					'availability'       => 'http://schema.org/InStock',

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -437,7 +437,6 @@ class Schema_Test extends TestCase {
 						'priceSpecification' => [
 							'price'                 => '10',
 							'priceCurrency'         => 'GBP',
-							'valueAddedTaxIncluded' => false,
 						],
 					],
 					[
@@ -448,7 +447,6 @@ class Schema_Test extends TestCase {
 						'priceSpecification' => [
 							'price'                 => '8',
 							'priceCurrency'         => 'GBP',
-							'valueAddedTaxIncluded' => false,
 						],
 					],
 					[
@@ -459,7 +457,6 @@ class Schema_Test extends TestCase {
 						'priceSpecification' => [
 							'price'                 => '12',
 							'priceCurrency'         => 'GBP',
-							'valueAddedTaxIncluded' => false,
 						],
 					],
 				],
@@ -939,7 +936,6 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'price'                 => '1.00',
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 					'url'                => $canonical,
 					'seller'             => [
@@ -1117,7 +1113,6 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'price'                 => '1.00',
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],

--- a/tests/classes/utils-test.php
+++ b/tests/classes/utils-test.php
@@ -59,7 +59,7 @@ class Utils_Test extends TestCase {
 	 * Test getting the product display price
 	 *
 	 * @covers WPSEO_WooCommerce_Utils::get_product_display_price
-	 * @covers WPSEO_WooCommerce_Utils::prices_with_tax
+	 * @covers WPSEO_WooCommerce_Utils::prices_should_include_tax
 	 */
 	public function test_get_product_display_price() {
 		$price    = 10;
@@ -97,7 +97,7 @@ class Utils_Test extends TestCase {
 	/**
 	 * Test the different cases for prices with or without tax.
 	 *
-	 * @covers WPSEO_WooCommerce_Utils::prices_with_tax
+	 * @covers WPSEO_WooCommerce_Utils::prices_should_include_tax
 	 */
 	public function test_prices_with_tax() {
 		Functions\stubs(
@@ -105,7 +105,7 @@ class Utils_Test extends TestCase {
 				'wc_tax_enabled' => false,
 			]
 		);
-		$this->assertFalse( WPSEO_WooCommerce_Utils::prices_with_tax() );
+		$this->assertFalse( WPSEO_WooCommerce_Utils::prices_should_include_tax() );
 
 		Functions\stubs(
 			[
@@ -118,7 +118,7 @@ class Utils_Test extends TestCase {
 			->with( 'woocommerce_tax_display_shop' )
 			->andReturn( 'excl' );
 
-		$this->assertFalse( WPSEO_WooCommerce_Utils::prices_with_tax() );
+		$this->assertFalse( WPSEO_WooCommerce_Utils::prices_should_include_tax() );
 
 		Monkey\Functions\expect( 'get_option' )
 			->twice()
@@ -128,9 +128,9 @@ class Utils_Test extends TestCase {
 		$options = Mockery::mock( 'alias:WPSEO_Options' )->makePartial();
 		$options->expects( 'get' )->once()->with( 'woo_schema_og_prices_with_tax' )->andReturn( false );
 
-		$this->assertFalse( WPSEO_WooCommerce_Utils::prices_with_tax() );
+		$this->assertFalse( WPSEO_WooCommerce_Utils::prices_should_include_tax() );
 
 		$options->expects( 'get' )->once()->with( 'woo_schema_og_prices_with_tax' )->andReturn( true );
-		$this->assertTrue( WPSEO_WooCommerce_Utils::prices_with_tax() );
+		$this->assertTrue( WPSEO_WooCommerce_Utils::prices_should_include_tax() );
 	}
 }

--- a/tests/classes/utils-test.php
+++ b/tests/classes/utils-test.php
@@ -96,7 +96,7 @@ class Utils_Test extends TestCase {
 	 *
 	 * @covers WPSEO_WooCommerce_Utils::prices_should_include_tax
 	 */
-	public function test_prices_with_tax() {
+	public function test_prices_should_include_tax() {
 		// Prices do not include tax, tax should be shown in shop => tax should be added.
 		Functions\stubs(
 			[
@@ -125,7 +125,7 @@ class Utils_Test extends TestCase {
 	 *
 	 * @covers WPSEO_WooCommerce_Utils::prices_should_exclude_tax
 	 */
-	public function test_prices_without_tax() {
+	public function test_prices_should_exclude_tax() {
 		// Prices include tax, tax should not be shown in shop => tax should be subtracted.
 		Functions\stubs(
 			[


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the product price and whether taxes were included were not accurately reflected in the Schema and Open Graph metatags.
* Removes the 'Prices in Open Graph and Schema include tax' setting in the plugin. Whether tax is included in Open Graph and Schema now solely relies on your product page settings in WooCommerce.

## Relevant technical choices:

* The previous code only checked whether the entered price excluded tax and tax should be **added**. I added code to also check whether the price included tax and tax should be **subtracted** (if shop is set to exclude tax).

## Test instructions

This PR can be tested by following these steps:

* Checkout and build the `master` branch of `wordpress-seo`.
* Checkout and build this branch of `wpseo-woocommerce`.

**TL,DR:** 
 * Prices in Schema and `product:price:amount` meta tag should be the same as the price shown on the product page.
 * `valueAddedTaxIncluded` Schema property should reflect the 'Display prices in the shop' WooCommerce tax setting.
   * 'including tax' = `valueAddedTaxIncluded` is **true**.
   * 'excluding tax' = `valueAddedTaxIncluded` is **false**.
 * Disabling tax calculations entirely, by unchecking 'Enable tax rates and calculations', should result in `valueAddedTaxIncluded` not being output in the Schema. 

### Disabling tax calculations should exclude `valueAddedTaxIncluded`.
 * Make sure that 'Enable tax rates and calculations' in WooCommerce general settings is disabled.
 * Make sure that you have a product with an entered price.
 * Go to a product page (on the frontend).
   * Schema should **not** have a `valueAddedTaxIncluded` property. 

### Initial settings for further tests.
 * Make sure that 'Enable tax rates and calculations' in WooCommerce general settings is enabled.
 * Make sure that you have a product with an entered price.
 * Make sure that you have a (wildcard) tax rate set.
   E.g. <img src="https://user-images.githubusercontent.com/487629/73946352-1635ca00-48f6-11ea-94e6-8eea909e3bae.png" />

### Prices entered including tax, shop set to display prices without tax.
 * On WooCommerce tax setting page:
    * 'Yes, I will enter prices inclusive of tax' should be selected.
    * 'Display prices in the shop' should be set to 'excluding tax'.
 * Go to a product page (on the frontend).
    * Schema price (`"price"`, two times in Schema) should be the same as the listed price on the page itself.
    * Open Graph price metatag (`product:price:amount`) should be the same as well.
    * `valueAddedTaxIncluded` Schema property should be set to `false`.

### Prices entered excluding tax, shop set to display prices without tax.
 * On WooCommerce tax setting page:
    * 'No, I will enter prices exclusive of tax' should be selected.
    * 'Display prices in the shop' should be set to 'excluding tax'.
 * Go to a product page (on the frontend).
    * Schema price (`"price"`, two times in Schema) should be the same as the listed price on the page itself.
    * Open Graph price metatag (`product:price:amount`) should be the same as well.
    * `valueAddedTaxIncluded` Schema property should be set to `false`.

### Prices entered excluding tax, shop set to display prices with tax.
 * On WooCommerce tax setting page:
    * 'No, I will enter prices exclusive of tax' should be selected.
    * 'Display prices in the shop' should be set to 'including tax'.
 * Go to a product page (on the frontend).
    * Schema price (`"price"`, two times in Schema) should be the same as the listed price on the page itself.
    * Open Graph price metatag (`product:price:amount`) should be the same as well.
    * `valueAddedTaxIncluded` Schema property should be set to `true`.

### Prices entered including tax, shop set to display prices with tax.
 * On WooCommerce tax setting page:
    * 'Yes, I will enter prices inclusive of tax' should be selected.
    * 'Display prices in the shop' should be set to 'including tax'.
 * Go to a product page (on the frontend).
    * Schema price (`"price"`, two times in Schema) should be the same as the listed price on the page itself.
    * Open Graph price metatag (`product:price:amount`) should be the same as well.
    * `valueAddedTaxIncluded` Schema property should be set to `true`.

Fixes #
