### PR TITLE
QA: use the variable

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -439,7 +439,7 @@ class WPSEO_WooCommerce_Schema {
 
 			if ( wc_tax_enabled() ) {
 				// Only add this property if tax calculation has been enabled in WooCommerce.
-				$offer['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+				$offer['priceSpecification']['valueAddedTaxIncluded'] = $prices_include_tax;
 			}
 
 			$data[] = $offer;


### PR DESCRIPTION
## Context
* Minor performance improvement

## Summary
This PR can be summarized in the following changelog entry:
* Minor performance improvement

## Relevant technical choices:

Above the `foreach` the `$prices_include_tax` variable is defined with the output of the same function call, so we may as well use it and remove the redundant repeated function call which would always have the same output anyway.

:arrow_right:  _Leaving this open for someone to quickly look this over in case I'm missing some context and the return value of the function call could change during the running of the loop._

## Test instructions

This PR can be tested by following these steps:

* This PR should have no impact on the functionality, so the schema code added for offers should be the same before and after.
