### PR TITLE
Hide all Yoast columns in the Product overview page except the SEO Score column

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 		 *
 		 * @var int
 		 */
-		public $db_version = 3;
+		public $db_version = 4;
 
 		/**
 		 * Array of defaults for the option.
@@ -56,15 +56,14 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 		 */
 		protected $defaults = [
 			// Non-form fields, set via validation routine.
-			'woo_dbversion'                 => 0, // Leave default as 0 to ensure activation/upgrade works.
+			'woo_dbversion'           => 0, // Leave default as 0 to ensure activation/upgrade works.
 
 			// Form fields.
-			'woo_schema_brand'              => '',
-			'woo_schema_manufacturer'       => '',
-			'woo_schema_color'              => '',
-			'woo_breadcrumbs'               => true,
-			'woo_hide_columns'              => true,
-			'woo_metabox_top'               => true,
+			'woo_schema_brand'        => '',
+			'woo_schema_manufacturer' => '',
+			'woo_schema_color'        => '',
+			'woo_breadcrumbs'         => true,
+			'woo_metabox_top'         => true,
 		];
 
 		/**
@@ -152,7 +151,6 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 
 					/* boolean (checkbox) field - may not be in form */
 					case 'woo_breadcrumbs':
-					case 'woo_hide_columns':
 					case 'woo_metabox_top':
 						if ( isset( $dirty[ $key ] ) ) {
 							$clean[ $key ] = WPSEO_Utils::validate_bool( $dirty[ $key ] );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -492,15 +492,10 @@ class Yoast_WooCommerce_SEO {
 	 * @return array Array with the filtered columns.
 	 */
 	public function column_heading( $columns ) {
-		if ( WPSEO_Options::get( 'woo_hide_columns' ) !== true ) {
-			return $columns;
-		}
-
 		$keys_to_remove = [
 			'wpseo-title',
 			'wpseo-metadesc',
 			'wpseo-focuskw',
-			'wpseo-score',
 			'wpseo-score-readability',
 		];
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -442,24 +442,6 @@ class Yoast_WooCommerce_SEO {
 		echo '<p>';
 		printf(
 		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce */
-			esc_html__( 'Both %2$s and %1$s add columns to the product page, to remove all but the SEO score column from %1$s on that page, check this box.', 'yoast-woo-seo' ),
-			'Yoast SEO',
-			'WooCommerce'
-		);
-		echo "</p>\n";
-
-		Yoast_Form::get_instance()->checkbox(
-			'woo_hide_columns',
-			sprintf(
-			/* translators: %1$s resolves to Yoast SEO */
-				esc_html__( 'Remove %1$s columns', 'yoast-woo-seo' ),
-				'Yoast SEO'
-			)
-		);
-
-		echo '<p>';
-		printf(
-		/* translators: %1$s resolves to Yoast SEO, %2$s resolves to WooCommerce */
 			esc_html__( 'Both %2$s and %1$s add metaboxes to the edit product page, if you want %2$s to be above %1$s, check the box.', 'yoast-woo-seo' ),
 			'Yoast SEO',
 			'WooCommerce'

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -69,7 +69,6 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 			[ 'woo_schema_manufacturer', 'yoast', 'yoast', 'yoast', null ],
 			[ 'woo_schema_color', 'yoast', 'yoast', 'yoast', null ],
 			[ 'woo_breadcrumbs', true, true, true, '' ],
-			[ 'woo_hide_columns', true, true, true, '' ],
 			[ 'woo_metabox_top', true, true, true, '' ],
 
 			// Validation where the dirty value is not in the validate data types.
@@ -77,7 +76,6 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 			[ 'woo_schema_manufacturer', 'bar', 'bar', 'yoast', null ],
 			[ 'woo_schema_color', 'bar', 'bar', 'yoast', null ],
 			[ 'woo_breadcrumbs', false, null, true, '' ],
-			[ 'woo_hide_columns', false, null, true, '' ],
 			[ 'woo_metabox_top', false, null, true, '' ],
 
 			// Validation where the old value is in the validate data types with short form enabled.
@@ -97,17 +95,14 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 			// Validation where the boolean old value is set with short form enabled.
 			[ 'woo_breadcrumbs', true, null, true, true, 'on' ],
-			[ 'woo_hide_columns', true, null, true, true, 'on' ],
 			[ 'woo_metabox_top', true, null, true, true, 'on' ],
 
 			// Validation where the boolean old value is not set with short form enabled.
 			[ 'woo_breadcrumbs', false, null, true, null, 'on' ],
-			[ 'woo_hide_columns', false, null, true, null, 'on' ],
 			[ 'woo_metabox_top', false, null, true, null, 'on' ],
 
 			// Validation where the boolean old value is not set with short form not enabled.
 			[ 'woo_breadcrumbs', false, null, true, true, 'off' ],
-			[ 'woo_hide_columns', false, null, true, true, 'off' ],
 			[ 'woo_metabox_top', false, null, true, true, 'off' ],
 		];
 	}

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -62,7 +62,7 @@ class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 			[ 'test', null, 123, null, null ],
 
 			// Tests the validation of the dbversion option.
-			[ 'woo_dbversion', 3, 1, 3, '' ],
+			[ 'woo_dbversion', 4, 1, 4, '' ],
 
 			// Tests the validation of the fields where the dirty value exists in the validate data types.
 			[ 'woo_schema_brand', 'yoast', 'yoast', 'yoast', null ],

--- a/integration-tests/woocommerce-seo-test.php
+++ b/integration-tests/woocommerce-seo-test.php
@@ -16,8 +16,6 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 	 * @covers Yoast_WooCommerce_SEO::column_heading
 	 */
 	public function test_column_heading() {
-		WPSEO_Option_Woo::register_option();
-
 		$woocommerce = new Yoast_WooCommerce_SEO();
 
 		$columns = [

--- a/integration-tests/woocommerce-seo-test.php
+++ b/integration-tests/woocommerce-seo-test.php
@@ -20,16 +20,28 @@ class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 		$woocommerce = new Yoast_WooCommerce_SEO();
 
-		WPSEO_Options::set( 'woo_hide_columns', true );
+		$columns = [
+			'another-column'          => '',
+			'wpseo-title'             => '',
+			'wpseo-metadesc'          => '',
+			'wpseo-focuskw'           => '',
+			'wpseo-score'             => '',
+			'wpseo-score-readability' => '',
+		];
 
-		$actual   = $woocommerce->column_heading(
-			[
-				'wpseo-title'    => '',
-				'another-column' => '',
-				'wpseo-focuskw'  => '',
-			]
-		);
-		$expected = [ 'another-column' => '' ];
+		if ( class_exists( 'WPSEO_Link_Columns' ) ) {
+			$columns += [
+				'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKS  => '',
+				'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKED => '',
+			];
+		}
+
+		$actual = $woocommerce->column_heading( $columns );
+
+		$expected = [
+			'another-column' => '',
+			'wpseo-score'    => '',
+		];
 
 		$this->assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Simplify the plugin settings by prodiving sane defaults

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides all Yoast columns in the Product overview page except the SEO Score column.

## Relevant technical choices:

- removes `woo_hide_columns` from the `wpseo_woo` option in the database
- removes related code used to validate the `woo_hide_columns` option
- adjusts existing test to check all columns except SEO Score aren't displayed

## Test instructions

This PR can be tested by following these steps:
- activate and install Yoast SEO, WooCommerce, and WooCommerce SEO switched to this branch
- check in the database table `wp_options` > option_name `wpseo_woo` there's no `woo_hide_columns` 
- in the admin, go to SEO > WooCommerce SEO and see there's no UI to hide columns any longer (refer to the screenshot on the issue)
- go to the WooCommerce Products overview page and see all the Yoast table columns (focus keyword, title, description, etc.) aren't displayed except the SEO Score one
- click on "Screen Options" at the top right of the page
- uncheck / check the `SEO score` checkbox to hide / unhide the SEO Score column and check it works as expected

## Note
When merging, ask team blog in collaboration with support to write a help article about how to use the Screen options to hide these columns. /cc @tacoverdo @willemientje

Fixes https://github.com/Yoast/featurerequests/issues/464