### PR TITLE
Sku incorrect value to blank

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -141,6 +141,7 @@ class WPSEO_WooCommerce_Schema {
 		$data = $this->change_seller_in_offers( $data );
 		$data = $this->filter_reviews( $data, $product );
 		$data = $this->filter_offers( $data, $product );
+		$data = $this->filter_sku( $data, $product );
 
 		// This product is the main entity of this page, so we set it as such.
 		$data['mainEntityOfPage'] = [
@@ -225,6 +226,26 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		return $offers;
+	}
+
+	/**
+	 * Check for the WooCommerce sku fallback to its id, and if so set it to an empty string again.
+	 *
+	 * @param array      $data    Schema Product data.
+	 * @param WC_Product $product The product.
+	 *
+	 * @return array Schema Product data.
+	 */
+	protected function filter_sku( $data, $product ) {
+		/*
+		 * When the SKU of a product is left empty, WooCommerce makes it the value of the product's id.
+		 * In this method we check for that and unset it if done so
+		 */
+		if ( empty( $product->get_sku() ) ) {
+			unset( $data['sku'] );
+		}
+
+		return $data;
 	}
 
 	/**

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -229,7 +229,7 @@ class WPSEO_WooCommerce_Schema {
 	}
 
 	/**
-	 * Check for the WooCommerce sku fallback to its id, and if so set it to an empty string again.
+	 * Removes the SKU when it's empty to prevent the WooCommerce fallback to the product's ID.
 	 *
 	 * @param array      $data    Schema Product data.
 	 * @param WC_Product $product The product.
@@ -239,7 +239,7 @@ class WPSEO_WooCommerce_Schema {
 	protected function filter_sku( $data, $product ) {
 		/*
 		 * When the SKU of a product is left empty, WooCommerce makes it the value of the product's id.
-		 * In this method we check for that and unset it if done so
+		 * In this method we check for that and unset it if done so.
 		 */
 		if ( empty( $product->get_sku() ) ) {
 			unset( $data['sku'] );

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -648,6 +648,27 @@ class Schema_Test extends TestCase {
 	}
 
 	/**
+	 * Tests we remove the SKU when WooCommerce fallbacks to the product's ID.
+	 *
+	 * @covers ::filter_sku
+	 */
+	public function test_filter_sku_empty() {
+		$schema  = new Schema_Double();
+		$product = Mockery::mock( 'WC_Product' );
+
+		// The WooCommerce SKU input field is empty.
+		$product->expects( 'get_sku' )->once()->andReturn( '' );
+		// WooCommerce fallbacks to the products'ID.
+		$woocommeerce_sku_fallback = [
+			'sku' => '12345',
+		];
+
+		$output = $schema->filter_sku( $woocommeerce_sku_fallback, $product );
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
 	 * Test adding the global identifier
 	 *
 	 * @covers ::add_global_identifier

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -844,12 +844,14 @@ class Schema_Test extends TestCase {
 	public function test_change_product() {
 		$product_id   = 1;
 		$product_name = 'TestProduct';
+		$product_sku  = 'sku1234';
 		$base_url     = 'http://local.wordpress.test/';
 		$canonical    = $base_url . 'product/test/';
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
+		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
 		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
@@ -1017,12 +1019,14 @@ class Schema_Test extends TestCase {
 	public function test_change_product_no_thumb() {
 		$product_id   = 1;
 		$product_name = 'TestProduct';
+		$product_sku  = 'sku1234';
 		$base_url     = 'http://local.wordpress.test/';
 		$canonical    = $base_url . 'product/test/';
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
+		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
 		$product->expects( 'get_price' )->once()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
@@ -1192,6 +1196,7 @@ class Schema_Test extends TestCase {
 	public function test_change_product_with_color() {
 		$product_id   = 1;
 		$product_name = 'TestProduct';
+		$product_sku  = 'sku1234';
 		$base_url     = 'http://local.wordpress.test/';
 		$canonical    = $base_url . 'product/test/';
 
@@ -1200,6 +1205,7 @@ class Schema_Test extends TestCase {
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
+		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
 		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );

--- a/tests/doubles/schema-double.php
+++ b/tests/doubles/schema-double.php
@@ -80,4 +80,16 @@ class Schema_Double extends WPSEO_WooCommerce_Schema {
 	public function add_global_identifier( $product ) {
 		return parent::add_global_identifier( $product );
 	}
+
+	/**
+	 * Enhances the SKU data output by WooCommerce.
+	 *
+	 * @param array       $data    SKU Schema data.
+	 * @param \WC_Product $product The WooCommerce product we're working with.
+	 *
+	 * @return array SKU Schema data.
+	 */
+	public function filter_sku( $data, $product ) {
+		return parent::filter_sku( $data, $product );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the SKU of a product is left empty, WooCommerce makes it the value of the product's id. 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an empty SKU fallbacks to the product's ID.

## Relevant technical choices:

* Created a `filter_sku` function that is called in `change_product` in `woocommerce-schema.php`

## Test instructions

This PR can be tested by following these steps:

* Checkout this branch and build
* Install Yoast SEO and Woocommerce
* Add a product (variable or simple)
* Leave SKU blank
* See that no SKU value is printed in the product graph in the source code
* Repeat the above steps on trunk and note that the sku value should be put out in the graph. 

Fixes https://github.com/Yoast/bugreports/issues/357
