### PR TITLE
Check offers data exist before attempting to use it.

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -143,6 +143,10 @@ class WPSEO_WooCommerce_Schema {
 	 * @return array Schema Product data.
 	 */
 	protected function filter_offers( $data, $product ) {
+		if ( ! isset( $data['offers'] ) || $data['offers'] === [] ) {
+			return $data;
+		}
+
 		$home_url       = trailingslashit( get_site_url() );
 		$data['offers'] = $this->filter_sales( $data['offers'], $product );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix PHP notices and warnings shown on the front end.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where PHP notices and warning where thrown for Products without a price.

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

- Install and activate Yoast SEO 13.4 RC3
- Install and activate Woocommerce 4.0.1
- Install and activate SEO Woocommerce switched to this branch
- Create empty product, do not add price
- Browse to the product on the front end
- Add a review
- See there are no PHP notices / warnings

Fixes https://github.com/Yoast/wpseo-woocommerce/issues/560