### PR TITLE
Improve Open Graph product availability

### DIFF
--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -24,7 +24,7 @@ class WPSEO_WooCommerce_OpenGraph {
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'brand' ], 10 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'price' ], 20 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'pinterest_product_availability' ], 25 );
-		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'in_stock' ], 30 );
+		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'product_availability' ], 30 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'retailer_item_id' ], 40 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'product_condition' ], 50 );
 	}
@@ -232,10 +232,18 @@ class WPSEO_WooCommerce_OpenGraph {
 	 *
 	 * @param WC_Product $product The WooCommerce product object.
 	 */
-	public function in_stock( WC_Product $product ) {
+	public function product_availability( WC_Product $product ) {
+		if ( $product->is_on_backorder() ) {
+			echo '<meta property="product:availability" content="pending" />' . "\n";
+			return;
+		}
+
 		if ( $product->is_in_stock() ) {
 			echo '<meta property="product:availability" content="in stock" />' . "\n";
+			return;
 		}
+
+		echo '<meta property="product:availability" content="out of stock" />' . "\n";
 	}
 
 	/**
@@ -295,5 +303,15 @@ class WPSEO_WooCommerce_OpenGraph {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Add our product stock availability.
+	 *
+	 * @deprecated 12.7
+	 * @codeCoverageIgnore
+	 */
+	public function in_stock() {
+		_deprecated_function( __METHOD__, 'WPSEO Woo 12.7' );
 	}
 }

--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -234,7 +234,7 @@ class WPSEO_WooCommerce_OpenGraph {
 	 */
 	public function product_availability( WC_Product $product ) {
 		if ( $product->is_on_backorder() ) {
-			echo '<meta property="product:availability" content="pending" />' . "\n";
+			echo '<meta property="product:availability" content="available for order" />' . "\n";
 			return;
 		}
 

--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -23,6 +23,7 @@ class WPSEO_WooCommerce_OpenGraph {
 
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'brand' ], 10 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'price' ], 20 );
+		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'pinterest_product_availability' ], 25 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'in_stock' ], 30 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'retailer_item_id' ], 40 );
 		add_action( 'Yoast\WP\Woocommerce\opengraph', [ $this, 'product_condition' ], 50 );
@@ -235,6 +236,25 @@ class WPSEO_WooCommerce_OpenGraph {
 		if ( $product->is_in_stock() ) {
 			echo '<meta property="product:availability" content="in stock" />' . "\n";
 		}
+	}
+
+	/**
+	 * Add our product stock availability for Pinterest Rich Pins.
+	 *
+	 * @param WC_Product $product The WooCommerce product object.
+	 */
+	public function pinterest_product_availability( WC_Product $product ) {
+		if ( $product->is_on_backorder() ) {
+			echo '<meta property="og:availability" content="backorder" />' . "\n";
+			return;
+		}
+
+		if ( $product->is_in_stock() ) {
+			echo '<meta property="og:availability" content="instock" />' . "\n";
+			return;
+		}
+
+		echo '<meta property="og:availability" content="out of stock" />' . "\n";
 	}
 
 	/**

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -269,7 +269,7 @@ class OpenGraph_Test extends TestCase {
 		\ob_start();
 		$og->product_availability( $product );
 
-		$this->assertSame( '<meta property="product:availability" content="pending" />' . "\n", \ob_get_clean() );
+		$this->assertSame( '<meta property="product:availability" content="available for order" />' . "\n", \ob_get_clean() );
 	}
 
 	/**

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -255,6 +255,56 @@ class OpenGraph_Test extends TestCase {
 	}
 
 	/**
+	 * Test the OpenGraph product availability for Pinterest Rich Pins with product in stock.
+	 *
+	 * @covers WPSEO_WooCommerce_OpenGraph::pinterest_product_availability
+	 */
+	public function test_pinterest_product_availability_in_stock() {
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'is_on_backorder' )->andReturn( false );
+		$product->expects( 'is_in_stock' )->andReturn( true );
+
+		$og = new WPSEO_WooCommerce_OpenGraph();
+		\ob_start();
+		$og->pinterest_product_availability( $product );
+
+		$this->assertSame( '<meta property="og:availability" content="instock" />' . "\n", \ob_get_clean() );
+	}
+
+	/**
+	 * Test the OpenGraph product availability for Pinterest Rich Pins with product in backorder.
+	 *
+	 * @covers WPSEO_WooCommerce_OpenGraph::pinterest_product_availability
+	 */
+	public function test_pinterest_product_availability_on_backorder() {
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'is_on_backorder' )->andReturn( true );
+
+		$og = new WPSEO_WooCommerce_OpenGraph();
+		\ob_start();
+		$og->pinterest_product_availability( $product );
+
+		$this->assertSame( '<meta property="og:availability" content="backorder" />' . "\n", \ob_get_clean() );
+	}
+
+	/**
+	 * Test the OpenGraph product availability for Pinterest Rich Pins with product out of stock.
+	 *
+	 * @covers WPSEO_WooCommerce_OpenGraph::pinterest_product_availability
+	 */
+	public function test_pinterest_product_availability_out_of_stock() {
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'is_on_backorder' )->andReturn( false );
+		$product->expects( 'is_in_stock' )->andReturn( false );
+
+		$og = new WPSEO_WooCommerce_OpenGraph();
+		\ob_start();
+		$og->pinterest_product_availability( $product );
+
+		$this->assertSame( '<meta property="og:availability" content="out of stock" />' . "\n", \ob_get_clean() );
+	}
+
+	/**
 	 * Test setting the OpenGraph image.
 	 *
 	 * @covers WPSEO_WooCommerce_OpenGraph::set_opengraph_image

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -30,7 +30,8 @@ class OpenGraph_Test extends TestCase {
 
 		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'brand' ] ) );
 		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'price' ] ) );
-		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'in_stock' ] ) );
+		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'product_availability' ] ) );
+		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'pinterest_product_availability' ] ) );
 		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'retailer_item_id' ] ) );
 		$this->assertTrue( \has_action( 'Yoast\WP\Woocommerce\opengraph', [ $og, 'product_condition' ] ) );
 	}
@@ -239,19 +240,53 @@ class OpenGraph_Test extends TestCase {
 	}
 
 	/**
-	 * Test the OpenGraph in stock enhancement.
+	 * Test the OpenGraph product availability with product in stock.
 	 *
-	 * @covers WPSEO_WooCommerce_OpenGraph::in_stock
+	 * @covers WPSEO_WooCommerce_OpenGraph::product_availability
 	 */
