### PR TITLE
QA: don't use FQN for an imported class

### DIFF
--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -25,7 +25,7 @@ class OpenGraph_Test extends TestCase {
 	 * @return void
 	 */
 	public function setUp() {
-		$this->instance = Mockery::mock( \WPSEO_WooCommerce_OpenGraph::class )
+		$this->instance = Mockery::mock( WPSEO_WooCommerce_OpenGraph::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 

--- a/tests/classes/twitter-test.php
+++ b/tests/classes/twitter-test.php
@@ -2,10 +2,10 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Classes;
 
-use Mockery;
-use Yoast\WP\Woocommerce\Tests\TestCase;
-
 use Brain\Monkey;
+use Mockery;
+use WPSEO_WooCommerce_Twitter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class Twitter_Test
@@ -25,7 +25,7 @@ class Twitter_Test extends TestCase {
 	 * Sets up the tests.
 	 */
 	public function setUp() {
-		$this->instance = new \WPSEO_WooCommerce_Twitter();
+		$this->instance = new WPSEO_WooCommerce_Twitter();
 
 		parent::setUp();
 	}
@@ -141,7 +141,7 @@ class Twitter_Test extends TestCase {
 	 * @return Mockery\MockInterface The mock presentation
 	 */
 	private function mock_presentation( $context, $model ) {
-		$presentation = \Mockery::mock();
+		$presentation = Mockery::mock();
 
 		$presentation->context = $context;
 		$presentation->model   = $model;


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

These classes all have import `use` statements (or should have), so those should be used instead of the fully qualified name.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.