### PR TITLE
Update checkbox to new styling

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -476,7 +476,7 @@ class Yoast_WooCommerce_SEO {
 			);
 			echo '</p>';
 
-			echo '<fieldset id="id-name" class="yoast-field-group">';
+			echo '<fieldset class="yoast-field-group">';
 			Yoast_Form::get_instance()->checkbox(
 				'woo_breadcrumbs',
 				sprintf(
@@ -498,7 +498,7 @@ class Yoast_WooCommerce_SEO {
 		);
 		echo '</p>';
 
-		echo '<fieldset id="id-name" class="yoast-field-group">';
+		echo '<fieldset class="yoast-field-group">';
 		Yoast_Form::get_instance()->checkbox(
 			'woo_metabox_top',
 			sprintf(

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -472,8 +472,9 @@ class Yoast_WooCommerce_SEO {
 				'Yoast SEO',
 				'WooCommerce'
 			);
-			echo "</p>\n";
+			echo '</p>';
 
+			echo '<fieldset id="id-name" class="yoast-field-group">';
 			Yoast_Form::get_instance()->checkbox(
 				'woo_breadcrumbs',
 				sprintf(
@@ -482,6 +483,7 @@ class Yoast_WooCommerce_SEO {
 					'WooCommerce'
 				)
 			);
+			echo '</fieldset>';
 		}
 
 		echo '<h2>' . esc_html__( 'Admin', 'yoast-woo-seo' ) . '</h2>';
@@ -492,8 +494,9 @@ class Yoast_WooCommerce_SEO {
 			'Yoast SEO',
 			'WooCommerce'
 		);
-		echo "</p>\n";
+		echo '</p>';
 
+		echo '<fieldset id="id-name" class="yoast-field-group">';
 		Yoast_Form::get_instance()->checkbox(
 			'woo_metabox_top',
 			sprintf(
@@ -502,6 +505,7 @@ class Yoast_WooCommerce_SEO {
 				'WooCommerce'
 			)
 		);
+		echo '</fieldset>';
 
 		// Submit button and debug info.
 		Yoast_Form::get_instance()->admin_footer( true, false );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -509,7 +509,7 @@ class Yoast_WooCommerce_SEO {
 		);
 		echo '</fieldset>';
 
-		echo '</div>'; //yoast-feature
+		echo '</div>'; // yoast-feature.
 
 		// Submit button and debug info.
 		Yoast_Form::get_instance()->admin_footer( true, false );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -454,6 +454,8 @@ class Yoast_WooCommerce_SEO {
 			$taxonomies[ strtolower( $object_taxonomy->name ) ] = esc_html( $object_taxonomy->labels->name );
 		}
 
+		echo '<div class="yoast-feature">';
+
 		echo '<h2>' . esc_html__( 'Schema & OpenGraph additions', 'yoast-woo-seo' ) . '</h2>
 		<p>' . esc_html__( 'If you have product attributes for the following types, select them here, the plugin will make sure they\'re used for the appropriate Schema.org and OpenGraph markup.', 'yoast-woo-seo' ) . '</p>';
 
@@ -506,6 +508,8 @@ class Yoast_WooCommerce_SEO {
 			)
 		);
 		echo '</fieldset>';
+
+		echo '</div>'; //yoast-feature
 
 		// Submit button and debug info.
 		Yoast_Form::get_instance()->admin_footer( true, false );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Updates the plugin to the new Yoast styling.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Updates the plugin to the new Yoast styling.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Build the plugin and get the `https://github.com/Yoast/wpseo-woocommerce/tree/FRO-211-woocommerse-styling-update branch` from the wordpress-seo repo.
* Install and activate Woocommerce
* Go the the Woocommerce page under SEO
* Check if the page uses the new styling

Fixes https://yoast.atlassian.net/browse/FRO-211
