### PR TITLE
Fixes `test_change_product_with_color` Schema tests on trunk

### DIFF
--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -821,7 +821,7 @@ class Schema_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Schema::add_image
 	 * @covers \WPSEO_WooCommerce_Schema::add_brand
 	 * @covers \WPSEO_WooCommerce_Schema::add_manufacturer
-	 * @covers \WPSEO_WooCommerce_Schema::add_colors
+	 * @covers \WPSEO_WooCommerce_Schema::add_color
 	 * @covers \WPSEO_WooCommerce_Schema::add_organization_for_attribute
 	 */
 	public function test_change_product() {
@@ -988,7 +988,7 @@ class Schema_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Schema::add_image
 	 * @covers \WPSEO_WooCommerce_Schema::add_brand
 	 * @covers \WPSEO_WooCommerce_Schema::add_manufacturer
-	 * @covers \WPSEO_WooCommerce_Schema::add_colors
+	 * @covers \WPSEO_WooCommerce_Schema::add_color
 	 * @covers \WPSEO_WooCommerce_Schema::add_organization_for_attribute
 	 */
 	public function test_change_product_no_thumb() {
@@ -1163,7 +1163,7 @@ class Schema_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Schema::add_image
 	 * @covers \WPSEO_WooCommerce_Schema::add_brand
 	 * @covers \WPSEO_WooCommerce_Schema::add_manufacturer
-	 * @covers \WPSEO_WooCommerce_Schema::add_colors
+	 * @covers \WPSEO_WooCommerce_Schema::add_color
 	 * @covers \WPSEO_WooCommerce_Schema::add_organization_for_attribute
 	 */
 	public function test_change_product_with_color() {

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1290,7 +1290,6 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'price'                 => '1.00',
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want all of the unit tests to pass on `trunk`, to make sure that the quality of our code is the good and no bugs have been introduced.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the `test_change_product_with_color` test.
* Fixes typo in `covers` annotations of the `add_color` method.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Check that the unit tests pass.

Fixes #
