### PR TITLE
Set new hidden columns defaults only if user did not change the previous defaults

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -551,10 +551,11 @@ class Yoast_WooCommerce_SEO {
 
 		$user_hidden_yoast_columns = array_filter( $user_hidden_columns, [ $this, 'filter_yoast_columns' ] );
 
-		$is_old_default = ( count( array_diff( $yoast_hidden_columns_old_defaults, $user_hidden_yoast_columns ) ) === 0 ) ? true : false;
+		$is_old_default = count( array_diff( $yoast_hidden_columns_old_defaults, $user_hidden_yoast_columns ) ) === 0;
 
 		// Don't do anything if the Yoast hidden columns old defaults have been changed by the user.
 		if ( ! $is_old_default ) {
+			update_user_option( $user_id, 'wpseo_woo_columns_hidden_default', '1', true );
 			return;
 		}
 
@@ -592,17 +593,6 @@ class Yoast_WooCommerce_SEO {
 	 */
 	private function filter_yoast_columns( $column ) {
 		return strpos( $column, 'wpseo-' ) === 0;
-	}
-
-	/**
-	 * Filter items if they have a count of zero.
-	 *
-	 * @param array $item The item to potentially filter out.
-	 *
-	 * @return bool Whether or not the count is zero.
-	 */
-	private function filter_items( $item ) {
-		return $item['count'] !== 0;
 	}
 
 	/**

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -547,19 +547,20 @@ class Yoast_WooCommerce_SEO {
 			'wpseo-focuskw',
 		];
 
-		$user_hidden_columns = get_hidden_columns( $current_screen );
-
+		$user_id                   = get_current_user_id();
+		$user_hidden_columns       = get_hidden_columns( $current_screen );
 		$user_hidden_yoast_columns = array_filter( $user_hidden_columns, [ $this, 'filter_yoast_columns' ] );
-
-		$is_old_default = count( array_diff( $yoast_hidden_columns_old_defaults, $user_hidden_yoast_columns ) ) === 0;
+		$is_old_default            = (
+			count( $yoast_hidden_columns_old_defaults ) === count( $user_hidden_yoast_columns )
+			&& count( array_diff( $yoast_hidden_columns_old_defaults, $user_hidden_yoast_columns ) ) === 0
+			&& count( array_diff( $user_hidden_yoast_columns, $yoast_hidden_columns_old_defaults ) ) === 0
+		);
 
 		// Don't do anything if the Yoast hidden columns old defaults have been changed by the user.
 		if ( ! $is_old_default ) {
 			update_user_option( $user_id, 'wpseo_woo_columns_hidden_default', '1', true );
 			return;
 		}
-
-		$user_id = get_current_user_id();
 
 		// Don't do anything if the new defaults have already been set.
 		if ( get_user_option( 'wpseo_woo_columns_hidden_default', $user_id ) === '1' ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to cover the case were users may had set their custom settings for the Yoast columns and then they activate SEO Woo: in this case the user custom settings should not be changed. This way, new "defaults" are set only if the current setting is the "old defaults".
For reference, see the original issue https://github.com/Yoast/featurerequests/issues/464 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves setting new defaults for the columns visibility in the Products overview page.

## Relevant technical choices:

* checks if the current hidden columns user setting is the same as the old defaults, where these columns were the hidden ones:
- wpseo-title
- wpseo-metadesc
- wpseo-focuskw

## Test instructions

This PR can be tested by following these steps:

- activate Yoast SEO and WooCommerce
- go to the Products page
- set custom settings for the Yoast columns in the Screen Options 
- activate SEO Woo
- go to the Products page
- observe your columns settings **did not change**
- deactivate SEO Woo
- go back to the Products page
- set the columns setting to the old defaults: all visible except:
  - wpseo-title
  - wpseo-metadesc
  - wpseo-focuskw
- activate SEO Woo
- go back to the Products page
- observe that this time the settings did change to the new default: only SEO score is visible
- check the database: a user meta `wpseo_woo_columns_hidden_default` has been set for your user


Fixes [P3-80]