### PR TITLE
Set minimum WP version to 5.4 and tested up to to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,17 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=5.4 WP_MULTISITE=1 PHPUNIT=1 PHPCS=1 SECURITY=1
+      env: WP_VERSION=5.5 WP_MULTISITE=1 PHPUNIT=1 PHPCS=1 SECURITY=1
     - php: 5.6
-      env: WP_VERSION=5.3 PHPLINT=1 PHPUNIT=1
-    - php: 7.4
       env: WP_VERSION=5.4 PHPLINT=1 PHPUNIT=1
+    - php: 7.4
+      env: WP_VERSION=5.5 PHPLINT=1 PHPUNIT=1
     - php: 7.0
       env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
     - php: "nightly"
       env: PHPLINT=1
     - stage: deploy
-      env: WP_VERSION=5.3
+      env: WP_VERSION=5.5
       if: tag IS present
       before_install:
         - openssl aes-256-cbc -K $encrypted_2b922af4d08d_key -iv $encrypted_2b922af4d08d_iv -in ./deploy_keys/wpseo_woo_deploy.enc -out ./deploy_keys/wpseo_woo_deploy -d

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WooCommerce Yoast SEO
 =====================
-Requires at least: 5.3
-Tested up to: 5.4
+Requires at least: 5.4
+Tested up to: 5.5
 Stable tag: 13.4
 Requires PHP: 5.6.20
 Depends: Yoast SEO, WooCommerce


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On August 11, WordPress 5.5 will be released. Because we always support the 2 latest versions, the minimum supported version needs to be updated to 5.4.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets minimum supported WordPress version to 5.4.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
