### PR TITLE
Bug: fix undefined variable notice

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -429,11 +429,12 @@ class WPSEO_WooCommerce_Schema {
 	protected function add_individual_offers( $product ) {
 		$variations = $product->get_available_variations();
 
-		$currency     = get_woocommerce_currency();
-		$decimals     = wc_get_price_decimals();
-		$data         = [];
-		$product_id   = $product->get_id();
-		$product_name = $product->get_name();
+		$currency           = get_woocommerce_currency();
+		$prices_include_tax = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+		$decimals           = wc_get_price_decimals();
+		$data               = [];
+		$product_id         = $product->get_id();
+		$product_name       = $product->get_name();
 
 		foreach ( $variations as $key => $variation ) {
 			$variation_name = implode( ' / ', $variation['attributes'] );


### PR DESCRIPTION
## Context

* Plugin shouldn't throw any PHP notices.

## Summary
This PR can be summarized in the following changelog entry:

* Fixed potential undefined variable notice.

## Relevant technical choices:

PR #588 (included in v 13.0.0) removed the `$prices_include_tax` variable, but it was still being used in the `if ( wc_tax_enabled() ) {` clause just below.

This brings back the variable to prevents those notices.

## Test instructions

This PR can be tested by following these steps:

* Should be testable when the Woo install has product variants and offers.
* Toggle "prices have tax included" on/off.
* See the undefined variable notice in the PHP error logs.
* With this branch the notice should no longer be thrown.

