### PR TITLE
Omit the price amount and currency meta for variable and grouped products.

### DIFF
--- a/classes/presenters/woocommerce-product-price-amount-presenter.php
+++ b/classes/presenters/woocommerce-product-price-amount-presenter.php
@@ -23,6 +23,13 @@ class WPSEO_WooCommerce_Product_Price_Amount_Presenter extends WPSEO_WooCommerce
 	 * @return string The raw value.
 	 */
 	public function get() {
+		$product_type = WPSEO_WooCommerce_Utils::get_product_type( $this->product );
+
+		// Omit the price amount for variable products.
+		if ( $product_type === 'variable' ) {
+			return '';
+		}
+
 		return (string) WPSEO_WooCommerce_Utils::get_product_display_price( $this->product );
 	}
 }

--- a/classes/presenters/woocommerce-product-price-amount-presenter.php
+++ b/classes/presenters/woocommerce-product-price-amount-presenter.php
@@ -25,8 +25,8 @@ class WPSEO_WooCommerce_Product_Price_Amount_Presenter extends WPSEO_WooCommerce
 	public function get() {
 		$product_type = WPSEO_WooCommerce_Utils::get_product_type( $this->product );
 
-		// Omit the price amount for variable products.
-		if ( $product_type === 'variable' ) {
+		// Omit the price amount for variable and grouped products.
+		if ( $product_type === 'variable' || $product_type === 'grouped' ) {
 			return '';
 		}
 

--- a/classes/presenters/woocommerce-product-price-currency-presenter.php
+++ b/classes/presenters/woocommerce-product-price-currency-presenter.php
@@ -23,6 +23,13 @@ class WPSEO_WooCommerce_Product_Price_Currency_Presenter extends WPSEO_WooCommer
 	 * @return string The raw value.
 	 */
 	public function get() {
+		$product_type = WPSEO_WooCommerce_Utils::get_product_type( $this->product );
+
+		// Omit the currency for variable and grouped products.
+		if ( $product_type === 'variable' || $product_type === 'grouped' ) {
+			return '';
+		}
+
 		return (string) get_woocommerce_currency();
 	}
 }

--- a/classes/woocommerce-utils.php
+++ b/classes/woocommerce-utils.php
@@ -106,4 +106,19 @@ class WPSEO_WooCommerce_Utils {
 	public static function prices_have_tax_included() {
 		return get_option( 'woocommerce_tax_display_shop' ) === 'incl';
 	}
+
+	/**
+	 * Determines the product type.
+	 *
+	 * @param WC_Product $product The WooCommerce Product.
+	 *
+	 * @return string The product type. Fallbacks to 'simple'.
+	 */
+	public static function get_product_type( $product ) {
+		if ( method_exists( $product, 'get_type' ) ) {
+			return $product->get_type();
+		}
+
+		return 'simple';
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Avoid to output the lowest price and currency in the og meta `product:price:amount` for variable and grouped products.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Omits the `product:price:amount` and `product:price:currency` og meta for variable and grouped products.

## Relevant technical choices:

* introduced a utility method `get_product_type()`
* used that in the price amount presenter

## Test instructions

This PR can be tested by following these steps:

- install and activate Yoast SEO, WooCommerce, and Yoast SEO: WooCommerce
- create a variable product with variations with different prices
- on trunk:
- see the product on the front end
- inspect the source and observe the meta `product:price:amount` outputs the lowest price
- observe there's a `product:price:currency` meta
- switch to this branch
- inspect the source and check the meta `product:price:amount` is omitted
- check the `product:price:currency` is omitted as well
- check the above also for a _grouped_ product 

## Questions
- ~This PR doesn't touch the Schema price piece, which seems correct to me. Is that OK?~
(This has an answer on the issue so can be ignored, see https://github.com/Yoast/featurerequests/issues/112#issuecomment-618409025)
- Should the currency meta be omitted as well? [Edit: addressed]
- What about _grouped_ products? They actually have a price _range_ but the meta outputs only the lowest price [Edit: addressed]

Cc @jono-alderson @jdevalk 

Fixes https://github.com/Yoast/featurerequests/issues/112
