### PR TITLE
Add replacement variables for product global identifiers

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -18,6 +18,13 @@ class Yoast_WooCommerce_SEO {
 	const VERSION = WPSEO_WOO_VERSION;
 
 	/**
+	 * The product global identifiers.
+	 *
+	 * @var array
+	 */
+	private $global_identifiers = [];
+
+	/**
 	 * Return the plugin file.
 	 *
 	 * @return string
@@ -75,6 +82,7 @@ class Yoast_WooCommerce_SEO {
 			add_filter( 'wpseo_metadesc', [ $this, 'metadesc' ] );
 
 			add_action( 'wpseo_register_extra_replacements', [ $this, 'register_replacements' ] );
+			add_action( 'wp', [ $this, 'get_product_global_identifiers' ] );
 
 			add_filter( 'wpseo_sitemap_exclude_post_type', [ $this, 'xml_sitemap_post_types' ], 10, 2 );
 			add_filter( 'wpseo_sitemap_post_type_archive_link', [ $this, 'xml_sitemap_taxonomies' ], 10, 2 );
@@ -993,22 +1001,22 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Retrieves the product global identifiers.
 	 *
-	 * @return array The product global identifiers.
+	 * @return void
 	 */
 	public function get_product_global_identifiers() {
 		$product = $this->get_product();
 		if ( ! is_object( $product ) ) {
-			return [];
+			return;
 		}
 
 		$product_id               = $product->get_id();
 		$global_identifier_values = get_post_meta( $product_id, 'wpseo_global_identifier_values', true );
 
 		if ( ! is_array( $global_identifier_values ) ) {
-			return [];
+			return;
 		}
 
-		return $global_identifier_values;
+		$this->global_identifiers = $global_identifier_values;
 	}
 
 	/**
@@ -1017,9 +1025,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN8 identifier.
 	 */
 	public function get_product_var_gtin8() {
-		$global_identifier_values = $this->get_product_global_identifiers();
-
-		return isset( $global_identifier_values['gtin8'] ) ? $global_identifier_values['gtin8'] : '';
+		return isset( $this->global_identifiers['gtin8'] ) ? $this->global_identifiers['gtin8'] : '';
 	}
 
 	/**
@@ -1028,9 +1034,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN12 / UPC identifier.
 	 */
 	public function get_product_var_gtin12() {
-		$global_identifier_values = $this->get_product_global_identifiers();
-
-		return isset( $global_identifier_values['gtin12'] ) ? $global_identifier_values['gtin12'] : '';
+		return isset( $this->global_identifiers['gtin12'] ) ? $this->global_identifiers['gtin12'] : '';
 	}
 
 	/**
@@ -1039,9 +1043,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN13 / EAN identifier.
 	 */
 	public function get_product_var_gtin13() {
-		$global_identifier_values = $this->get_product_global_identifiers();
-
-		return isset( $global_identifier_values['gtin13'] ) ? $global_identifier_values['gtin13'] : '';
+		return isset( $this->global_identifiers['gtin13'] ) ? $this->global_identifiers['gtin13'] : '';
 	}
 
 	/**
@@ -1050,9 +1052,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN14 / ITF-14 identifier.
 	 */
 	public function get_product_var_gtin14() {
-		$global_identifier_values = $this->get_product_global_identifiers();
-
-		return isset( $global_identifier_values['gtin14'] ) ? $global_identifier_values['gtin14'] : '';
+		return isset( $this->global_identifiers['gtin14'] ) ? $this->global_identifiers['gtin14'] : '';
 	}
 
 	/**
@@ -1061,9 +1061,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product ISBN identifier.
 	 */
 	public function get_product_var_isbn() {
-		$global_identifier_values = $this->get_product_global_identifiers();
-
-		return isset( $global_identifier_values['isbn'] ) ? $global_identifier_values['isbn'] : '';
+		return isset( $this->global_identifiers['isbn'] ) ? $this->global_identifiers['isbn'] : '';
 	}
 
 	/**
@@ -1072,9 +1070,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product MPN identifier.
 	 */
 	public function get_product_var_mpn() {
-		$global_identifier_values = $this->get_product_global_identifiers();
-
-		return isset( $global_identifier_values['mpn'] ) ? $global_identifier_values['mpn'] : '';
+		return isset( $this->global_identifiers['mpn'] ) ? $this->global_identifiers['mpn'] : '';
 	}
 
 	/**

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -819,6 +819,48 @@ class Yoast_WooCommerce_SEO {
 			'basic',
 			'The product\'s brand.'
 		);
+
+		wpseo_register_var_replacement(
+			'wc_gtin8',
+			[ $this, 'get_product_var_gtin8' ],
+			'basic',
+			'The product\'s GTIN8 identifier.'
+		);
+
+		wpseo_register_var_replacement(
+			'wc_gtin12',
+			[ $this, 'get_product_var_gtin12' ],
+			'basic',
+			'The product\'s GTIN12 \/ UPC identifier.'
+		);
+
+		wpseo_register_var_replacement(
+			'wc_gtin13',
+			[ $this, 'get_product_var_gtin13' ],
+			'basic',
+			'The product\'s GTIN13 \/ EAN identifier.'
+		);
+
+		wpseo_register_var_replacement(
+			'wc_gtin14',
+			[ $this, 'get_product_var_gtin14' ],
+			'basic',
+			'The product\'s GTIN14 \/ ITF-14 identifier.'
+		);
+
+		wpseo_register_var_replacement(
+			'wc_isbn',
+			[ $this, 'get_product_var_isbn' ],
+			'basic',
+			'The product\'s ISBN identifier.'
+		);
+
+		wpseo_register_var_replacement(
+			'wc_mpn',
+			[ $this, 'get_product_var_mpn' ],
+			'basic',
+			'The product\'s MPN identifier.'
+		);
 	}
 
 	/**
@@ -946,6 +988,93 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Retrieves the product global identifiers.
+	 *
+	 * @return array The product global identifiers.
+	 */
+	public function get_product_global_identifiers() {
+		$product = $this->get_product();
+		if ( ! is_object( $product ) ) {
+			return [];
+		}
+
+		$product_id               = $product->get_id();
+		$global_identifier_values = get_post_meta( $product_id, 'wpseo_global_identifier_values', true );
+
+		if ( ! is_array( $global_identifier_values ) ) {
+			return [];
+		}
+
+		return $global_identifier_values;
+	}
+
+	/**
+	 * Retrieves the product GTIN8 identifier.
+	 *
+	 * @return string The product GTIN8 identifier.
+	 */
+	public function get_product_var_gtin8() {
+		$global_identifier_values = $this->get_product_global_identifiers();
+
+		return isset( $global_identifier_values['gtin8'] ) ? $global_identifier_values['gtin8'] : '';
+	}
+
+	/**
+	 * Retrieves the product GTIN12 / UPC identifier.
+	 *
+	 * @return string The product GTIN12 / UPC identifier.
+	 */
+	public function get_product_var_gtin12() {
+		$global_identifier_values = $this->get_product_global_identifiers();
+
+		return isset( $global_identifier_values['gtin12'] ) ? $global_identifier_values['gtin12'] : '';
+	}
+
+	/**
+	 * Retrieves the product GTIN13 / EAN identifier.
+	 *
+	 * @return string The product GTIN13 / EAN identifier.
+	 */
+	public function get_product_var_gtin13() {
+		$global_identifier_values = $this->get_product_global_identifiers();
+
+		return isset( $global_identifier_values['gtin13'] ) ? $global_identifier_values['gtin13'] : '';
+	}
+
+	/**
+	 * Retrieves the product GTIN14 / ITF-14 identifier.
+	 *
+	 * @return string The product GTIN14 / ITF-14 identifier.
+	 */
+	public function get_product_var_gtin14() {
+		$global_identifier_values = $this->get_product_global_identifiers();
+
+		return isset( $global_identifier_values['gtin14'] ) ? $global_identifier_values['gtin14'] : '';
+	}
+
+	/**
+	 * Retrieves the product ISBN identifier.
+	 *
+	 * @return string The product ISBN identifier.
+	 */
+	public function get_product_var_isbn() {
+		$global_identifier_values = $this->get_product_global_identifiers();
+
+		return isset( $global_identifier_values['isbn'] ) ? $global_identifier_values['isbn'] : '';
+	}
+
+	/**
+	 * Retrieves the product MPN identifier.
+	 *
+	 * @return string The product MPN identifier.
+	 */
+	public function get_product_var_mpn() {
+		$global_identifier_values = $this->get_product_global_identifiers();
+
+		return isset( $global_identifier_values['mpn'] ) ? $global_identifier_values['mpn'] : '';
 	}
 
 	/**

--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -164,6 +164,12 @@ YoastReplaceVarPlugin.prototype.registerReplacements = function() {
 	this.addReplacement( new ReplaceVar( "%%wc_sku%%",       "wc_sku" ) );
 	this.addReplacement( new ReplaceVar( "%%wc_shortdesc%%", "wc_shortdesc" ) );
 	this.addReplacement( new ReplaceVar( "%%wc_brand%%",     "wc_brand" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_gtin8%%",     "wc_gtin8" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_gtin12%%",    "wc_gtin12" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_gtin13%%",    "wc_gtin13" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_gtin14%%",    "wc_gtin14" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_isbn%%",      "wc_isbn" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_mpn%%",       "wc_mpn" ) );
 };
 
 /**
@@ -194,6 +200,12 @@ YoastReplaceVarPlugin.prototype.replaceVariables = function( data ) {
 		data = data.replace( /%%wc_sku%%/g, jQuery( "#_sku" ).val() );
 		data = data.replace( /%%wc_shortdesc%%/g, getShortDescription() );
 		data = data.replace( /%%wc_brand%%/g, getBrand() );
+		data = data.replace( /%%wc_gtin8%%/g, jQuery( "#yoast_identfier_gtin8" ).val() );
+		data = data.replace( /%%wc_gtin12%%/g, jQuery( "#yoast_identfier_gtin12" ).val() );
+		data = data.replace( /%%wc_gtin13%%/g, jQuery( "#yoast_identfier_gtin13" ).val() );
+		data = data.replace( /%%wc_gtin14%%/g, jQuery( "#yoast_identfier_gtin14" ).val() );
+		data = data.replace( /%%wc_isbn%%/g, jQuery( "#yoast_identfier_isbn" ).val() );
+		data = data.replace( /%%wc_mpn%%/g, jQuery( "#yoast_identfier_mpn" ).val() );
 
 		data = this.replacePlaceholders( data );
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -974,7 +974,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertSame( $expected, $instance->data );
+		$this->assertEquals( $expected, $instance->data );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the product identifiers (GTIN, ISBN etc.) to the SEO title and Meta description replacement variables.

## Relevant technical choices:

- Please notice under the hood the product identifiers are custom fields. They belong to a specific product post. They will work only on the Edit product page, on a per product basis.
- While working on this I noticed a few things that look odd to me, will create separate issues.

## Test instructions

This PR can be tested by following these steps:

- install / activate WooCommerce and wpseo-woocommerce
- switch wpseo-woocommerce to this branch and build
- publish a product making sure it has at least a price and it's in stock (so that it's actually visible on the front end)
- in the product snippet editor, add one or more (or all) the product identifiers to the SEO title and Meta description:
  - click "Edit snippet"
  - click "Insert snippet variable"
  - type `wc`
  - the suggestions dropdown will show all the available replacement variables related to WooCommerce:

<img width="782" alt="Screenshot 2020-03-03 at 10 40 12" src="https://user-images.githubusercontent.com/1682452/75763102-04501700-5d3c-11ea-8813-20450ad8909f.png">

  - add the variables
  - update the product post
- now, inspect the front end source
- see the document `<title>` tag, the `og:title`, `twitter:title`, `description`, `og:description`, and the `twitter:description` meta don't contain the product identifiers yet
- go to the "Product data" meta box > Yoast SEO tab:

<img width="975" alt="Screenshot 2020-03-03 at 10 41 28" src="https://user-images.githubusercontent.com/1682452/75763954-6a896980-5d3d-11ea-87d2-3d9ae117b7d6.png">

- enter some values for the variables you added to the title and description (spaces aren't allowed)
- update the product post
- refresh the product front end page and inspect its source
- see that the document `<title>` tag, `og:title`, `twitter:title`, the `description`, `og:description`,  and`twitter:description` meta now contain the product identifier values
- play with the values: add / remove them and check the markup is correct

Note: also the `"@type": "ItemPage"` schema piece `name` and `description` will get the replacement variables, which seems correct to me.

Note: item 2 from the issue (update the yoast.com Knowledge base page) should be addressed elsewhere.

See https://github.com/Yoast/featurerequests/issues/439
