### PR TITLE
Travis/Composer: switch over to parallel linting of PHP files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,9 @@ before_install:
 
 install:
 - |
-  if [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" ]]; then
+  if [[ $TRAVIS_PHP_VERSION == "nightly" && "$PHPLINT" == "1" ]]; then
+    composer install --no-interaction --ignore-platform-reqs
+  elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$PHPLINT" == "1" ]]; then
     composer install --no-interaction
   elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "deploy" ]]; then
     composer install --no-dev --no-interaction
@@ -118,7 +120,7 @@ script:
 - |
   if [[ "$PHPLINT" == "1" ]]; then
     travis_fold start "PHP.check" && travis_time_start
-    find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    composer lint
     travis_time_finish && travis_fold end "PHP.check"
   fi
 # PHP CS

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,16 @@
     "require-dev": {
         "yoast/yoastcs": "^2.0.0",
         "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
-        "brain/monkey": "^2.4"
+        "brain/monkey": "^2.4",
+        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-console-highlighter": "^0.5"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude node_modules --exclude .git"
+        ],
         "config-yoastcs": [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acd223f12974f5dee483e3ba7f177f3d",
+    "content-hash": "a8413a58a7d2339c535e25057eddbe49",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -441,6 +441,153 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "php-parallel-lint/php-console-color",
+            "version": "v0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Console-Color.git",
+                "reference": "b6af326b2088f1ad3b264696c9fd590ec395b49e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Console-Color/zipball/b6af326b2088f1ad3b264696c9fd590ec395b49e",
+                "reference": "b6af326b2088f1ad3b264696c9fd590ec395b49e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "replace": {
+                "jakub-onderka/php-console-color": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-code-style": "1.0",
+                "php-parallel-lint/php-parallel-lint": "1.0",
+                "php-parallel-lint/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "~4.3",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JakubOnderka\\PhpConsoleColor\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "time": "2020-05-14T05:47:14+00:00"
+        },
+        {
+            "name": "php-parallel-lint/php-console-highlighter",
+            "version": "v0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Console-Highlighter.git",
+                "reference": "21bf002f077b177f056d8cb455c5ed573adfdbb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Console-Highlighter/zipball/21bf002f077b177f056d8cb455c5ed573adfdbb8",
+                "reference": "21bf002f077b177f056d8cb455c5ed573adfdbb8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.4.0",
+                "php-parallel-lint/php-console-color": "~0.2"
+            },
+            "replace": {
+                "jakub-onderka/php-console-highlighter": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-code-style": "~1.0",
+                "php-parallel-lint/php-parallel-lint": "~1.0",
+                "php-parallel-lint/php-var-dump-check": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JakubOnderka\\PhpConsoleHighlighter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "acci@acci.cz",
+                    "homepage": "http://www.acci.cz/"
+                }
+            ],
+            "description": "Highlight PHP code in terminal",
+            "time": "2020-05-13T07:37:49+00:00"
+        },
+        {
+            "name": "php-parallel-lint/php-parallel-lint",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
+                "reference": "474f18bc6cc6aca61ca40bfab55139de614e51ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/474f18bc6cc6aca61ca40bfab55139de614e51ca",
+                "reference": "474f18bc6cc6aca61ca40bfab55139de614e51ca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.4.0"
+            },
+            "replace": {
+                "grogy/php-parallel-lint": "*",
+                "jakub-onderka/php-parallel-lint": "*"
+            },
+            "require-dev": {
+                "nette/tester": "^1.3 || ^2.0",
+                "php-parallel-lint/php-console-highlighter": "~0.3",
+                "squizlabs/php_codesniffer": "~3.0"
+            },
+            "suggest": {
+                "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
+            },
+            "bin": [
+                "parallel-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "ahoj@jakubonderka.cz"
+                }
+            ],
+            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
+            "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+            "time": "2020-04-04T12:18:32+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",


### PR DESCRIPTION
## Context

* Dev environment improvement

## Summary

This PR can be summarized in the following changelog entry:

* Make Parallel Lint available

## Relevant technical choices:

### Composer

This installs two additional PHP packages in `require-dev`:
* [`php-parallel-lint`](https://packagist.org/packages/jakub-onderka/php-parallel-lint) which allows for linting PHP files in parallel (faster), as well as automatically recursively walking directories.
* [`php-console-highlighter`](https://packagist.org/packages/jakub-onderka/php-console-highlighter) which provides PHP code highlighting in the command line console, allowing the linter to display the results in a more meaningful manner.

It also adds a new `lint` script for use with Composer.

### Travis

* Switch out the script part in the Travis script which did the linting the "old-fashioned" way to use the new Parallel linting option.
* Adjust the `composer install` command in the `install` section to also run for builds which do linting.
* Note: for PHP "nightly" we need to `ignore-platform-reqs` for the time being as one of the PHPCS related dependencies does not allow for installation on PHP 8 yet.
    This has been fixed in the dependency, but there hasn't been a release yet containing the fix.

Ref:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.2.0
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v0.5


## Test instructions

This PR can be tested by following these steps:

* Check out this branch.
* Run `composer install`.
* Run `composer lint` & see it in action.
* Introduce a parse error in one of the files.
* Run `composer lint` & see the error being reported.
* Undo the parse error.

Also check a couple of the Travis builds to verify that the linting is running and passing.
