### PR TITLE
Twitter image falls back to first image in product image gallery

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -80,6 +80,7 @@ class Yoast_WooCommerce_SEO {
 			// Initialize schema & OpenGraph.
 			add_action( 'init', [ $this, 'initialize_opengraph' ] );
 			add_action( 'init', [ $this, 'initialize_schema' ] );
+			add_action( 'init', [ $this, 'initialize_twitter' ] );
 			add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
 
 			// Add metadescription filter.
@@ -127,6 +128,14 @@ class Yoast_WooCommerce_SEO {
 	 */
 	public function initialize_opengraph() {
 		new WPSEO_WooCommerce_OpenGraph();
+	}
+
+	/**
+	 * Initialized the twitter functionality.
+	 */
+	public function initialize_twitter() {
+		$twitter = new WPSEO_WooCommerce_Twitter();
+		$twitter->register_hooks();
 	}
 
 	/**

--- a/classes/woocommerce-twitter.php
+++ b/classes/woocommerce-twitter.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin file.
+ *
+ * @package WPSEO/WooCommerce
+ */
+
+/**
+ * Class WPSEO_WooCommerce_Twitter
+ */
+class WPSEO_WooCommerce_Twitter {
+
+	/**
+	 * Register hooks.
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_twitter_image', [ $this, 'fallback_to_product_gallery_image' ], 10, 2 );
+	}
+
+	/**
+	 * Lets the twitter image fall back to the first image in the product gallery.
+	 *
+	 * @param string                 $twitter_image The current twitter image.
+	 * @param Indexable_Presentation $presentation  The indexable presentation.
+	 *
+	 * @return string The image fallback.
+	 */
+	public function fallback_to_product_gallery_image( $twitter_image, $presentation ) {
+		// We should only fall back to the Twitter image if OpenGraph is disabled.
+		if ( ! $presentation->context->open_graph_enabled ) {
+			$object = $presentation->model;
+
+			// If a twitter image is set, do not overwrite it.
+			if ( $object->twitter_image ) {
+				return $twitter_image;
+			}
+
+			// Fall back to the first image in the product gallery.
+			if ( $object->object_sub_type === 'product' ) {
+				$product = \wc_get_product( $object->object_id );
+
+				if ( $product ) {
+					$gallery_image_ids      = $product->get_gallery_image_ids();
+					$first_gallery_image_id = \reset( $gallery_image_ids );
+
+					return YoastSEO()->helpers->twitter->image->get_by_id( $first_gallery_image_id );
+				}
+			}
+		}
+
+		return $twitter_image;
+	}
+}

--- a/classes/woocommerce-twitter.php
+++ b/classes/woocommerce-twitter.php
@@ -26,23 +26,27 @@ class WPSEO_WooCommerce_Twitter {
 	 * @return string The image fallback.
 	 */
 	public function fallback_to_product_gallery_image( $twitter_image, $presentation ) {
-		// We should only fall back to the Twitter image if OpenGraph is disabled and no other Twitter image is set.
-		if ( ! $presentation->context->open_graph_enabled && ! $twitter_image ) {
-			$object = $presentation->model;
+		// Do not fall back to product gallery image when open graph is enabled, or we already have a twitter image.
+		if ( $presentation->context->open_graph_enabled || $twitter_image ) {
+			return $twitter_image;
+		}
 
+		$object = $presentation->model;
+
+		// This method only provides a fallback for products.
+		if ( ! $object->object_type === 'post' && ! $object->object_sub_type === 'product' ) {
+			return $twitter_image;
+		}
+
+		$product = \wc_get_product( $object->object_id );
+
+		if ( $product ) {
 			// Fall back to the first image in the product gallery.
-			if ( $object->object_type === 'post' && $object->object_sub_type === 'product' ) {
-				$product = \wc_get_product( $object->object_id );
+			$gallery_image_ids      = $product->get_gallery_image_ids();
+			$first_gallery_image_id = \reset( $gallery_image_ids );
 
-				if ( $product ) {
-					$gallery_image_ids      = $product->get_gallery_image_ids();
-					$first_gallery_image_id = \reset( $gallery_image_ids );
-
-					if ( $first_gallery_image_id ) {
-						return YoastSEO()->helpers->twitter->image->get_by_id( $first_gallery_image_id );
-					}
-					return '';
-				}
+			if ( $first_gallery_image_id ) {
+				return YoastSEO()->helpers->twitter->image->get_by_id( $first_gallery_image_id );
 			}
 		}
 

--- a/classes/woocommerce-twitter.php
+++ b/classes/woocommerce-twitter.php
@@ -26,24 +26,22 @@ class WPSEO_WooCommerce_Twitter {
 	 * @return string The image fallback.
 	 */
 	public function fallback_to_product_gallery_image( $twitter_image, $presentation ) {
-		// We should only fall back to the Twitter image if OpenGraph is disabled.
-		if ( ! $presentation->context->open_graph_enabled ) {
+		// We should only fall back to the Twitter image if OpenGraph is disabled and no other Twitter image is set.
+		if ( ! $presentation->context->open_graph_enabled && ! $twitter_image ) {
 			$object = $presentation->model;
 
-			// If a twitter image is set, do not overwrite it.
-			if ( $object->twitter_image ) {
-				return $twitter_image;
-			}
-
 			// Fall back to the first image in the product gallery.
-			if ( $object->object_sub_type === 'product' ) {
+			if ( $object->object_type === 'post' && $object->object_sub_type === 'product' ) {
 				$product = \wc_get_product( $object->object_id );
 
 				if ( $product ) {
 					$gallery_image_ids      = $product->get_gallery_image_ids();
 					$first_gallery_image_id = \reset( $gallery_image_ids );
 
-					return YoastSEO()->helpers->twitter->image->get_by_id( $first_gallery_image_id );
+					if ( $first_gallery_image_id ) {
+						return YoastSEO()->helpers->twitter->image->get_by_id( $first_gallery_image_id );
+					}
+					return '';
 				}
 			}
 		}

--- a/tests/classes/twitter-test.php
+++ b/tests/classes/twitter-test.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes;
+
+use Mockery;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+use Brain\Monkey;
+
+/**
+ * Class OpenGraph_Test
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Twitter
+ */
+class OpenGraph_Test extends TestCase {
+
+	/**
+	 * The Twitter class under test.
+	 *
+	 * @var \WPSEO_WooCommerce_Twitter
+	 */
+	private $instance;
+
+	public function setUp() {
+		$this->instance = new \WPSEO_WooCommerce_Twitter();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests that the right hooks are registered.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Filters\expectAdded( 'wpseo_twitter_image' );
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests that the twitter image correctly falls back to the first
+	 * product gallery image.
+	 *
+	 * @covers ::fallback_to_product_gallery_image
+	 */
+	public function test_fallback_to_product_gallery_image() {
+		// Empty image, so should provide a fallback.
+		$empty_image_url = '';
+		$fallback_image_url = 'http://basic.wordpress.test/wp-content/uploads/2020/04/teddy_2.jpg';
+		$context         = (object) [
+			'open_graph_enabled' => false,
+		];
+		$model           = (object) [
+			'object_id'       => 13,
+			'object_type'     => 'post',
+			'object_sub_type' => 'product',
+		];
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$product->expects( 'get_gallery_image_ids' )
+			->andReturn( [ 21, 23, 24 ] );
+
+		$presentation = $this->mock_presentation( $context, $model );
+
+		Monkey\Functions\expect( 'wc_get_product' )
+			->with( $model->object_id )
+			->andReturn( $product );
+
+		$this->mock_yoastseo( 21, $fallback_image_url );
+
+		$image_url = $this->instance->fallback_to_product_gallery_image( $empty_image_url, $presentation );
+
+		$this->assertSame( $fallback_image_url, $image_url );
+	}
+
+	/**
+	 * Mocks the Indexable presentation.
+	 *
+	 * @param object $context The meta context.
+	 * @param object $model   The model.
+	 *
+	 * @return Mockery\MockInterface The mock presentation
+	 */
+	private function mock_presentation( $context, $model ) {
+		$presentation = \Mockery::mock();
+
+		$presentation->context = $context;
+		$presentation->model   = $model;
+
+		return $presentation;
+	}
+
+	/**
+	 * Mocks the YoastSEO function for the Twitter image tests.
+	 *
+	 * @param int    $fallback_image_id  The image ID of the fallback image.
+	 * @param string $fallback_image_url The image URL of the fallback image.
+	 */
+	private function mock_yoastseo( $fallback_image_id, $fallback_image_url ) {
+		$twitter_image_helper = Mockery::mock()->makePartial();
+		$twitter_image_helper
+			->expects( 'get_by_id' )
+			->with( $fallback_image_id )
+			->andReturn( $fallback_image_url  );
+
+		$surfaces = (object) [
+			'helpers' => (object) [
+				'twitter' => (object) [
+					'image' => $twitter_image_helper,
+				],
+			],
+		];
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( $surfaces );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the Twitter image to fall back to the first image in the product gallery when no product image is set, to ensure that Twitter shows an image when sharing the webpage.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `twitter:image` meta tag did not fall back to the first product gallery image when no main product image was set.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

### Happy path
* Disable the open graph meta data 
  * (set the 'Add Open Graph meta data' toggle to 'disabled' in _SEO_ > _Social_ > _Facebook_).
* Create a new WooCommerce product.
* Add multiple images to the product image gallery.
* Publish the product.
* Go to the frontend and check the HTML source code.
* The source code should have a `twitter:image` meta tag pointing to the URL of the first image in the product image gallery.

### Should not fall back to product gallery image if main product image is set.
* Go back to the product.
* Add a main product image.
* Go to the frontend and check the HTML source code.
* The source code should have a `twitter:image` meta tag pointing to the URL of the main product image.

### Should not display a twitter image meta tag when open graph is enabled.
* Enable open graph meta data.
* Go to the frontend of the product and check the HTML source code.
* The source code should **not** have a `twitter:image` meta tag.

Fixes https://github.com/Yoast/wpseo-woocommerce/issues/587
