### PR TITLE
Travis now clones the distribution version of WordPress SEO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,9 @@ before_script:
 # Clone WPSEO and its submodule
 - |
   if [[ "$PHPUNIT" == "1" ]]; then
-    git clone --depth=1 --branch="trunk" https://github.com/Yoast/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
+    git clone --depth=1 --branch="trunk" https://github.com/Yoast-dist/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
     cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
-    composer install --no-dev --no-interaction --ignore-platform-reqs
+    composer install --no-dev --no-scripts --no-interaction --ignore-platform-reqs
     cd -
   fi
 


### PR DESCRIPTION
This makes sure that the dependency injection container has been built and can be loaded.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the integration tests to be able to run.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the dependency injection container could not be installed in the Travis build when cloning and installing WordPress SEO.

## Relevant technical choices:

* Instead of the normal development repository, the distribution version of WordPress SEO is now cloned and installed. 
  * This means that the dependency injection container is already created and can be used out of the box.

## Test instructions

This PR can be tested by following these steps:

* Check the Travis build. It should pass with flying (e.g. green) colors.

Fixes #
