### PR TITLE
Removal of the use statements

### DIFF
--- a/classes/presenters/woocommerce-abstract-product-presenter.php
+++ b/classes/presenters/woocommerce-abstract-product-presenter.php
@@ -5,7 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WC_Product;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**

--- a/classes/presenters/woocommerce-pinterest-product-availability-presenter.php
+++ b/classes/presenters/woocommerce-pinterest-product-availability-presenter.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Availability_Presenter;
-
 /**
  * Represents the Pinterest product availability.
  */

--- a/classes/presenters/woocommerce-product-availability-presenter.php
+++ b/classes/presenters/woocommerce-product-availability-presenter.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Availability_Presenter;
-
 /**
  * Represents the product's availability.
  */

--- a/classes/presenters/woocommerce-product-brand-presenter.php
+++ b/classes/presenters/woocommerce-product-brand-presenter.php
@@ -5,9 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Presenter;
-use WPSEO_WooCommerce_Utils;
-
 /**
  * Represents the product's brand.
  */

--- a/classes/presenters/woocommerce-product-condition-presenter.php
+++ b/classes/presenters/woocommerce-product-condition-presenter.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Presenter;
-
 /**
  * Represents the product's condition.
  */

--- a/classes/presenters/woocommerce-product-opengraph-deprecation-presenter.php
+++ b/classes/presenters/woocommerce-product-opengraph-deprecation-presenter.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Presenter;
-
 /**
  * Represents the deprecated OpenGraph action.
  */

--- a/classes/presenters/woocommerce-product-price-amount-presenter.php
+++ b/classes/presenters/woocommerce-product-price-amount-presenter.php
@@ -5,9 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Presenter;
-use WPSEO_WooCommerce_Utils;
-
 /**
  * Represents the product's price amount.
  */

--- a/classes/presenters/woocommerce-product-price-currency-presenter.php
+++ b/classes/presenters/woocommerce-product-price-currency-presenter.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Presenter;
-
 /**
  * Represents the product's price currency.
  */

