### PR TITLE
Fix getting name on null term

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -327,13 +327,12 @@ class WPSEO_WooCommerce_Schema {
 	 * @param string     $taxonomy  The taxonomy to get the attribute's value from.
 	 */
 	private function add_organization_for_attribute( $attribute, $product, $taxonomy ) {
-		$term               = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
-		$stripped_term_name = wp_strip_all_tags( $term->name );
+		$term = $this->get_primary_term_or_first_term( $taxonomy, $product->get_id() );
 
 		if ( $term !== null ) {
 			$this->data[ $attribute ] = [
 				'@type' => 'Organization',
-				'name'  => $stripped_term_name,
+				'name'  => \wp_strip_all_tags( $term->name ),
 			];
 		}
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Non-user-facing due to only existing on trunk.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the organization schema on for a primary term would error.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Have a product with a manufacturer.
* Visit the frontend.
* No longer get an error due to term being null and trying to get name from null.

Fixes #
