### PR TITLE
Add term hierarchy as replacement variable.

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -207,7 +207,7 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		$replacevars['product']                = [ 'sitename', 'title', 'sep', 'primary_category' ];
-		$replacevars['product_cat']            = [ 'sitename', 'term_title', 'sep' ];
+		$replacevars['product_cat']            = [ 'sitename', 'term_title', 'sep', 'term_hierarchy' ];
 		$replacevars['product_tag']            = [ 'sitename', 'term_title', 'sep' ];
 		$replacevars['product_shipping_class'] = [ 'sitename', 'term_title', 'sep', 'page' ];
 		$replacevars['product_brand']          = [ 'sitename', 'term_title', 'sep' ];

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -179,8 +179,8 @@ class Schema_Test extends TestCase {
 					'price'              => '49.00',
 					'priceValidUntil'    => '2021-12-31',
 					'priceSpecification' => [
-						'price'                 => '49.00',
-						'priceCurrency'         => 'GBP',
+						'price'         => '49.00',
+						'priceCurrency' => 'GBP',
 					],
 					'priceCurrency'      => 'GBP',
 					'availability'       => 'http://schema.org/InStock',
@@ -433,9 +433,8 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - l',
 					'price'              => 10,
 					'priceSpecification' => [
-						'price'                 => 10,
-						'priceCurrency'         => 'GBP',
-
+						'price'         => 10,
+						'priceCurrency' => 'GBP',
 					],
 				],
 				[
@@ -444,9 +443,8 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - m',
 					'price'              => 8,
 					'priceSpecification' => [
-						'price'                 => 8,
-						'priceCurrency'         => 'GBP',
-
+						'price'         => 8,
+						'priceCurrency' => 'GBP',
 					],
 				],
 				[
@@ -455,9 +453,8 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - xl',
 					'price'              => 12,
 					'priceSpecification' => [
-						'price'                 => 12,
-						'priceCurrency'         => 'GBP',
-
+						'price'         => 12,
+						'priceCurrency' => 'GBP',
 					],
 				],
 			],
@@ -528,7 +525,6 @@ class Schema_Test extends TestCase {
 						'url'   => 'https://example.com',
 					],
 					'@id'           => 'https://example.com/#/schema/aggregate-offer/24-0',
-
 				],
 			],
 		];
@@ -586,7 +582,6 @@ class Schema_Test extends TestCase {
 						'url'   => 'https://example.com',
 					],
 					'@id'           => 'https://example.com/#/schema/aggregate-offer/24-0',
-
 				],
 			],
 		];
@@ -1111,8 +1106,8 @@ class Schema_Test extends TestCase {
 					],
 					'@id'                => $base_url . '/#/schema/offer/1-0',
 					'priceSpecification' => [
-						'price'                 => '1.00',
-						'priceCurrency'         => 'GBP',
+						'price'         => '1.00',
+						'priceCurrency' => 'GBP',
 					],
 				],
 			],
@@ -1288,9 +1283,8 @@ class Schema_Test extends TestCase {
 					],
 					'@id'                => $base_url . '/#/schema/offer/1-0',
 					'priceSpecification' => [
-						'price'                 => '1.00',
-						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
+						'price'         => '1.00',
+						'priceCurrency' => 'GBP',
 					],
 				],
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Please see https://github.com/Yoast/featurerequests/issues/426 and the test instructions on [the related PR](https://github.com/Yoast/wordpress-seo/pull/14497).

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the term ancestors hierarchy as a taxonomy replacement variable.

Fixes https://github.com/Yoast/featurerequests/issues/426