### PR TITLE
Set WC tested up to version to 4.0

### DIFF
--- a/wpseo-woocommerce.php
+++ b/wpseo-woocommerce.php
@@ -16,7 +16,7 @@
  * Domain Path: /languages/
  *
  * WC requires at least: 3.0
- * WC tested up to: 3.9
+ * WC tested up to: 4.0
  *
  * Copyright 2014-2019 Yoast BV (email: support@yoast.com)
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removing the notification in WooCommerce that WooCommerce SEO is not tested with their 4.0 version.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* “We’ve tested with WooCommerce 4.0. Everything works as expected!”

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Install WooCommerce 3.9.
* Use this branch.
* See no notification telling WooCommerce SEO is not tested with Woo's 4.0 version.

Fixes https://github.com/Yoast/featurerequests/issues/471