-	public function test_in_stock() {
+	public function test_product_availability_in_stock() {
 		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'is_on_backorder' )->andReturn( false );
 		$product->expects( 'is_in_stock' )->andReturn( true );
 
 		$og = new WPSEO_WooCommerce_OpenGraph();
 		\ob_start();
-		$og->in_stock( $product );
+		$og->product_availability( $product );
 
 		$this->assertSame( '<meta property="product:availability" content="in stock" />' . "\n", \ob_get_clean() );
+	}
+
+	/**
+	 * Test the OpenGraph product availability with product in backorder.
+	 *
+	 * @covers WPSEO_WooCommerce_OpenGraph::product_availability
+	 */
+	public function test_product_availability_on_backorder() {
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'is_on_backorder' )->andReturn( true );
+
+		$og = new WPSEO_WooCommerce_OpenGraph();
+		\ob_start();
+		$og->product_availability( $product );
+
+		$this->assertSame( '<meta property="product:availability" content="pending" />' . "\n", \ob_get_clean() );
+	}
+
+	/**
+	 * Test the OpenGraph product availability with product out of stock.
+	 *
+	 * @covers WPSEO_WooCommerce_OpenGraph::product_availability
+	 */
+	public function test_product_availability_out_of_stock() {
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'is_on_backorder' )->andReturn( false );
+		$product->expects( 'is_in_stock' )->andReturn( false );
+
+		$og = new WPSEO_WooCommerce_OpenGraph();
+		\ob_start();
+		$og->product_availability( $product );
+
+		$this->assertSame( '<meta property="product:availability" content="out of stock" />' . "\n", \ob_get_clean() );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1182,6 +1182,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
+		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 
 		Mockery::getConfiguration()->setConstantsMap(
 			[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve the Open Graph output for compatibility with what Pinterest expects. Also, handle `out of stock` and `backorder` statuses in addition to `instock`.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the Open Graph product availability for better compatibility with Facebook and Pinterest.

## Relevant technical choices:

- deprecates `WPSEO_WooCommerce_OpenGraph->in_stock()`: **the deprecation is set for the 12.7 release**
- introduces `WPSEO_WooCommerce_OpenGraph->product_availability()` 
- introduces `WPSEO_WooCommerce_OpenGraph->pinterest_product_availability()` 
- both new methods handle the 3 stock statuses supported by WooCommerce: in stock, out of stock, on backorder
- adds tests

After some research, it appears this is a bit of a mess as Facebook and Pinterest expect different meta property names and also _different values_. I'd appreciate a review from SEO experts here, specifically regarding:
- `in stock` for Facebook vs. `instock` for Pinterest
- `pending` for Facebook vs. `backorder` for Pinterest

/Cc @jdevalk @jono-alderson 

## Test instructions

This PR can be tested by following these steps:

- create a WooCommerce product

**Test the "in stock" output:**
- in the Product data metabox > Inventory tab: make sure "Stock status" is set to "In stock"
- publish the product
- inspect the source on the front end:
  - `og:availability` is set to `instock` without spaces
  - `product:availability` is set to `in stock` with a space

**Test the "out of stock" output:**
- set the product Stock status to "Out of stock" and save
- inspect the source on the front end:
  - `og:availability` is set to `out of stock`
  - `product:availability` is set to `out of stock`

**Test the "on backorder" output:**
- set the product Stock status to "On backorder" and save
- inspect the source on the front end:
  - `og:availability` is set to `backorder `
  - `product:availability` is set to `available for order`


Fixes https://github.com/Yoast/featurerequests/issues/332