### PR TITLE
Call the right class

### DIFF
--- a/classes/woocommerce-permalink-watcher.php
+++ b/classes/woocommerce-permalink-watcher.php
@@ -5,7 +5,7 @@
  * @package WPSEO/WooCommerce
  */
 
-use Yoast\WP\SEO\ORM\Yoast_Model;
+use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
@@ -94,7 +94,7 @@ class WPSEO_Woocommerce_Permalink_Watcher {
 	 */
 	protected function reset_permalink_indexables( $type, $subtype ) {
 		Wrapper::get_wpdb()->update(
-			Yoast_Model::get_table_name( 'Indexable' ),
+			Model::get_table_name( 'Indexable' ),
 			[
 				'permalink' => null,
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The class `Yoast_Model` has been renamed and moved to another namespace.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an non existing class is called.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Have some products present and make sure there are indexables made for them
* Go to the permalink settings and change the structure for the product
* Visit your database and see the permalinks are set to null for the product indexables

Fixes #609