--- a/classes/presenters/woocommerce-product-retailer-item-id-presenter.php
+++ b/classes/presenters/woocommerce-product-retailer-item-id-presenter.php
@@ -5,8 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use WPSEO_WooCommerce_Abstract_Product_Presenter;
-
 /**
  * Represents the product's retailer item ID.
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There is no need to have `use` statements for no-namespaced classes. This might result in PHP warnings:
```
Warning: The use statement with non-compound name 'WPSEO_WooCommerce_Abstract_Product_Presenter' has no effect in /var/www/html/wp-content/plugins/wpseo-woocommerce/classes/presenters/woocommerce-product-price-currency-presenter.php on line 8 Call Stack: 0.0017 401912 1. {main}() /var/www/html/index.php:0 0.0030 402184 2. require('/var/www/html/wp-blog-header.php') /var/www/html/index.php:17 3.3847 7517880 3. require_once('/var/www/html/wp-includes/template-loader.php') /var/www/html/wp-blog-header.php:19 3.4056 7536616 4. include('/var/www/html/wp-content/plugins/woocommerce/templates/single-product.php') /var/www/html/wp-includes/template-loader.php:106 3.4056 7536616 5. get_header() /var/www/html/wp-content/plugins/woocommerce/templates/single-product.php:22 3.4058 7543416 6. locate_template() /var/www/html/wp-includes/general-template.php:41 3.4085 7543496 7. load_template() /var/www/html/wp-includes/template.php:672 3.4090 7544016 8. require_once('/var/www/html/wp-content/themes/twentytwenty/header.php') /var/www/html/wp-includes/template.php:723 3.4098 7553976 9. wp_head() /var/www/html/wp-content/themes/twentytwenty/header.php:23 3.4098 7553976 10. do_action() /var/www/html/wp-includes/general-template.php:2884 3.4098 7554352 11. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:478 3.4098 7554352 12. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:311 3.4564 7709280 13. Yoast\WP\SEO\Integrations\Front_End_Integration->call_wpseo_head() /var/www/html/wp-includes/class-wp-hook.php:287 3.4584 7730768 14. do_action() /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php:244 3.4584 7731144 15. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:478 3.4584 7731144 16. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:311 3.4584 7732272 17. Yoast\WP\SEO\Integrations\Front_End_Integration->present_head() /var/www/html/wp-includes/class-wp-hook.php:287 3.4905 7839264 18. Yoast\WP\SEO\Integrations\Front_End_Integration->get_presenters() /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php:254 3.5397 7933296 19. apply_filters() /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php:292 3.5397 7933696 20. WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:206 3.5397 7935200 21. Yoast_WooCommerce_SEO->add_frontend_presenter() /var/www/html/wp-includes/class-wp-hook.php:287 3.5512 7951392 22. spl_autoload_call() /var/www/html/wp-content/plugins/wpseo-woocommerce/classes/woocommerce-seo.php:154 3.5512 7951472 23. Composer\Autoload\ClassLoader->loadClass() /var/www/html/wp-content/plugins/wpseo-woocommerce/classes/woocommerce-seo.php:154 3.5512 7951472 24. Composer\Autoload\includeFile() /var/www/html/wp-content/plugins/wordpress-seo/vendor/composer/ClassLoader.php:322 Warning: The use statement with non-compound name 'WPSEO_WooCommerce_Abstract_Product_Presenter' has no effect in /var/www/html/wp-content/plugins/wpseo-woocommerce/classes/presenters/woocommerce-product-retailer-item-id-presenter.php on line 8 Call Stack: 0.0017 401912 1. {main}() /var/www/html/index.php:0 0.0030 402184 2. require('/var/www/html/wp-blog-header.php') /var/www/html/index.php:17 3.3847 7517880 3. require_once('/var/www/html/wp-includes/template-loader.php') /var/www/html/wp-blog-header.php:19 3.4056 7536616 4. include('/var/www/html/wp-content/plugins/woocommerce/templates/single-product.php') /var/www/html/wp-includes/template-loader.php:106 3.4056 7536616 5. get_header() /var/www/html/wp-content/plugins/woocommerce/templates/single-product.php:22 3.4058 7543416 6. locate_template() /var/www/html/wp-includes/general-template.php:41 3.4085 7543496 7. load_template() /var/www/html/wp-includes/template.php:672 3.4090 7544016 8. require_once('/var/www/html/wp-content/themes/twentytwenty/header.php') /var/www/html/wp-includes/template.php:723 3.4098 7553976 9. wp_head() /var/www/html/wp-content/themes/twentytwenty/header.php:23 3.4098 7553976 10. do_action() /var/www/html/wp-includes/general-template.php:2884 3.4098 7554352 11. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:478 3.4098 7554352 12. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:311 3.4564 7709280 13. Yoast\WP\SEO\Integrations\Front_End_Integration->call_wpseo_head() /var/www/html/wp-includes/class-wp-hook.php:287 3.4584 7730768 14. do_action() /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php:244 3.4584 7731144 15. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:478 3.4584 7731144 16. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:311 3.4584 7732272 17. Yoast\WP\SEO\Integrations\Front_End_Integration->present_head() /var/www/html/wp-includes/class-wp-hook.php:287 3.4905 7839264 18. Yoast\WP\SEO\Integrations\Front_End_Integration->get_presenters() /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php:254 3.5397 7933296 19. apply_filters() /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/front-end-integration.php:292 3.5397 7933696 20. WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:206 3.5397 7935200 21. Yoast_WooCommerce_SEO->add_frontend_presenter() /var/www/html/wp-includes/class-wp-hook.php:287 3.5718 7955856 22. spl_autoload_call() /var/www/html/wp-content/plugins/wpseo-woocommerce/classes/woocommerce-seo.php:162 3.5718 7955936 23. Composer\Autoload\ClassLoader->loadClass() /var/www/html/wp-content/plugins/wpseo-woocommerce/classes/woocommerce-seo.php:162 3.5718 7955936 24. Composer\Autoload\includeFile() /var/www/html/wp-content/plugins/wordpress-seo/vendor/composer/ClassLoader.php:322
```

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It removes some PHP warnings.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

**Note:** Sometimes the warnings are given and sometimes not. I've no clue why. Make sure everything works like behore.

* Disable query monitor and any other debug plugins
* Checkout the release branch
* Create and visit a product and see the warnings at the top of the page
* Checkout this branch and see the warnings gone away.

Fixes #
