### PR TITLE
P3-14 Added a single test for using the valueAddedTaxIncluded property

### DIFF
--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1640,7 +1640,7 @@ class Schema_Test extends TestCase {
 	public function test_filter_offers_with_vat() {
 		$schema = new Schema_Double();
 
-		$input  = [
+		$input = [
 			'@type'       => 'Product',
 			'name'        => 'Customizable responsive toolset',
 			'url'         => 'https://example.com/product/customizable-responsive-toolset/',
@@ -1696,6 +1696,7 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_price' )->once()->andReturn( 49 );
 		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
+		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$this->meta
 			->expects( 'for_current_page' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `valueAddedTaxIncluded` property was added, but never covered by tests.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a single test to cover the `valueAddedTaxIncluded` property.

## Relevant technical choices:

* Added a single test to check that, if particular circumstances are met (i.e. `woocommerce_tax_display_shop` is set to `incl`), that the expected output is returned.
* Replaced the 'namespaced' calls to `expect` with a `use` statement, just to clean things up a tiny bit.

## Test instructions

This PR can be tested by following these steps:

* Ensure all tests pass.

Fixes #552 