### PR TITLE
Escape Attribute term

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -300,15 +300,8 @@ class WPSEO_WooCommerce_Schema {
 	 * @param string     $taxonomy  The taxonomy to get the attribute's value from.
 	 */
 	private function add_organization_for_attribute( $attribute, $product, $taxonomy ) {
-		$term = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
-
-		// Escape the string, so harmful input data will not be executed.
-		$escaped_term_name = WPSEO_Utils::format_json_encode( $term->name );
-		// Remove possible double quotes.
-		$stripped_term_name = wp_strip_all_tags( $escaped_term_name );
-		if ( $stripped_term_name[0] === '"' && $stripped_term_name[ ( strlen( $stripped_term_name ) - 1 ) ] === '"' ) {
-			$stripped_term_name = substr( $stripped_term_name, 1, -1 );
-		}
+		$term               = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
+		$stripped_term_name = wp_strip_all_tags( $term->name );
 
 		if ( $term !== null ) {
 			$this->data[ $attribute ] = [

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -274,12 +274,11 @@ class WPSEO_WooCommerce_Schema {
 		if ( $tag_stripped_term_name[0] === '"' && $tag_stripped_term_name[ ( strlen( $tag_stripped_term_name ) - 1 ) ] === '"' ) {
 			$tag_stripped_term_name = substr( $tag_stripped_term_name, 1, -1 );
 		}
-		$term->name = $tag_stripped_term_name;
 
 		if ( $term !== null ) {
 			$this->data[ $attribute ] = [
 				'@type' => 'Organization',
-				'name'  => $term->name,
+				'name'  => $tag_stripped_term_name,
 			];
 		}
 	}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -300,20 +300,20 @@ class WPSEO_WooCommerce_Schema {
 	 * @param string     $taxonomy  The taxonomy to get the attribute's value from.
 	 */
 	private function add_organization_for_attribute( $attribute, $product, $taxonomy ) {
-		$term     = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
-		$termname = $term->name;
+		$term = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
 
-		// Escape the string so that harmful input data will not be executed.
-		$escaped_term_name      = WPSEO_Utils::format_json_encode( $termname );
-		$tag_stripped_term_name = wp_strip_all_tags( $escaped_term_name );
-		if ( $tag_stripped_term_name[0] === '"' && $tag_stripped_term_name[ ( strlen( $tag_stripped_term_name ) - 1 ) ] === '"' ) {
-			$tag_stripped_term_name = substr( $tag_stripped_term_name, 1, -1 );
+		// Escape the string, so harmful input data will not be executed.
+		$escaped_term_name = WPSEO_Utils::format_json_encode( $term->name );
+		// Remove possible double quotes.
+		$stripped_term_name = wp_strip_all_tags( $escaped_term_name );
+		if ( $stripped_term_name[0] === '"' && $stripped_term_name[ ( strlen( $stripped_term_name ) - 1 ) ] === '"' ) {
+			$stripped_term_name = substr( $stripped_term_name, 1, -1 );
 		}
 
 		if ( $term !== null ) {
 			$this->data[ $attribute ] = [
 				'@type' => 'Organization',
-				'name'  => $tag_stripped_term_name,
+				'name'  => $stripped_term_name,
 			];
 		}
 	}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -265,7 +265,16 @@ class WPSEO_WooCommerce_Schema {
 	 * @param string      $taxonomy  The taxonomy to get the attribute's value from.
 	 */
 	private function add_organization_for_attribute( $attribute, $product, $taxonomy ) {
-		$term = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
+		$term     = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
+		$termname = $term->name;
+
+		// Escape the string so that harmful input data will not be executed.
+		$escaped_term_name      = WPSEO_Utils::format_json_encode( $termname );
+		$tag_stripped_term_name = wp_strip_all_tags( $escaped_term_name );
+		if ( $tag_stripped_term_name[0] === '"' && $tag_stripped_term_name[ ( strlen( $tag_stripped_term_name ) - 1 ) ] === '"' ) {
+			$tag_stripped_term_name = substr( $tag_stripped_term_name, 1, -1 );
+		}
+		$term->name = $tag_stripped_term_name;
 
 		if ( $term !== null ) {
 			$this->data[ $attribute ] = [

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -884,6 +884,9 @@ class Schema_Test extends TestCase {
 		$schema_image->expects( '__construct' )->once()->with( $canonical . '#woocommerceimageplaceholder' )->andReturnSelf();
 		$schema_image->expects( 'generate_from_url' )->once()->with( $base_url . '/example_image.jpg' )->andReturn( $image_data );
 
+		$utils->expects( 'format_json_encode' )->twice()->andReturn( 'TestProduct' );
+		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
+
 		$data = [
 			'@type'       => 'Product',
 			'@id'         => $canonical . '#product',
@@ -1049,6 +1052,9 @@ class Schema_Test extends TestCase {
 		$schema_image = Mockery::mock( 'overload:WPSEO_Schema_Image' );
 		$schema_image->expects( '__construct' )->once()->with( $canonical . '#woocommerceimageplaceholder' )->andReturnSelf();
 		$schema_image->expects( 'generate_from_url' )->once()->with( $base_url . '/example_image.jpg' )->andReturn( $image_data );
+
+		$utils->expects( 'format_json_encode' )->twice()->andReturn( 'TestProduct' );
+		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
 		$data = [
 			'@type'       => 'Product',

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -884,7 +884,6 @@ class Schema_Test extends TestCase {
 		$schema_image->expects( '__construct' )->once()->with( $canonical . '#woocommerceimageplaceholder' )->andReturnSelf();
 		$schema_image->expects( 'generate_from_url' )->once()->with( $base_url . '/example_image.jpg' )->andReturn( $image_data );
 
-		$utils->expects( 'format_json_encode' )->twice()->andReturn( 'TestProduct' );
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
 		$data = [
@@ -1057,7 +1056,6 @@ class Schema_Test extends TestCase {
 		$schema_image->expects( '__construct' )->once()->with( $canonical . '#woocommerceimageplaceholder' )->andReturnSelf();
 		$schema_image->expects( 'generate_from_url' )->once()->with( $base_url . '/example_image.jpg' )->andReturn( $image_data );
 
-		$utils->expects( 'format_json_encode' )->twice()->andReturn( 'TestProduct' );
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
 		$data = [
@@ -1177,7 +1175,6 @@ class Schema_Test extends TestCase {
 
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'get_home_url' )->once()->with()->andReturn( $canonical );
-		$utils->expects( 'format_json_encode' )->twice()->andReturn( 'TestProduct' );
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
 		$product = Mockery::mock( 'WC_Product' );

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1177,6 +1177,8 @@ class Schema_Test extends TestCase {
 
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'get_home_url' )->once()->with()->andReturn( $canonical );
+		$utils->expects( 'format_json_encode' )->twice()->andReturn( 'TestProduct' );
+		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to users to not be able of entering possible harmful javascript code into the schema using the attributes

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where possible harmful javascript could be entered in the database and affect a website.

## Relevant technical choices:

* Chosen for `WPSEO_Utils::format_json_encode` over `json_encode` because it is conform the Yoast standards
* Chosen to remove the first and last character of the string if they happen to be double quotes, because otherwise the schema output would include 4 double quotes in total (""example"")


## Test instructions

This PR can be tested by following these steps:

1. Install Yoast SEO (Premium), Woocommerce and wpseo woocommerce
2. Create a product attribute names `brand` and add a term called `banana`
3. In SEO -> WooCommerce SEO -> set Brand to `Product brand`
4. Create a product, give it a price and assign the brand attribute, set it to use `banana`. Save the product.
5. In your database, go to `<wp-prefix>_terms` and lookup `banana`. Change the name to `</script><script>alert(1)</script><script>`
6. Visit the product on the frontend, note that no pop-up shows
7. Inspect the source code and note that in the product graph the `name` of `"brand"` is ""
8. In your database, change the name to `</script><h1>hello</h1><script>`
9. Visit the product on the frontend, note that no `h1` shows and the additional information is the same as the name in the database 
10. Inspect the source code and note that in the product graph the `name` of `"brand"` is "hello"
11. In your database change the name to `Gimli`
12. Visit the product on the frontend, note that the additional information is the same as the name in the database (Gimli)
13. Inspect the source code and note that in the product graph `name` is "Gimli"
14. In your database change the name to `"Gimli"` (with the double quotes)
15. Visit the product on the frontend, note that the additional information is the same as the name in the database ("Gimli") with quotes
16. Inspect the source code and note that in the product graph the quotes are escaped


Fixes Yoast/bugreports#927
