### PR TITLE
Implemented full image from gallery in xml sitemap

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -327,7 +327,7 @@ class Yoast_WooCommerce_SEO {
 			$attachments = array_filter( explode( ',', $product_image_gallery ) );
 
 			foreach ( $attachments as $attachment_id ) {
-				$image_src = wp_get_attachment_image_src( $attachment_id );
+				$image_src = wp_get_attachment_image_src( $attachment_id, 'full' );
 				$image     = [
 					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WPSEO hook.
 					'src'   => apply_filters( 'wpseo_xml_sitemap_img_src', $image_src[0], $post_id ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  The image size of product gallery images should be the full size in the product XML sitemap.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->

This PR can be summarized in the following changelog entry:

* Fixes a bug where the thumbnail product gallery images (150x150) are added to the XML product sitemap instead of the full size images.

## Relevant technical choices:

* Used the second parameter in `wp_get_attachment_image_src` (which determines size).

## Test instructions

This PR can be tested by following these steps:

On trunk:
* Create a product
* At `Product gallery` click `Add product gallery images` and add multiple images 
* Publish
* Go to the product sitemap XML (http://basic.wordpress.test/product-sitemap.xml)
* Inspect the page source of the XML sitemap product page
* Notice that the **GALLERY** images are 150x150, i.e., that the `<image:loc>` sections contain a URL ending in `-150x150.png`

On this branch: (236-full-size-gallery-images-sitemap):
* Create a product
* At `Product gallery` click `Add product gallery images` and add multiple images 
* Publish
* Go to the product sitemap XML (http://basic.wordpress.test/product-sitemap.xml)
* Inspect the page source of the XML sitemap product page
* Notice that the **GALLERY** images are regular full size, i.e., that the `<image:loc>` represent the full size images

Fixes Yoast/featurerequests#236