### PR TITLE
Alter schema availability for products on backorder.

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -198,6 +198,11 @@ class WPSEO_WooCommerce_Schema {
 				$data['offers'][ $key ]['@id']    = YoastSEO()->meta->for_current_page()->site_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
 				$data['offers'][ $key ]['offers'] = $this->add_individual_offers( $product );
 			}
+
+			// Alter availability when product is "on backorder".
+			if ( $product->is_on_backorder() ) {
+				$data['offers'][ $key ]['availability'] = 'http://schema.org/PreOrder';
+			}
 		}
 
 		return $data;

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -231,6 +231,77 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_price' )->once()->andReturn( 49 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
+
+		$this->meta
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( (object) [ 'site_url' => 'https://example.com/' ] );
+
+		$output = $schema->filter_offers( $input, $product );
+
+		$this->assertSame( $expected_output, $output );
+	}
+
+	/**
+	 * Test filtering offers with produc on backorder.
+	 *
+	 * @covers ::filter_offers
+	 */
+	public function test_filter_offers_with_product_on_backorder() {
+		$schema = new Schema_Double();
+		$input  = [
+			'@type'       => 'Product',
+			'name'        => 'Customizable responsive toolset',
+			'url'         => 'https://example.com/product/customizable-responsive-toolset/',
+			'description' => 'Sit debitis reprehenderit non rem natus. Corporis quidem quos et sit similique. Et ad hic exercitationem repudiandae rem laborum.\n\n\n\n\n\n\n\n\nCumque iusto cum enim ut. Et ipsum tempore dolorem ullam aspernatur autem et. Aut molestiae dolor natus. Ducimus molestias perspiciatis magni in libero deleniti ut. Rerum perspiciatis autem et maiores hic ducimus.\n\n\nAut tenetur ducimus distinctio quaerat deserunt sed. Sint ullam ut deserunt deleniti velit et. Incidunt in molestiae voluptas corrupti qui facilis quia.\n\n\n\n\n\nIste asperiores voluptas expedita id cupiditate. Sed error corrupti quibusdam dolor facere enim tenetur. Asperiores error qui commodi dolorem veritatis aspernatur.',
+			'image'       => [
+				'@id' => 'https://example.com/product/customizable-responsive-toolset/#primaryimage',
+			],
+			'sku'         => '209643',
+			'offers'      => [
+				[
+					'@type'              => 'Offer',
+					'price'              => '49.00',
+					'priceSpecification' => [
+						'price'         => '49.00',
+						'priceCurrency' => 'GBP',
+					],
+					'priceCurrency'      => 'GBP',
+					'availability'       => 'http://schema.org/PreOrder',
+					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
+					'seller'             => [
+						'@type' => 'Organization',
+						'name'  => 'WooCommerce',
+						'url'   => 'https://example.com',
+					],
+				],
+			],
+		];
+
+		$expected_output                     = $input;
+		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
+
+		$base_url = 'http://example.com';
+		Functions\stubs(
+			[
+				'get_site_url'             => $base_url,
+				'wc_get_price_decimals'    => 2,
+				'wc_tax_enabled'           => false,
+				'wc_format_decimal'        => static function ( $number ) {
+					return \number_format( $number, 2 );
+				},
+				'get_woocommerce_currency' => 'GBP',
+				'wc_prices_include_tax'    => false,
+			]
+		);
+
+		$product = Mockery::mock( 'WC_Product' );
+		$product->expects( 'get_id' )->once()->andReturn( '209643' );
+		$product->expects( 'get_price' )->once()->andReturn( 49 );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
+		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( true );
 
 		$this->meta
 			->expects( 'for_current_page' )
@@ -497,6 +568,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_available_variations' )->once()->andReturn( $variants );
 		$product->expects( 'get_name' )->once()->andReturn( 'Customizable responsive toolset' );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$this->meta
 			->expects( 'for_current_page' )
@@ -853,6 +925,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$mock = Mockery::mock( 'alias:WPSEO_Options' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
@@ -1026,6 +1099,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_price' )->once()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$mock = Mockery::mock( 'alias:WPSEO_Options' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
@@ -1203,6 +1277,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$mock = Mockery::mock( 'alias:WPSEO_Options' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
@@ -1482,6 +1557,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( true );
 		$product->expects( 'get_date_on_sale_to' )->once()->andReturn( 'not-a-null-value' );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$this->meta
 			->expects( 'for_current_page' )

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -212,10 +212,9 @@ class Schema_Test extends TestCase {
 		$expected_output                     = $input;
 		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
 
-		$base_url = 'http://example.com';
 		Functions\stubs(
 			[
-				'get_site_url'             => $base_url,
+				'get_site_url'             => 'http://example.com',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
 				'wc_format_decimal'        => static function ( $number ) {
@@ -244,7 +243,7 @@ class Schema_Test extends TestCase {
 	}
 
 	/**
-	 * Test filtering offers with produc on backorder.
+	 * Test filtering offers with product on backorder.
 	 *
 	 * @covers ::filter_offers
 	 */
@@ -282,10 +281,9 @@ class Schema_Test extends TestCase {
 		$expected_output                     = $input;
 		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
 
-		$base_url = 'http://example.com';
 		Functions\stubs(
 			[
-				'get_site_url'             => $base_url,
+				'get_site_url'             => 'http://example.com',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
 				'wc_format_decimal'        => static function ( $number ) {
@@ -551,10 +549,9 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$base_url = 'https://example.com';
 		Functions\stubs(
 			[
-				'get_site_url'             => $base_url,
+				'get_site_url'             => 'https://example.com',
 				'get_woocommerce_currency' => 'GBP',
 				'wc_prices_include_tax'    => false,
 				'wc_get_price_decimals'    => 2,
@@ -830,10 +827,9 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$base_url = 'https://example.com';
 		Functions\stubs(
 			[
-				'get_site_url' => $base_url,
+				'get_site_url' => 'https://example.com',
 			]
 		);
 		$product = Mockery::mock( 'WC_Product' );
@@ -1539,7 +1535,6 @@ class Schema_Test extends TestCase {
 		$expected_output                     = $input;
 		$expected_output['offers'][0]['@id'] = 'http://example.com/#/schema/offer/209643-0';
 
-		$base_url = 'http://example.com/';
 		Functions\stubs(
 			[
 				'wc_get_price_decimals'    => 2,
@@ -1562,7 +1557,7 @@ class Schema_Test extends TestCase {
 		$this->meta
 			->expects( 'for_current_page' )
 			->once()
-			->andReturn( (object) [ 'site_url' => $base_url ] );
+			->andReturn( (object) [ 'site_url' => 'http://example.com/' ] );
 
 		$output = $schema->filter_offers( $input, $product );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the Product Schema to make the `availability` property accurate.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Outputs a `PreOrder` value for the Product Schema availability property when the Product is "on backorder".

## Relevant technical choices:

- filtered the availability value in the `filter_offers()` method
- added a test for the "on backorder" case and adjusted the existing tests

## Test instructions

This PR can be tested by following these steps:

- install and activate Yoast SEO, WooCommerce, and Yoast SEO: WooCommerce
- create or edit a simple product
- in "Product data" meta box > Inventory, set the "Stock status" to "On backorder"
- view the product on the front end
- append the URL parameter `?yoastdebug` to the URL in your browser's address bar and press Enter to request again the page
- see the page source (on macOS Chrome: Alt + Cmd  U)
- see the product schema availability property
- check its value is `"availability": "http://schema.org/PreOrder"`

Note:
WooCommerce has 4 different types of products and only the "simple" product provide a UI in the 
"Product data" meta box to change the stock availability.

For the WooCommerce "variable" and "grouped" products:
- the UI to set stock availability is intentionally hidden, see the CSS classes on the "stock status" UI element `stock_status_field hide_if_variable hide_if_external hide_if_grouped form-field _stock_status_field`
- but then it can be se in the Quick Edit form 🙈 
- so you can change the main product availability in the Quick Edit form
- inspect the products page source on the front end and check the schema availability is `"availability": "http://schema.org/PreOrder"`
- the single offers grouped under the main product don't have an availability property and this is just how WooCommerce works

For the WooCommerce external/affiliate product:
- there's no way to set stock availability, not even in the Quick Edit form, so it's always "in stock"


Fixes https://github.com/Yoast/wpseo-woocommerce/issues/555