### PR TITLE
Remove OpenGraph description override

### DIFF
--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -19,7 +19,6 @@ class WPSEO_WooCommerce_OpenGraph {
 	public function __construct() {
 		add_filter( 'language_attributes', [ $this, 'product_namespace' ], 11 );
 		add_filter( 'wpseo_opengraph_type', [ $this, 'return_type_product' ] );
-		add_filter( 'wpseo_opengraph_desc', [ $this, 'product_taxonomy_desc_enhancement' ] );
 
 		add_action( 'wpseo_add_opengraph_additional_images', [ $this, 'set_opengraph_image' ] );
 	}
@@ -42,11 +41,16 @@ class WPSEO_WooCommerce_OpenGraph {
 	/**
 	 * Make sure the OpenGraph description is put out.
 	 *
+	 * @deprecated 13.0
+	 * @codeCoverageIgnore
+	 *
 	 * @param string $desc The current description, will be overwritten if we're on a product page.
 	 *
 	 * @return string
 	 */
 	public function product_taxonomy_desc_enhancement( $desc ) {
+		_deprecated_function( __METHOD__, 'WPSEO Woo 13.0' );
+
 		if ( is_product_taxonomy() ) {
 			$term_desc = term_description();
 

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -24,7 +24,6 @@ class OpenGraph_Test extends TestCase {
 
 		$this->assertTrue( \has_filter( 'language_attributes', [ $og, 'product_namespace' ] ) );
 		$this->assertTrue( \has_filter( 'wpseo_opengraph_type', [ $og, 'return_type_product' ] ) );
-		$this->assertTrue( \has_filter( 'wpseo_opengraph_desc', [ $og, 'product_taxonomy_desc_enhancement' ] ) );
 		$this->assertTrue( \has_action( 'wpseo_add_opengraph_additional_images', [ $og, 'set_opengraph_image' ] ) );
 	}
 
@@ -49,34 +48,6 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 		$this->assertSame( 'article', $og->return_type_product( 'article' ) );
-	}
-
-	/**
-	 * Test the OpenGraph description enhancement.
-	 *
-	 * @covers WPSEO_WooCommerce_OpenGraph::product_taxonomy_desc_enhancement
-	 */
-	public function test_product_taxonomy_desc_enhancement() {
-		Functions\stubs(
-			[
-				'is_product_taxonomy' => false,
-			]
-		);
-
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertSame( 'example description', $og->product_taxonomy_desc_enhancement( 'example description' ) );
-
-		$expected = 'This is our expected description';
-
-		Functions\stubs(
-			[
-				'is_product_taxonomy' => true,
-				'term_description'    => $expected,
-				'wp_strip_all_tags'   => null,
-				'strip_shortcodes'    => null,
-			]
-		);
-		$this->assertSame( $expected, $og->product_taxonomy_desc_enhancement( 'example description' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove the OpenGraph description override because that is already done in Yoast SEO itself.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Unifies the OpenGraph description callbacks as per https://developer.yoast.com/features/meta-tags/.

## Relevant technical choices:

* Deprecate function.
* Remove/adjust related tests.

## Test instructions

This PR can be tested by following these steps:

* Make sure you  have configured template for product categories:
<img width="654" alt="Screenshot 2020-04-13 at 09 05 53" src="https://user-images.githubusercontent.com/19681708/79100144-ff807900-7d65-11ea-8118-911eafbeb0aa.png">

* Start creating new product category with empty content, see that default template is applied:
<img width="428" alt="Screenshot 2020-04-13 at 09 08 15" src="https://user-images.githubusercontent.com/19681708/79100239-52f2c700-7d66-11ea-8b58-7d249e6e93a7.png">

* Publish category and check description tags (where before the `og:description` would be `content`):

```
<meta name="description" content="default" />
<meta property="og:description" content="default" />
```

Fixes #581 
