### PR TITLE
Add presenter tests

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -142,4 +142,9 @@
 		</properties>
 	</rule>
 
+	<!-- Disable max classname sniff in the tests for now. -->
+	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
+		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -142,9 +142,9 @@
 		</properties>
 	</rule>
 
-	<!-- Disable max classname sniff in the tests for now. -->
+	<!-- Disable max classname sniff in the tests/classes/presenters for now. -->
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
-		<exclude-pattern>/tests/*\.php$</exclude-pattern>
+		<exclude-pattern>/tests/classes/presenters/*\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/classes/presenters/woocommerce-product-opengraph-deprecation-presenter.php
+++ b/classes/presenters/woocommerce-product-opengraph-deprecation-presenter.php
@@ -22,9 +22,9 @@ class WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter extends WPSEO_Wo
 		 * @since 12.6.0
 		 * @deprecated 13.0
 		 *
-		 * @api   WC_Product $product The WooCommerce product we're outputting for.
+		 * @api array $product The WooCommerce product we're outputting for.
 		 */
-		do_action_deprecated( 'Yoast\WP\Woocommerce\opengraph', $this->product, 'WPSEO Woo 13.0', 'wpseo_frontend_presenters' );
+		do_action_deprecated( 'Yoast\WP\Woocommerce\opengraph', (array) $this->product, 'WPSEO Woo 13.0', 'wpseo_frontend_presenters' );
 
 		return '';
 	}

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Pinterest_Product_Availability_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter
+ *
+ * @group presenters
+ */
+class Pinterest_Product_Availability_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 * @covers \WPSEO_WooCommerce_Abstract_Product_Availability_Presenter::__construct
+	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
+	 */
+	public function test_construct() {
+		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, true );
+
+		$this->assertAttributeEquals( $this->product, 'product', $instance );
+		$this->assertAttributeEquals( false, 'is_on_backorder', $instance );
+		$this->assertAttributeEquals( true, 'is_in_stock', $instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false );
+
+		$this->assertAttributeEquals( '<meta property="og:availability" content="%s" />', 'tag_format', $instance );
+	}
+
+	/**
+	 * Tests that the fallback is out of stock.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, false );
+
+		$this->assertEquals( 'out of stock', $instance->get() );
+	}
+
+	/**
+	 * Tests on backorder.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_on_backorder() {
+		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, true );
+
+		$this->assertEquals( 'backorder', $instance->get() );
+	}
+
+	/**
+	 * Tests in stock.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_in_stock() {
+		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, true );
+
+		$this->assertEquals( 'instock', $instance->get() );
+	}
+}

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -45,8 +45,8 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, true );
 
 		$this->assertAttributeEquals( $this->product, 'product', $instance );
-		$this->assertAttributeEquals( false, 'is_on_backorder', $instance );
-		$this->assertAttributeEquals( true, 'is_in_stock', $instance );
+		$this->assertAttributeSame( false, 'is_on_backorder', $instance );
+		$this->assertAttributeSame( true, 'is_in_stock', $instance );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_tag_format() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false );
 
-		$this->assertAttributeEquals( '<meta property="og:availability" content="%s" />', 'tag_format', $instance );
+		$this->assertAttributeSame( '<meta property="og:availability" content="%s" />', 'tag_format', $instance );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_get() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, false );
 
-		$this->assertEquals( 'out of stock', $instance->get() );
+		$this->assertSame( 'out of stock', $instance->get() );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_get_on_backorder() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, true );
 
-		$this->assertEquals( 'backorder', $instance->get() );
+		$this->assertSame( 'backorder', $instance->get() );
 	}
 
 	/**
@@ -90,6 +90,6 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_get_in_stock() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, true );
 
-		$this->assertEquals( 'instock', $instance->get() );
+		$this->assertSame( 'instock', $instance->get() );
 	}
 }

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -51,6 +51,8 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false );

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -45,8 +45,8 @@ class Product_Availability_Presenter_Test extends TestCase {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, true );
 
 		$this->assertAttributeEquals( $this->product, 'product', $instance );
-		$this->assertAttributeEquals( false, 'is_on_backorder', $instance );
-		$this->assertAttributeEquals( true, 'is_in_stock', $instance );
+		$this->assertAttributeSame( false, 'is_on_backorder', $instance );
+		$this->assertAttributeSame( true, 'is_in_stock', $instance );
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_tag_format() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false );
 
-		$this->assertAttributeEquals( '<meta property="product:availability" content="%s" />', 'tag_format', $instance );
+		$this->assertAttributeSame( '<meta property="product:availability" content="%s" />', 'tag_format', $instance );
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_get() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, false );
 
-		$this->assertEquals( 'out of stock', $instance->get() );
+		$this->assertSame( 'out of stock', $instance->get() );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_get_on_backorder() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, true );
 
-		$this->assertEquals( 'available for order', $instance->get() );
+		$this->assertSame( 'available for order', $instance->get() );
 	}
 
 	/**
@@ -90,6 +90,6 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_get_in_stock() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, true );
 
-		$this->assertEquals( 'instock', $instance->get() );
+		$this->assertSame( 'instock', $instance->get() );
 	}
 }

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Product_Availability_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Product_Availability_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_Availability_Presenter
+ *
+ * @group presenters
+ */
+class Product_Availability_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 * @covers \WPSEO_WooCommerce_Abstract_Product_Availability_Presenter::__construct
+	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
+	 */
+	public function test_construct() {
+		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, true );
+
+		$this->assertAttributeEquals( $this->product, 'product', $instance );
+		$this->assertAttributeEquals( false, 'is_on_backorder', $instance );
+		$this->assertAttributeEquals( true, 'is_in_stock', $instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false );
+
+		$this->assertAttributeEquals( '<meta property="product:availability" content="%s" />', 'tag_format', $instance );
+	}
+
+	/**
+	 * Tests that the fallback is out of stock.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, false );
+
+		$this->assertEquals( 'out of stock', $instance->get() );
+	}
+
+	/**
+	 * Tests on backorder.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_on_backorder() {
+		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, true );
+
+		$this->assertEquals( 'available for order', $instance->get() );
+	}
+
+	/**
+	 * Tests in stock.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_in_stock() {
+		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, true );
+
+		$this->assertEquals( 'instock', $instance->get() );
+	}
+}

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -51,6 +51,8 @@ class Product_Availability_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false );

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -65,6 +65,8 @@ class Product_Brand_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$this->assertAttributeEquals( '<meta property="product:brand" content="%s" />', 'tag_format', $this->instance );

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -47,12 +47,27 @@ class Product_Brand_Presenter_Test extends TestCase {
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
 
 		$this->product = Mockery::mock( 'WC_Product' );
-		$this->product->expects( 'get_id' )->andReturn( 1 );
 
 		$this->instance          = new WPSEO_WooCommerce_Product_Brand_Presenter( $this->product );
 		$this->instance->helpers = (object) [
 			'options' => Mockery::mock( 'Yoast\WP\SEO\Helpers\Options_Helper' ),
 		];
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$this->assertAttributeEquals( '<meta property="product:brand" content="%s" />', 'tag_format', $this->instance );
 	}
 
 	/**
@@ -71,6 +86,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->andReturn( $schema_brand );
 
 		// Tests for `get_brand_term_name`.
+		$this->product->expects( 'get_id' )->andReturn( 1 );
 		Mockery::mock( 'overload:WPSEO_Primary_Term' )
 			->expects( 'get_primary_term' )
 			->once()
@@ -108,6 +124,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->andReturn( $schema_brand );
 
 		// Tests for `get_brand_term_name`.
+		$this->product->expects( 'get_id' )->andReturn( 1 );
 		Mockery::mock( 'overload:WPSEO_Primary_Term' )
 			->expects( 'get_primary_term' )
 			->once()
@@ -139,6 +156,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->andReturn( $schema_brand );
 
 		// Tests for `get_brand_term_name`.
+		$this->product->expects( 'get_id' )->andReturn( 1 );
 		Mockery::mock( 'overload:WPSEO_Primary_Term' )
 			->expects( 'get_primary_term' )
 			->once()

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -43,10 +43,12 @@ class Product_Brand_Presenter_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		// Needs to exist.
+		// Needs to exist as WPSEO_WooCommerce_Product_Brand_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
 
-		$this->product           = Mockery::mock( 'WC_Product' );
+		$this->product = Mockery::mock( 'WC_Product' );
+		$this->product->expects( 'get_id' )->andReturn( 1 );
+
 		$this->instance          = new WPSEO_WooCommerce_Product_Brand_Presenter( $this->product );
 		$this->instance->helpers = (object) [
 			'options' => Mockery::mock( 'Yoast\WP\SEO\Helpers\Options_Helper' ),
@@ -69,10 +71,9 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->andReturn( $schema_brand );
 
 		// Tests for `get_brand_term_name`.
-		Mockery::mock( 'overload:WPSEO_WooCommerce_Utils' )
-			->expects( 'search_primary_term' )
+		Mockery::mock( 'overload:WPSEO_Primary_Term' )
+			->expects( 'get_primary_term' )
 			->once()
-			->with( [ $schema_brand ], $this->product )
 			->andReturn( '' );
 		Functions\expect( 'get_the_ID' )
 			->once()
@@ -107,10 +108,9 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->andReturn( $schema_brand );
 
 		// Tests for `get_brand_term_name`.
-		Mockery::mock( 'overload:WPSEO_WooCommerce_Utils' )
-			->expects( 'search_primary_term' )
+		Mockery::mock( 'overload:WPSEO_Primary_Term' )
+			->expects( 'get_primary_term' )
 			->once()
-			->with( [ $schema_brand ], $this->product )
 			->andReturn( '' );
 		Functions\expect( 'get_the_ID' )
 			->once()
@@ -139,12 +139,15 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->andReturn( $schema_brand );
 
 		// Tests for `get_brand_term_name`.
-		Mockery::mock( 'overload:WPSEO_WooCommerce_Utils' )
-			->expects( 'search_primary_term' )
+		Mockery::mock( 'overload:WPSEO_Primary_Term' )
+			->expects( 'get_primary_term' )
 			->once()
-			->with( [ $schema_brand ], $this->product )
 			->andReturn( 'primary' );
+		Functions\expect( 'get_term_by' )
+			->once()
+			->with( 'id', 'primary', 'test-brand' )
+			->andReturn( (object) [ 'name' => 'primary term' ] );
 
-		$this->assertEquals( 'primary', $this->instance->get() );
+		$this->assertEquals( 'primary term', $this->instance->get() );
 	}
 }

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WPSEO_WooCommerce_Product_Brand_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Product_Brand_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_Brand_Presenter
+ *
+ * @group presenters
+ */
+class Product_Brand_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \Yoast\WP\SEO\Helpers\Options_Helper|\Mockery\MockInterface
+	 */
+	protected $options;
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var WPSEO_WooCommerce_Product_Brand_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product           = Mockery::mock( 'WC_Product' );
+		$this->instance          = new WPSEO_WooCommerce_Product_Brand_Presenter( $this->product );
+		$this->instance->helpers = (object) [
+			'options' => Mockery::mock( 'Yoast\WP\SEO\Helpers\Options_Helper' ),
+		];
+	}
+
+	/**
+	 * Tests that the get function returns the first brand found.
+	 *
+	 * @covers ::get
+	 * @covers ::get_brand_term_name
+	 */
+	public function test_get() {
+		$schema_brand = 'test-brand';
+
+		$this->instance->helpers->options
+			->expects( 'get' )
+			->once()
+			->with( 'woo_schema_brand' )
+			->andReturn( $schema_brand );
+
+		// Tests for `get_brand_term_name`.
+		Mockery::mock( 'overload:WPSEO_WooCommerce_Utils' )
+			->expects( 'search_primary_term' )
+			->once()
+			->with( [ $schema_brand ], $this->product )
+			->andReturn( '' );
+		Functions\expect( 'get_the_ID' )
+			->once()
+			->andReturn( 123 );
+		Functions\expect( 'get_the_terms' )
+			->once()
+			->with( 123, $schema_brand )
+			->andReturn(
+				[
+					(object) [ 'name' => 'first' ],
+					(object) [ 'name' => 'second' ],
+					(object) [ 'name' => 'third' ],
+				]
+			);
+
+		$this->assertEquals( 'first', $this->instance->get() );
+	}
+
+	/**
+	 * Tests that the get function returns an empty string when no brands are found.
+	 *
+	 * @covers ::get
+	 * @covers ::get_brand_term_name
+	 */
+	public function test_get_without_brands() {
+		$schema_brand = 'test-brand';
+
+		$this->instance->helpers->options
+			->expects( 'get' )
+			->once()
+			->with( 'woo_schema_brand' )
+			->andReturn( $schema_brand );
+
+		// Tests for `get_brand_term_name`.
+		Mockery::mock( 'overload:WPSEO_WooCommerce_Utils' )
+			->expects( 'search_primary_term' )
+			->once()
+			->with( [ $schema_brand ], $this->product )
+			->andReturn( '' );
+		Functions\expect( 'get_the_ID' )
+			->once()
+			->andReturn( 123 );
+		Functions\expect( 'get_the_terms' )
+			->once()
+			->with( 123, $schema_brand )
+			->andReturn( [] );
+
+		$this->assertEquals( '', $this->instance->get() );
+	}
+
+	/**
+	 * Tests that the get function returns the primary brand.
+	 *
+	 * @covers ::get
+	 * @covers ::get_brand_term_name
+	 */
+	public function test_get_primary_brand() {
+		$schema_brand = 'test-brand';
+
+		$this->instance->helpers->options
+			->expects( 'get' )
+			->once()
+			->with( 'woo_schema_brand' )
+			->andReturn( $schema_brand );
+
+		// Tests for `get_brand_term_name`.
+		Mockery::mock( 'overload:WPSEO_WooCommerce_Utils' )
+			->expects( 'search_primary_term' )
+			->once()
+			->with( [ $schema_brand ], $this->product )
+			->andReturn( 'primary' );
+
+		$this->assertEquals( 'primary', $this->instance->get() );
+	}
+}

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -69,7 +69,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeEquals( '<meta property="product:brand" content="%s" />', 'tag_format', $this->instance );
+		$this->assertAttributeSame( '<meta property="product:brand" content="%s" />', 'tag_format', $this->instance );
 	}
 
 	/**
@@ -107,7 +107,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 				]
 			);
 
-		$this->assertEquals( 'first', $this->instance->get() );
+		$this->assertSame( 'first', $this->instance->get() );
 	}
 
 	/**
@@ -139,7 +139,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->with( 123, $schema_brand )
 			->andReturn( [] );
 
-		$this->assertEquals( '', $this->instance->get() );
+		$this->assertSame( '', $this->instance->get() );
 	}
 
 	/**
@@ -168,6 +168,6 @@ class Product_Brand_Presenter_Test extends TestCase {
 			->with( 'id', 'primary', 'test-brand' )
 			->andReturn( (object) [ 'name' => 'primary term' ] );
 
-		$this->assertEquals( 'primary term', $this->instance->get() );
+		$this->assertSame( 'primary term', $this->instance->get() );
 	}
 }

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Brain\Monkey\Filters;
+use Mockery;
+use WPSEO_WooCommerce_Product_Condition_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Product_Condition_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_Condition_Presenter
+ *
+ * @group presenters
+ */
+class Product_Condition_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var WPSEO_WooCommerce_Product_Condition_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+
+		$this->instance = new WPSEO_WooCommerce_Product_Condition_Presenter( $this->product );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$this->assertAttributeEquals( '<meta property="product:condition" content="%s" />', 'tag_format', $this->instance );
+	}
+
+	/**
+	 * Tests that the filter is applied.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		Filters\expectApplied( 'Yoast\WP\Woocommerce\product_condition' )
+			->once()
+			->with( 'new', $this->product )
+			->andReturn( 'condition' );
+
+		$this->assertEquals( 'condition', $this->instance->get() );
+	}
+
+	/**
+	 * Tests that the filter output is converted to a string.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_string_conversion() {
+		Filters\expectApplied( 'Yoast\WP\Woocommerce\product_condition' )
+			->once()
+			->with( 'new', $this->product )
+			->andReturn( 123 );
+
+		$this->assertEquals( '123', $this->instance->get() );
+	}
+}

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -60,7 +60,7 @@ class Product_Condition_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeEquals( '<meta property="product:condition" content="%s" />', 'tag_format', $this->instance );
+		$this->assertAttributeSame( '<meta property="product:condition" content="%s" />', 'tag_format', $this->instance );
 	}
 
 	/**
@@ -74,7 +74,7 @@ class Product_Condition_Presenter_Test extends TestCase {
 			->with( 'new', $this->product )
 			->andReturn( 'condition' );
 
-		$this->assertEquals( 'condition', $this->instance->get() );
+		$this->assertSame( 'condition', $this->instance->get() );
 	}
 
 	/**
@@ -88,6 +88,9 @@ class Product_Condition_Presenter_Test extends TestCase {
 			->with( 'new', $this->product )
 			->andReturn( 123 );
 
-		$this->assertEquals( '123', $this->instance->get() );
+		$actual = $this->instance->get();
+
+		$this->assertSame( '123', $actual );
+		$this->assertInternalType( 'string', $actual );
 	}
 }

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -56,6 +56,8 @@ class Product_Condition_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$this->assertAttributeEquals( '<meta property="product:condition" content="%s" />', 'tag_format', $this->instance );

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+use function Brain\Monkey\Actions\did;
+
+/**
+ * Class Product_OpenGraph_Deprecation_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter
+ *
+ * @group presenters
+ */
+class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+
+		$this->instance = new WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter( $this->product );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+	}
+
+	/**
+	 * Tests that the action is done.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		did( 'Yoast\WP\Woocommerce\opengraph' );
+
+		$this->assertEquals( '', $this->instance->get() );
+	}
+}

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -2,10 +2,10 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
+use Brain\Monkey\Actions;
 use Mockery;
 use WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
-use function Brain\Monkey\Actions\did;
 
 /**
  * Class Product_OpenGraph_Deprecation_Presenter_Test.
@@ -60,8 +60,8 @@ class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
 	 * @covers ::get
 	 */
 	public function test_get() {
-		did( 'Yoast\WP\Woocommerce\opengraph' );
+		Actions\did( 'Yoast\WP\Woocommerce\opengraph' );
 
-		$this->assertEquals( '', $this->instance->get() );
+		$this->assertSame( '', $this->instance->get() );
 	}
 }

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Product_Price_Amount_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * Class Product_Price_Amount_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_Price_Amount_Presenter
+ *
+ * @group presenters
+ */
+class Product_Price_Amount_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var WPSEO_WooCommerce_Product_Price_Amount_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+
+		$this->instance = new WPSEO_WooCommerce_Product_Price_Amount_Presenter( $this->product );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$this->assertAttributeEquals( '<meta property="product:price:amount" content="%s" />', 'tag_format', $this->instance );
+	}
+
+	/**
+	 * Tests that the display price is retrieved.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$this->product
+			->expects( 'get_price' )
+			->once()
+			->andReturn( '11' );
+		$this->product
+			->expects( 'get_min_purchase_quantity' )
+			->once()
+			->andReturn( '1' );
+
+		expect( 'wc_get_price_decimals' )->once()->andReturn( 0 );
+		expect( 'wc_tax_enabled' )->once()->andReturn( false );
+		expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
+
+		$this->assertEquals( '11', $this->instance->get() );
+	}
+
+	/**
+	 * Tests that the display price is converted to a string.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_string_conversion() {
+		$this->product
+			->expects( 'get_price' )
+			->once()
+			->andReturn( '11' );
+		$this->product
+			->expects( 'get_min_purchase_quantity' )
+			->once()
+			->andReturn( '1' );
+
+		expect( 'wc_get_price_decimals' )->once()->andReturn( 0 );
+		expect( 'wc_tax_enabled' )->once()->andReturn( false );
+		expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
+
+		$actual = $this->instance->get();
+
+		$this->assertSame( '11', $actual );
+		$this->assertTrue( \is_string( $actual ) );
+	}
+}

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -55,6 +55,8 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$this->assertAttributeEquals( '<meta property="product:price:amount" content="%s" />', 'tag_format', $this->instance );

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -81,7 +81,7 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 		expect( 'wc_tax_enabled' )->once()->andReturn( false );
 		expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
 
-		$this->assertEquals( '11', $this->instance->get() );
+		$this->assertSame( '11', $this->instance->get() );
 	}
 
 	/**
@@ -106,6 +106,6 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 		$actual = $this->instance->get();
 
 		$this->assertSame( '11', $actual );
-		$this->assertTrue( \is_string( $actual ) );
+		$this->assertInternalType( 'string', $actual );
 	}
 }

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Product_Price_Currency_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * Class Product_Price_Currency_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_Price_Currency_Presenter
+ *
+ * @group presenters
+ */
+class Product_Price_Currency_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var WPSEO_WooCommerce_Product_Price_Currency_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+
+		$this->instance = new WPSEO_WooCommerce_Product_Price_Currency_Presenter( $this->product );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$this->assertAttributeEquals( '<meta property="product:price:currency" content="%s" />', 'tag_format', $this->instance );
+	}
+
+	/**
+	 * Tests that the currency is retrieved.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		expect( 'get_woocommerce_currency' )->once()->andReturn( 'EUR' );
+
+		$this->assertSame( 'EUR', $this->instance->get() );
+	}
+}

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -55,6 +55,8 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$this->assertAttributeEquals( '<meta property="product:price:currency" content="%s" />', 'tag_format', $this->instance );

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -59,7 +59,7 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeEquals( '<meta property="product:price:currency" content="%s" />', 'tag_format', $this->instance );
+		$this->assertAttributeSame( '<meta property="product:price:currency" content="%s" />', 'tag_format', $this->instance );
 	}
 
 	/**

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -58,7 +58,7 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeEquals( '<meta property="product:retailer_item_id" content="%s" />', 'tag_format', $this->instance );
+		$this->assertAttributeSame( '<meta property="product:retailer_item_id" content="%s" />', 'tag_format', $this->instance );
 	}
 
 	/**

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Product_Retailer_Item_ID_Presenter_Test.
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter
+ *
+ * @group presenters
+ */
+class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
+
+	/**
+	 * Holds the product.
+	 *
+	 * @var \WC_Product|\Mockery\MockInterface
+	 */
+	protected $product;
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * Initializes the test setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
+
+		$this->product = Mockery::mock( 'WC_Product' );
+
+		$this->instance = new WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter( $this->product );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+	}
+
+	/**
+	 * Tests the tag format.
+	 */
+	public function test_tag_format() {
+		$this->assertAttributeEquals( '<meta property="product:retailer_item_id" content="%s" />', 'tag_format', $this->instance );
+	}
+
+	/**
+	 * Tests that the product SKU is retrieved.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get() {
+		$this->product
+			->expects( 'get_sku' )
+			->once()
+			->andReturn( 'keeping stock' );
+
+		$this->assertSame( 'keeping stock', $this->instance->get() );
+	}
+}

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -54,6 +54,8 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests the tag format.
+	 *
+	 * @coversNothing
 	 */
 	public function test_tag_format() {
 		$this->assertAttributeEquals( '<meta property="product:retailer_item_id" content="%s" />', 'tag_format', $this->instance );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want 100% code coverage in our tests.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tests for the presenters.

## Relevant technical choices:

* WordPress action arguments should be an array, we previously sent a WC_Product. This is enforced through Brain Monkey. So to fix this I convert the WC_Product to an array in the deprecated action. -- The alternative would be that we do not test this.
* Temporarily disable the `Yoast.NamingConventions.ObjectNameDepth.MaxExceeded` sniff for the tests. The names seem fine as they are, Joost said to ignore it for now and Herre agreed with the temporary disabling as included here.

## Test instructions

This PR can be tested by following these steps:

* Ensure the test coverage is 100%
* Have an opinion about the technical choice I made.

Fixes #577 
