### PR TITLE
Improve the output of the price replacement variable

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -926,16 +926,9 @@ class Yoast_WooCommerce_SEO {
 			return '';
 		}
 
-		if (
-			method_exists( $product, 'get_price' )
-			&& method_exists( $product, 'is_type' )
-		) {
-			if ( $product->is_type( 'variable' ) ) {
-				return $this->get_variable_product_price( $product );
-			}
-
-			if ( $product->is_type( 'grouped' ) ) {
-				return $this->get_grouped_product_price( $product );
+		if ( method_exists( $product, 'is_type' ) && method_exists( $product, 'get_price' ) ) {
+			if ( $product->is_type( 'variable' ) || $product->is_type( 'grouped' ) ) {
+				return $this->get_product_price_from_price_html( $product );
 			}
 
 			return wp_strip_all_tags( wc_price( $product->get_price() ), true );
@@ -945,39 +938,13 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Retrieves a variable product price.
+	 * Retrieves the price for a variable or grouped product.
 	 *
 	 * @param WC_Product $product The product.
 	 *
-	 * @return string The variable product price.
+	 * @return string The price of a variable or grouped product.
 	 */
-	public function get_variable_product_price( $product ) {
-		if (
-			method_exists( $product, 'get_variation_price' )
-			&& method_exists( $product, 'wc_price' )
-			&& method_exists( $product, 'wc_format_price_range' )
-		) {
-			$lowest  = $product->get_variation_price( 'min', false );
-			$highest = $product->get_variation_price( 'max', false );
-
-			if ( $lowest === $highest ) {
-				return wp_strip_all_tags( wc_price( $lowest ), true );
-			}
-
-			return wp_strip_all_tags( wc_format_price_range( $lowest, $highest ), true );
-		}
-
-		return '';
-	}
-
-	/**
-	 * Retrieves a grouped product price.
-	 *
-	 * @param WC_Product $product The product.
-	 *
-	 * @return string The grouped product price.
-	 */
-	public function get_grouped_product_price( $product ) {
+	public function get_product_price_from_price_html( $product ) {
 		if ( method_exists( $product, 'get_price_html' ) && method_exists( $product, 'get_price_suffix' ) ) {
 			$price_html   = $product->get_price_html();
 			$price_suffix = $product->get_price_suffix();

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -939,7 +939,7 @@ class Yoast_WooCommerce_SEO {
 				return $this->get_product_price_from_price_html( $product );
 			}
 
-			$price = $product->get_price();
+			$price = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
 
 			// For empty prices we want to output an empty string, as wc_price() converts them to `currencySymbol + 0.00`.
 			if ( $price === '' ) {
@@ -947,7 +947,7 @@ class Yoast_WooCommerce_SEO {
 			}
 
 			// WooCommerce converts negative prices to 0 so we do the same here.
-			if ( $price < 0 ) {
+			if ( intval( $price ) < 0 ) {
 				$price = 0;
 			}
 
@@ -969,7 +969,7 @@ class Yoast_WooCommerce_SEO {
 			$price_html   = $product->get_price_html();
 			$price_suffix = $product->get_price_suffix();
 
-			return wp_strip_all_tags( rtrim( $price_html, $price_suffix ), true );
+			return wp_strip_all_tags( str_replace( $price_suffix, '', $price_html ), true );
 		}
 
 		return '';

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -946,6 +946,11 @@ class Yoast_WooCommerce_SEO {
 				return '';
 			}
 
+			// WooCommerce converts negative prices to 0.
+			if ( $price < 0 ) {
+				$price = 0;
+			}
+
 			return wp_strip_all_tags( wc_price( $price ), true );
 		}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -584,7 +584,15 @@ class Yoast_WooCommerce_SEO {
 	 * @return WC_Product|null
 	 */
 	private function get_product() {
-		if ( ! is_singular( 'product' ) || ! function_exists( 'wc_get_product' ) ) {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return null;
+		}
+
+		if ( is_admin() ) {
+			return wc_get_product( get_the_ID() );
+		}
+
+		if ( ! is_singular( 'product' ) ) {
 			return null;
 		}
 
@@ -931,7 +939,14 @@ class Yoast_WooCommerce_SEO {
 				return $this->get_product_price_from_price_html( $product );
 			}
 
-			return wp_strip_all_tags( wc_price( $product->get_price() ), true );
+			$price = $product->get_price();
+
+			// For empty prices we want to output an empty string, as wc_price() converts them to `currencySymbol + 0.00`.
+			if ( $price === '' ) {
+				return '';
+			}
+
+			return wp_strip_all_tags( wc_price( $price ), true );
 		}
 
 		return '';
@@ -1107,6 +1122,7 @@ class Yoast_WooCommerce_SEO {
 			'currencySymbol' => get_woocommerce_currency_symbol(),
 			'decimals'       => wc_get_price_decimals(),
 			'locale'         => str_replace( '_', '-', get_locale() ),
+			'price'          => $this->get_product_var_price(),
 		];
 	}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -930,11 +930,8 @@ class Yoast_WooCommerce_SEO {
 	 */
 	public function get_product_var_price() {
 		$product = $this->get_product();
-		if ( ! is_object( $product ) ) {
-			return '';
-		}
 
-		if ( method_exists( $product, 'is_type' ) && method_exists( $product, 'get_price' ) ) {
+		if ( is_object( $product ) && method_exists( $product, 'is_type' ) && method_exists( $product, 'get_price' ) ) {
 			if ( $product->is_type( 'variable' ) || $product->is_type( 'grouped' ) ) {
 				return $this->get_product_price_from_price_html( $product );
 			}

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -946,7 +946,7 @@ class Yoast_WooCommerce_SEO {
 				return '';
 			}
 
-			// WooCommerce converts negative prices to 0.
+			// WooCommerce converts negative prices to 0 so we do the same here.
 			if ( $price < 0 ) {
 				$price = 0;
 			}

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -929,10 +929,13 @@ class Yoast_WooCommerce_SEO {
 		if (
 			method_exists( $product, 'get_price' )
 			&& method_exists( $product, 'is_type' )
-			&& $product->get_price() !== ''
 		) {
 			if ( $product->is_type( 'variable' ) ) {
 				return $this->get_variable_product_price( $product );
+			}
+
+			if ( $product->is_type( 'grouped' ) ) {
+				return $this->get_grouped_product_price( $product );
 			}
 
 			return wp_strip_all_tags( wc_price( $product->get_price() ), true );
@@ -949,7 +952,11 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The variable product price.
 	 */
 	public function get_variable_product_price( $product ) {
-		if ( method_exists( $product, 'get_variation_price' ) ) {
+		if (
+			method_exists( $product, 'get_variation_price' )
+			&& method_exists( $product, 'wc_price' )
+			&& method_exists( $product, 'wc_format_price_range' )
+		) {
 			$lowest  = $product->get_variation_price( 'min', false );
 			$highest = $product->get_variation_price( 'max', false );
 
@@ -958,6 +965,24 @@ class Yoast_WooCommerce_SEO {
 			}
 
 			return wp_strip_all_tags( wc_format_price_range( $lowest, $highest ), true );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Retrieves a grouped product price.
+	 *
+	 * @param WC_Product $product The product.
+	 *
+	 * @return string The grouped product price.
+	 */
+	public function get_grouped_product_price( $product ) {
+		if ( method_exists( $product, 'get_price_html' ) && method_exists( $product, 'get_price_suffix' ) ) {
+			$price_html   = $product->get_price_html();
+			$price_suffix = $product->get_price_suffix();
+
+			return wp_strip_all_tags( rtrim( $price_html, $price_suffix ), true );
 		}
 
 		return '';

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -926,8 +926,38 @@ class Yoast_WooCommerce_SEO {
 			return '';
 		}
 
-		if ( method_exists( $product, 'get_price' ) ) {
+		if (
+			method_exists( $product, 'get_price' )
+			&& method_exists( $product, 'is_type' )
+			&& $product->get_price() !== ''
+		) {
+			if ( $product->is_type( 'variable' ) ) {
+				return $this->get_variable_product_price( $product );
+			}
+
 			return wp_strip_all_tags( wc_price( $product->get_price() ), true );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Retrieves a variable product price.
+	 *
+	 * @param WC_Product $product The product.
+	 *
+	 * @return string The variable product price.
+	 */
+	public function get_variable_product_price( $product ) {
+		if ( method_exists( $product, 'get_variation_price' ) ) {
+			$lowest  = $product->get_variation_price( 'min', false );
+			$highest = $product->get_variation_price( 'max', false );
+
+			if ( $lowest === $highest ) {
+				return wp_strip_all_tags( wc_price( $lowest ), true );
+			}
+
+			return wp_strip_all_tags( wc_format_price_range( $lowest, $highest ), true );
 		}
 
 		return '';

--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -14,14 +14,14 @@ var modifiableFields = [
 ];
 
 /**
- * Calculates the price based on the set price and sale price.
+ * Gets the localized product active price.
  *
- * @returns {string} The calculated price.
+ * @returns {string} The localized active price.
  */
 function getPrice() {
-	var price = parseFloat( jQuery( "#_regular_price" ).val() );
+	var activePrice = parseFloat( jQuery( "#_sale_price" ).val() ) || parseFloat( jQuery( "#_regular_price" ).val() );
 
-	return price.toLocaleString(
+	return activePrice.toLocaleString(
 		wpseoWooReplaceVarsL10n.locale,
 		{
 			style: "currency",
@@ -133,7 +133,9 @@ var YoastReplaceVarPlugin = function() {
  * @returns {void}
  */
 YoastReplaceVarPlugin.prototype.registerEvents = function() {
-	jQuery( document ).on( "input", "#_regular_price, #_sku", this.declareReloaded.bind( this ) );
+	jQuery( document ).on( "input", "#_regular_price, #_sale_price, #_sku", this.declareReloaded.bind( this ) );
+	// When WooCommerce empties the sale price field with `val( '' )`, for example when higher than the regular price.
+	jQuery( document ).on( "change", "#_sale_price", this.declareReloaded.bind( this ) );
 
 	var brandElements = [ "#taxonomy-product_brand", "#pwb-branddiv" ];
 

--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -14,9 +14,9 @@ var modifiableFields = [
 ];
 
 /**
- * Gets the localized product active price.
+ * Gets the product active price.
  *
- * @returns {string} The localized active price.
+ * @returns {string} The active price.
  */
 function getPrice() {
 	var activePrice = wpseoWooReplaceVarsL10n.price;
@@ -131,9 +131,7 @@ var YoastReplaceVarPlugin = function() {
  * @returns {void}
  */
 YoastReplaceVarPlugin.prototype.registerEvents = function() {
-	jQuery( document ).on( "input", "#_regular_price, #_sale_price, #_sku", this.declareReloaded.bind( this ) );
-	// When WooCommerce empties the sale price field with `val( '' )`, for example when higher than the regular price.
-	jQuery( document ).on( "change", "#_sale_price", this.declareReloaded.bind( this ) );
+	jQuery( document ).on( "input", "#_sku", this.declareReloaded.bind( this ) );
 
 	var brandElements = [ "#taxonomy-product_brand", "#pwb-branddiv" ];
 

--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -19,19 +19,13 @@ var modifiableFields = [
  * @returns {string} The localized active price.
  */
 function getPrice() {
-	var activePrice = parseFloat( jQuery( "#_sale_price" ).val() ) || parseFloat( jQuery( "#_regular_price" ).val() );
+	var activePrice = wpseoWooReplaceVarsL10n.price;
 
-	if ( isNaN( activePrice ) ) {
+	if ( ! activePrice ) {
 		return "";
 	}
 
-	return activePrice.toLocaleString(
-		wpseoWooReplaceVarsL10n.locale,
-		{
-			style: "currency",
-			currency: wpseoWooReplaceVarsL10n.currency,
-		}
-	);
+	return activePrice;
 }
 
 /**

--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -21,6 +21,10 @@ var modifiableFields = [
 function getPrice() {
 	var activePrice = parseFloat( jQuery( "#_sale_price" ).val() ) || parseFloat( jQuery( "#_regular_price" ).val() );
 
+	if ( isNaN( activePrice ) ) {
+		return "";
+	}
+
 	return activePrice.toLocaleString(
 		wpseoWooReplaceVarsL10n.locale,
 		{

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1290,7 +1290,6 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'price'                 => '1.00',
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To provide users with a better `price` replacement variable that outputs the correct price for regular price, sale price, grouped product price, variable product price.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the price replacement variable.

## Relevant technical choices:

- makes sure to use Woo methods that take into account whether a product is on sale thus returning the sale price when appropriate 
- retrieves the product price also in the admin 
- uses the Woo `get_price_html` method for variable and grouped products so that we get a properly formatted _price range_ string
- puts the product price into the l10n object and use that for the snippet preview 
- the price in the snippet preview doesn't update "on the fly" any longer

To do in a separate issue:
- fix empty prices everywhere
- fix negative prices everywhere

[Edit] created https://github.com/Yoast/wpseo-woocommerce/issues/557 for empty / negative prices.

## Test instructions

First, it is important to get how the different product prices work in WooCommerce. To my understanding:

- **simple product:** the price is the product regular price or the sale price 
- **external/affiliate product:** same 
- **grouped product:**
  - the price is a range based on the linked products min and max prices e.g. `€11.00 – €99.00`
  - when the min and max prices are `0`, the grouped product price is a string: `Free!`
- **variable product:** the price is a range based on the product variations min and max prices e.g.: `€9.00 – €33.00`

Most of these can have sale prices and tax included / excluded.


This PR can be tested by following these steps:

Sorry, but these are pretty long instructions.
- in the docker environment:
- install and activate WooCommerce 4.0.0
- clone this `wpseo-woocommerce` repo within your plugins directory and activate the plugin

**Simple product:**
- create a simple product with a regular price 
- in the snippet editor, put the `wc_price` replacement variable in the title and in the description 
- the snippet preview will initially display the price as `0.00`
- publish 
- see the snippet preview now displays the correct price
- see in the front end markup the various titles contain the correct price:
  - the document `<title>` tag 
  - the `og:title`
  - the `twitter:title`
- see in the front end markup the various descriptions contain the correct price:
  - the meta description  
  - the `og:description`
  - the `twitter:description`
- edit the product, enter a sale price, and save
- repeat the previous steps to check the price 
- edit the product and enter sale price dates (click "Schedule" next to the Sale price) 
- save and repeat the previous steps to check the price: it should display the sale price 
- edit the sale price dates and set the "to" date to yesterday so the product isn't on sale any longer 
- save and repeat the previous steps to check the price: it should display the regular price 
- edit and remove the sale price and sale price dates
- enable taxes and create a tax rate to apply to all products as described here: https://github.com/Yoast/wpseo-woocommerce/pull/490#issuecomment-582933357
  - ignore the last bullet point of the instructions, that is no longer necessary
  - make sure the product is set to "Tax status: Taxable" and "Tax class: Standard"
- play with the "Display prices in the shop" setting, changing it to "Including tax" and "Excluding tax"
- each time you change the setting check the price in the snippet preview changes accordingly 
- check the price in the front end markup changes accordingly


**External/Affiliate product:**
This is similar to simple products:
- create an External/Affiliate product
- repeat the simple product steps 

**Grouped product:**
- create 2 - 3 simple products with different prices 
- create a grouped product 
- in the "Product data" meta box > Linked Products tab 
  - add the 2 - 3 simple products
- basically, repeat the steps of the simple product keeping in mind a few differences:
  - the grouped product price will be a range e.g.: `€11.00 – €99.00`
  - a grouped product doesn't have a sale price: its children do have a sale price 
  - the price in the `product:price:amount` meta is wrong: this should be fixed separately 
  - when the child products min and max prices are `0`, the grouped product price is a string: `Free!`
  - with some taxes settings, when min and max prices are `0`, Woo outputs `0.00` instead of `Free!`: this is a Woo bug, reported upstream on https://github.com/woocommerce/woocommerce/issues/25948
  - the Schema product is wrong: this should be fixed separately 


**Variable product:**
- go to Products > Attributes
- create a "Color" attribute 
- create a few attribute terms e.g. "Red", "Green", "Blue"
- create a variable product 
- in the "Product data" meta box > Attributes tab:
  - add the Color attribute to be used as variation 
  - click "Select all" to add the "Red", "Green", "Blue" terms
  - check the "Used for variations" checkbox and press "Save attributes"
- in the "Product data" meta box > Variations
  - keep "add variation" selected and click "Go"
  - in the added variation change "Any Color" to "Blue" and add a variation price
  - repeat to add the Green and Red variations 
  - click "Save changes"
- basically, repeat the steps of the simple product keeping in mind a few differences:
  - the variable product price will be the range of the variations prices e.g. `€7.00 – €9.00`
  - variations do have sale prices and sale price dates 
  - the price in the `product:price:amount` meta is wrong: this should be fixed separately 
  - the product Schema becomes an `AggregateOffer` with each single variation listed as single `Offer`
  - with some tax settings, the single offer prices do change 
  - however, it appears the `lowPrice` and `highPrice` values in the `AggregateOffer` do not change: this seems wrong but it should be fixed separately 


Please do try to break it in any way you can think of and report missed / edge cases 🙂 



Fixes https://github.com/Yoast/featurerequests/issues/83