### PR TITLE
P3-35 Make the Yoast SEO columns hidden by default

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -536,12 +536,16 @@ class Yoast_WooCommerce_SEO {
 	 * @return void
 	 */
 	public function set_yoast_columns_hidden_by_default( $current_screen ) {
-		$user_id             = get_current_user_id();
-		$user_hidden_columns = get_hidden_columns( $current_screen );
+		$user_id = get_current_user_id();
 
-		if ( get_user_option( 'wpseo_woo_columns_hidden_default', $user_id ) === '1' ) {
+		if (
+			$current_screen->id !== 'edit-product' ||
+			get_user_option( 'wpseo_woo_columns_hidden_default', $user_id ) === '1'
+		) {
 			return;
 		}
+
+		$user_hidden_columns = get_hidden_columns( $current_screen );
 
 		$yoast_hidden_columns = [
 			'wpseo-title',

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -66,7 +66,7 @@ class Yoast_WooCommerce_SEO {
 			add_action( 'admin_print_styles', [ $this, 'config_page_styles' ] );
 
 			// Hide the Yoast SEO columns in the Product table by default, except the SEO score column.
-			add_action( 'admin_init', [ $this, 'set_yoast_columns_hidden_by_default' ] );
+			add_action( 'current_screen', [ $this, 'set_yoast_columns_hidden_by_default' ] );
 
 			// Move Woo box above SEO box.
 			add_action( 'admin_footer', [ $this, 'footer_js' ] );
@@ -531,16 +531,19 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Hides the Yoast SEO columns in the Product table by default, except the SEO score one.
 	 *
+	 * @param WP_Screen $current_screen Current WP_Screen object.
+	 *
 	 * @return void
 	 */
-	public function set_yoast_columns_hidden_by_default() {
-		$user_id = get_current_user_id();
+	public function set_yoast_columns_hidden_by_default( $current_screen ) {
+		$user_id             = get_current_user_id();
+		$user_hidden_columns = get_hidden_columns( $current_screen );
 
 		if ( get_user_option( 'wpseo_woo_columns_hidden_default', $user_id ) === '1' ) {
 			return;
 		}
 
-		$yoast_hidden = [
+		$yoast_hidden_columns = [
 			'wpseo-title',
 			'wpseo-metadesc',
 			'wpseo-focuskw',
@@ -548,11 +551,13 @@ class Yoast_WooCommerce_SEO {
 		];
 
 		if ( class_exists( 'WPSEO_Link_Columns' ) ) {
-			$yoast_hidden[] = 'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKS;
-			$yoast_hidden[] = 'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKED;
+			$yoast_hidden_columns[] = 'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKS;
+			$yoast_hidden_columns[] = 'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKED;
 		}
 
-		update_user_option( $user_id, 'manageedit-productcolumnshidden', $yoast_hidden, true );
+		$hidden_columns = array_merge( $user_hidden_columns, $yoast_hidden_columns );
+
+		update_user_option( $user_id, 'manageedit-productcolumnshidden', $hidden_columns, true );
 		update_user_option( $user_id, 'wpseo_woo_columns_hidden_default', '1', true );
 	}
 

--- a/integration-tests/woocommerce-seo-test.php
+++ b/integration-tests/woocommerce-seo-test.php
@@ -11,40 +11,6 @@
 class Yoast_WooCommerce_SEO_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 	/**
-	 * Tests the filtering of Yoast SEO columns.
-	 *
-	 * @covers Yoast_WooCommerce_SEO::column_heading
-	 */
-	public function test_column_heading() {
-		$woocommerce = new Yoast_WooCommerce_SEO();
-
-		$columns = [
-			'another-column'          => '',
-			'wpseo-title'             => '',
-			'wpseo-metadesc'          => '',
-			'wpseo-focuskw'           => '',
-			'wpseo-score'             => '',
-			'wpseo-score-readability' => '',
-		];
-
-		if ( class_exists( 'WPSEO_Link_Columns' ) ) {
-			$columns += [
-				'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKS  => '',
-				'wpseo-' . WPSEO_Link_Columns::COLUMN_LINKED => '',
-			];
-		}
-
-		$actual = $woocommerce->column_heading( $columns );
-
-		$expected = [
-			'another-column' => '',
-			'wpseo-score'    => '',
-		];
-
-		$this->assertSame( $expected, $actual );
-	}
-
-	/**
 	 * Tests the sitemap filtering of a product that is not hidden.
 	 *
 	 * @covers Yoast_WooCommerce_SEO::filter_hidden_product


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the Yoast SEO columns hidden by default (except SEO score) and users still able to make the visible.

Follow-up to https://github.com/Yoast/wpseo-woocommerce/pull/578/

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the Yoast SEO columns hidden by default in the Products overview table.

## Relevant technical choices:

The main point for this change is that the columns visibility is a _per-user_ setting. In order to make users able to set the columns visibility, this must be saved (and checked against) a user option. I used these WordPress functions:
- get_current_user_id()
- get_user_option()
- update_user_option()

I'd like to discuss with a senior dev / architect if this approach is OK. Also, this makes integration-tests a bit pointless, I guess.


## Test instructions

This PR can be tested by following these steps:

- activate Yoast SEO, WooCommerce, and Woo SEO
- delete from your database any user meta with meta_key `manageedit-productcolumnshidden` for any user (search for it in the wp_usermeta table)
- go to the Products page
- observe the SEO score column is visible by default and all the other Yoast SEO columns are hidden by default
- expand the Screen Options and verify the related checkboxes state is as the one in the screenshot below:

<img width="1279" alt="Screenshot 2020-06-15 at 15 18 42" src="https://user-images.githubusercontent.com/1682452/84665082-babcbe00-af1f-11ea-8301-8deb1979e0bb.png">

- check a couple checkboxes to make some of the Yoast SEO columns visible, e.g.: "Readability score" and "Keyphrase"
- navigate to another page
- navigate back to the Products overview
- observe the "Readability score", "Keyphrase", and "SEO score" columns are still visible
- play with the columns, navigate away again, navigate back, check the columns visibility is correct 
- in your database `wp_usermeta` table, delete your user meta with the meta key `wpseo_woo_columns_hidden_default`
- go to the Products page (or refresh the page) and verify the SEO score column is visible and all the other Yoast SEO columns are hidden
- repeat the steps above using another user
- if you need to repeat the test, you will also need to delete from your database `wp_usermeta` table the user meta with meta_key `wpseo_woo_columns_hidden_default`

Fixes [P3-35]
