### PR TITLE
Add webpage type to types

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -108,14 +108,12 @@ class WPSEO_WooCommerce_Schema {
 				$webpage_data['@type'] = [ $webpage_data['@type'] ];
 			}
 			$webpage_data['@type'][] = 'ItemPage';
-			$webpage_data['@type']   = array_unique( $webpage_data['@type'] );
 		}
 		if ( is_checkout() || is_checkout_pay_page() ) {
 			if ( ! is_array( $webpage_data['@type'] ) ) {
 				$webpage_data['@type'] = [ $webpage_data['@type'] ];
 			}
 			$webpage_data['@type'][] = 'CheckoutPage';
-			$webpage_data['@type']   = array_unique( $webpage_data['@type'] );
 		}
 
 		return $webpage_data;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -104,10 +104,16 @@ class WPSEO_WooCommerce_Schema {
 	 */
 	public function filter_webpage( $webpage_data ) {
 		if ( is_product() ) {
-			$webpage_data['@type'] = 'ItemPage';
+			if ( ! is_array( $webpage_data['@type'] ) ) {
+				$webpage_data['@type'] = [ $webpage_data['@type'] ];
+			}
+			$webpage_data['@type'][] = 'ItemPage';
 		}
 		if ( is_checkout() || is_checkout_pay_page() ) {
-			$webpage_data['@type'] = 'CheckoutPage';
+			if ( ! is_array( $webpage_data['@type'] ) ) {
+				$webpage_data['@type'] = [ $webpage_data['@type'] ];
+			}
+			$webpage_data['@type'][] = 'CheckoutPage';
 		}
 
 		return $webpage_data;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -108,12 +108,14 @@ class WPSEO_WooCommerce_Schema {
 				$webpage_data['@type'] = [ $webpage_data['@type'] ];
 			}
 			$webpage_data['@type'][] = 'ItemPage';
+			$webpage_data['@type']   = array_unique( $webpage_data['@type'] );
 		}
 		if ( is_checkout() || is_checkout_pay_page() ) {
 			if ( ! is_array( $webpage_data['@type'] ) ) {
 				$webpage_data['@type'] = [ $webpage_data['@type'] ];
 			}
 			$webpage_data['@type'][] = 'CheckoutPage';
+			$webpage_data['@type']   = array_unique( $webpage_data['@type'] );
 		}
 
 		return $webpage_data;

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -126,7 +126,7 @@ class Schema_Test extends TestCase {
 		);
 
 		$expected = [
-			'@type' => 'CheckoutPage',
+			'@type' => [ 'WebPage', 'CheckoutPage' ],
 		];
 		$schema   = new WPSEO_WooCommerce_Schema();
 		$this->assertSame( $expected, $schema->filter_webpage( $input ) );
@@ -140,7 +140,7 @@ class Schema_Test extends TestCase {
 		);
 
 		$expected = [
-			'@type' => 'ItemPage',
+			'@type' => [ 'WebPage', 'ItemPage' ],
 		];
 		$schema   = new WPSEO_WooCommerce_Schema();
 		$this->assertSame( $expected, $schema->filter_webpage( $input ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the schema webpage type would be overwritten instead of added to.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

### Product
* Go to the frontend of a product page.
* Check the schema `@type` of the `#webpage` graph piece.
* The `@type` should be `[ "WebPage", "ItemPage" ]`.
* Go to the admin edit of this page.
* Change the schema's page type and check that it is added as the `@type`.

### Checkout
* Go to the frontend of the checkout page (make sure you have something in your cart or you might be redirected to the cart page instead).
* Check the schema `@type` of the `#webpage` graph piece.
* The `@type` should be `[ "WebPage", "CheckoutPage" ]`.
* Change the schema's page type and check that it is added as the `@type`.


Fixes https://yoast.atlassian.net/browse/P1-110
