### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
+os: linux
+dist: xenial
 language: php
-dist: trusty
+
+services:
+  - mysql
 
 branches:
   only:


### PR DESCRIPTION
## Context

* Improved CI / build testing

## Summary
This PR can be summarized in the following changelog entry:

* Improved CI / build testing

## Relevant technical choices:

As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Makes the expected OS explicit (linux).
* The `xenial` distro is quite bare, so `mysql` is not available by default. Adding this as a `service` fixes that.

## Test instructions

This PR can be tested by following these steps:

* Verify that the build passes and that the third column on the Travis build page shows `xenial`.
