### PR TITLE
Fix unit test

### DIFF
--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -933,15 +933,15 @@ class Schema_Test extends TestCase {
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
-					'priceSpecification' => [
-						'price'                 => '1.00',
-						'priceCurrency'         => 'GBP',
-					],
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $canonical . '#organization',
 					],
 					'@id'                => $base_url . '/#/schema/offer/1-0',
+					'priceSpecification' => [
+						'price'         => '1.00',
+						'priceCurrency' => 'GBP',
+					],
 				],
 			],
 			'review'           => [


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* Because `assertEquals` was recently changed to `assertSame`, the unit test failed because the schema properties were not in the right order. I changed the order of the properties to fix this.

## Test instructions

This PR can be tested by following these steps:

* See that Travis passes.

Fixes #
