### PR TITLE
Don't show open graph images gallery when image set by user

### DIFF
--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -318,6 +318,11 @@ class WPSEO_WooCommerce_OpenGraph {
 	 * @return bool True on success, false on failure.
 	 */
 	protected function set_opengraph_image_product( $opengraph_image, WC_Product $product ) {
+		// Don't add the gallery images if the user set a specific image for this product.
+		if ( $this->is_opengraph_image_set_by_user( $product->get_id() ) ) {
+			return true;
+		}
+
 		$img_ids = $product->get_gallery_image_ids();
 
 		if ( is_array( $img_ids ) && $img_ids !== [] ) {
@@ -329,6 +334,20 @@ class WPSEO_WooCommerce_OpenGraph {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks whether users set a specific open graph image for a product.
+	 *
+	 * @param int $product_id The product ID.
+	 *
+	 * @return bool Whether users set a specific open graph image for a product.
+	 */
+	protected function is_opengraph_image_set_by_user( $product_id ) {
+		$indexable_repository = YoastSEO()->classes->get( 'Yoast\WP\SEO\Repositories\Indexable_Repository' );
+		$indexable            = $indexable_repository->find_by_id_and_type( $product_id, 'post' );
+
+		return $indexable->open_graph_image_source === 'set-by-user';
 	}
 
 	/**

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -13,6 +13,26 @@ use Yoast\WP\Woocommerce\Tests\TestCase;
 class OpenGraph_Test extends TestCase {
 
 	/**
+	 * Class instance to use for the test.
+	 *
+	 * @var \Mockery\MockInterface
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the class which will be tested.
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		$this->instance = Mockery::mock( \WPSEO_WooCommerce_OpenGraph::class )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		parent::setUp();
+	}
+
+	/**
 	 * Test that our constructor works.
 	 *
 	 * @covers WPSEO_WooCommerce_OpenGraph::__construct
@@ -37,15 +57,14 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertSame( 'product', $og->return_type_product( 'article' ) );
+		$this->assertSame( 'product', $this->instance->return_type_product( 'article' ) );
 
 		Functions\stubs(
 			[
 				'is_singular' => false,
 			]
 		);
-		$this->assertSame( 'article', $og->return_type_product( 'article' ) );
+		$this->assertSame( 'article', $this->instance->return_type_product( 'article' ) );
 	}
 
 	/**
@@ -54,8 +73,6 @@ class OpenGraph_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_OpenGraph::product_namespace
 	 */
 	public function test_product_namespace() {
-		$og = new WPSEO_WooCommerce_OpenGraph();
-
 		Functions\stubs(
 			[
 				'is_singular' => false,
@@ -63,14 +80,14 @@ class OpenGraph_Test extends TestCase {
 		);
 
 		$input = 'prefix="fn: https://yoast.com/bla"';
-		$this->assertSame( $input, $og->product_namespace( $input ) );
+		$this->assertSame( $input, $this->instance->product_namespace( $input ) );
 
 		Functions\stubs(
 			[
 				'is_singular' => true,
 			]
 		);
-		$this->assertSame( 'prefix="fn: https://yoast.com/bla product: http://ogp.me/ns/product#"', $og->product_namespace( $input ) );
+		$this->assertSame( 'prefix="fn: https://yoast.com/bla product: http://ogp.me/ns/product#"', $this->instance->product_namespace( $input ) );
 	}
 
 	/**
@@ -91,8 +108,7 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertTrue( $og->set_opengraph_image( $og_image ) );
+		$this->assertTrue( $this->instance->set_opengraph_image( $og_image ) );
 	}
 
 	/**
@@ -112,8 +128,7 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertFalse( $og->set_opengraph_image( $og_image ) );
+		$this->assertFalse( $this->instance->set_opengraph_image( $og_image ) );
 	}
 
 	/**
@@ -128,6 +143,7 @@ class OpenGraph_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_gallery_image_ids' )->once()->andReturn( [ 1234, 1235, 1236 ] );
+		$product->expects( 'get_id' )->once()->andReturn( 12 );
 
 		Functions\stubs(
 			[
@@ -137,8 +153,8 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertTrue( $og->set_opengraph_image( $og_image ) );
+		$this->instance->shouldReceive( 'is_opengraph_image_set_by_user' )->andReturnFalse();
+		$this->assertTrue( $this->instance->set_opengraph_image( $og_image ) );
 	}
 
 	/**
@@ -152,6 +168,7 @@ class OpenGraph_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_gallery_image_ids' )->once()->andReturn( [] );
+		$product->expects( 'get_id' )->once()->andReturn( 12 );
 
 		Functions\stubs(
 			[
@@ -161,8 +178,8 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertFalse( $og->set_opengraph_image( $og_image ) );
+		$this->instance->shouldReceive( 'is_opengraph_image_set_by_user' )->andReturnFalse();
+		$this->assertFalse( $this->instance->set_opengraph_image( $og_image ) );
 	}
 
 	/**
@@ -181,8 +198,7 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertFalse( $og->set_opengraph_image( $og_image ) );
+		$this->assertFalse( $this->instance->set_opengraph_image( $og_image ) );
 	}
 
 	/**
@@ -195,6 +211,7 @@ class OpenGraph_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_gallery_image_ids' )->once()->andReturn( [] );
+		$product->expects( 'get_id' )->once()->andReturn( 12 );
 
 		Functions\stubs(
 			[
@@ -204,7 +221,7 @@ class OpenGraph_Test extends TestCase {
 			]
 		);
 
-		$og = new WPSEO_WooCommerce_OpenGraph();
-		$this->assertFalse( $og->set_opengraph_image( $og_image ) );
+		$this->instance->shouldReceive( 'is_opengraph_image_set_by_user' )->andReturnFalse();
+		$this->assertFalse( $this->instance->set_opengraph_image( $og_image ) );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the open graph image output when users set a specific image for a product.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where all product gallery images were used as open graph images even though users set a specific image for a product.

## Relevant technical choices:

* Introduces a new method to check whether users set a specific image for a product, based on the `indexables` implementation. Hat tip to @hansjovis 
* Refactors most of the related tests to use a mocked instance of the main class to test.

## Test instructions

This PR can be tested by following these steps:

- install Yoast SEO, WooCommerce, Yoast SEO: WooCommerce
- on trunk
- create a product and add some images in the "Product gallery" meta box
- add an image in the Yoast SEO meta box > Social > Facebook > Facebook Image
- publish the product
- see the product on the front end and inspect the source
- see there are multiple images used as open graph images: all the ones from the product gallery plus the one set in the Yoast SEO metabox
- switch to this branch 
- refresh the product page on the front end and inspect the page source
- check that only the image set in the Yoast SEO metabox is now used as open graph image
- remove the image set in the Yoast SEO metabox and update the product post
- inspect the product page source again and see that only the images from the gallery are now used as open graph images

## Questions
- I'd like this behavior be confirmed as the desired one /Cc @jono-alderson @jdevalk 
- the refactored tests should be reviewed, specifically: wondering if there’s a specific reason why the tests were instantiating the `WPSEO_WooCommerce_OpenGraph` class each time. I changed that to use a mocked class instance so that I can use `shouldReceive( 'is_opengraph_image_set_by_user' )`

Fixes https://github.com/Yoast/bugreports/issues/812