### PR TITLE
Return early if $data['offers'] is not available

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -143,6 +143,11 @@ class WPSEO_WooCommerce_Schema {
 	 * @return array Schema Product data.
 	 */
 	protected function filter_offers( $data, $product ) {
+		// Bail if $data['offers'] is not available
+		if ( empty( $data['offers'] ) ) {
+			return $data;
+		}
+		
 		$home_url       = trailingslashit( get_site_url() );
 		$data['offers'] = $this->filter_sales( $data['offers'], $product );
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -143,11 +143,11 @@ class WPSEO_WooCommerce_Schema {
 	 * @return array Schema Product data.
 	 */
 	protected function filter_offers( $data, $product ) {
-		// Bail if $data['offers'] is not available
+		// Bail if $data['offers'] is not available.
 		if ( empty( $data['offers'] ) ) {
 			return $data;
 		}
-		
+	
 		$home_url       = trailingslashit( get_site_url() );
 		$data['offers'] = $this->filter_sales( $data['offers'], $product );
 


### PR DESCRIPTION
Not doing so causes an invalid argument supplied for foreach() ErrorException.

## Context
* Return early if $data['offers'] isn't available to prevent errors

## Summary
* Fixes a bug where an ErrorException is thrown when `$data['offers']` is not available when trying to loop over via a `foreach()`

## Relevant technical choices:
* n/a

## Test instructions
* n/a
