### PR TITLE
P3-204 improve slack sharing of products

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -81,6 +81,7 @@ class Yoast_WooCommerce_SEO {
 			add_action( 'init', [ $this, 'initialize_opengraph' ] );
 			add_action( 'init', [ $this, 'initialize_schema' ] );
 			add_action( 'init', [ $this, 'initialize_twitter' ] );
+			add_action( 'init', [ $this, 'initialize_slack' ] );
 			add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
 
 			// Add metadescription filter.
@@ -135,6 +136,14 @@ class Yoast_WooCommerce_SEO {
 	 */
 	public function initialize_twitter() {
 		$twitter = new WPSEO_WooCommerce_Twitter();
+		$twitter->register_hooks();
+	}
+
+	/**
+	 * Initialized the slack functionality.
+	 */
+	public function initialize_slack() {
+		$twitter = new WPSEO_WooCommerce_Slack();
 		$twitter->register_hooks();
 	}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -132,7 +132,7 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Initialized the twitter functionality.
+	 * Initializes the twitter functionality.
 	 */
 	public function initialize_twitter() {
 		$twitter = new WPSEO_WooCommerce_Twitter();
@@ -140,11 +140,11 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Initialized the slack functionality.
+	 * Initializes the slack functionality.
 	 */
 	public function initialize_slack() {
-		$twitter = new WPSEO_WooCommerce_Slack();
-		$twitter->register_hooks();
+		$slack = new WPSEO_WooCommerce_Slack();
+		$slack->register_hooks();
 	}
 
 	/**

--- a/classes/woocommerce-slack.php
+++ b/classes/woocommerce-slack.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin file.
+ *
+ * @package WPSEO/WooCommerce
+ */
+
+/**
+ * Class WPSEO_WooCommerce_Slack
+ */
+class WPSEO_WooCommerce_Slack {
+
+	/**
+	 * Register hooks.
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_enhanced_data', [ $this, 'filter_enhanced_data' ], 10, 2 );
+	}
+
+	/**
+	 * Replace the default enhanced data (author, reading time) with custom data.
+	 *
+	 * @param array $data The array of labels => value.
+	 * @param Indexable_Presentation $presentation  The indexable presentation.
+	 *
+	 * @return array The filtered array.
+	 */
+	public function filter_enhanced_data( $data, $presentation ) {
+		$object     = $presentation->model;
+		$product    = \wc_get_product( $object->object_id );
+
+		if ( $product ) {
+			$data       = [];
+			$product_type = WPSEO_WooCommerce_Utils::get_product_type( $product );
+			// Omit the price amount for variable and grouped products.
+			$show_price = apply_filters( 'Yoast\WP\Woocommerce\og_price', true ) && ! ( $product_type === 'variable' || $product_type === 'grouped' );
+
+			$availability = 'Out of stock';
+			if ( $product->is_on_backorder() ) {
+				$availability = 'On backorder';
+			}
+
+			if ( $product->is_in_stock() ) {
+				$availability = 'In stock';
+			}
+
+			if ( $show_price ) {
+				$price = \wp_strip_all_tags( $product->get_price_html() );
+				$data[ __( 'Price', 'woocommerce' ) ] = $price;
+			}
+			$data[ __( 'Availability', 'woocommerce' ) ] = __( $availability, 'woocommerce' );
+		}
+
+		return $data;
+	}
+}

--- a/classes/woocommerce-slack.php
+++ b/classes/woocommerce-slack.php
@@ -20,35 +20,36 @@ class WPSEO_WooCommerce_Slack {
 	/**
 	 * Replace the default enhanced data (author, reading time) with custom data.
 	 *
-	 * @param array $data The array of labels => value.
+	 * @param array                  $data The array of labels => value.
 	 * @param Indexable_Presentation $presentation  The indexable presentation.
 	 *
 	 * @return array The filtered array.
 	 */
 	public function filter_enhanced_data( $data, $presentation ) {
-		$object     = $presentation->model;
-		$product    = \wc_get_product( $object->object_id );
+		$object  = $presentation->model;
+		$product = \wc_get_product( $object->object_id );
 
 		if ( $product ) {
-			$data       = [];
+			$data         = [];
 			$product_type = WPSEO_WooCommerce_Utils::get_product_type( $product );
 			// Omit the price amount for variable and grouped products.
 			$show_price = apply_filters( 'Yoast\WP\Woocommerce\og_price', true ) && ! ( $product_type === 'variable' || $product_type === 'grouped' );
 
-			$availability = 'Out of stock';
+			$availability = __( 'Out of stock', 'yoast-woo-seo' );
 			if ( $product->is_on_backorder() ) {
-				$availability = 'On backorder';
+				$availability = __( 'On backorder', 'yoast-woo-seo' );
 			}
 
 			if ( $product->is_in_stock() ) {
-				$availability = 'In stock';
+				$availability = __( 'In stock', 'yoast-woo-seo' );
 			}
 
 			if ( $show_price ) {
 				$price = \wp_strip_all_tags( $product->get_price_html() );
-				$data[ __( 'Price', 'woocommerce' ) ] = $price;
+
+				$data[ __( 'Price', 'yoast-woo-seo' ) ] = $price;
 			}
-			$data[ __( 'Availability', 'woocommerce' ) ] = __( $availability, 'woocommerce' );
+			$data[ __( 'Availability', 'yoast-woo-seo' ) ] = $availability;
 		}
 
 		return $data;

--- a/classes/woocommerce-slack.php
+++ b/classes/woocommerce-slack.php
@@ -11,17 +11,17 @@
 class WPSEO_WooCommerce_Slack {
 
 	/**
-	 * Register hooks.
+	 * Registers the hooks.
 	 */
 	public function register_hooks() {
 		\add_filter( 'wpseo_enhanced_data', [ $this, 'filter_enhanced_data' ], 10, 2 );
 	}
 
 	/**
-	 * Replace the default enhanced data (author, reading time) with custom data.
+	 * Replaces the default enhanced data (author, reading time) with custom data.
 	 *
-	 * @param array                  $data The array of labels => value.
-	 * @param Indexable_Presentation $presentation  The indexable presentation.
+	 * @param array                  $data         The array of labels => value.
+	 * @param Indexable_Presentation $presentation The indexable presentation.
 	 *
 	 * @return array The filtered array.
 	 */

--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -51,17 +51,17 @@ class Slack_Test extends TestCase {
 			'Est. reading time' => '15 minutes',
 		];
 
-		$model              = (object) [
+		$model   = (object) [
 			'object_id'       => 13,
 			'object_type'     => 'post',
 			'object_sub_type' => 'product',
 		];
-		$product            = Mockery::mock( 'WC_Product' )->makePartial();
-		$price              = '&euro;25.00';
+		$product = Mockery::mock( 'WC_Product' )->makePartial();
+		$price   = '&euro;25.00';
 
 		$product
 			->expects( 'get_price_html' )
-			->andReturn(  );
+			->andReturn( $price );
 		$product
 			->expects( 'is_on_backorder' )
 			->andReturn( false );
@@ -78,12 +78,14 @@ class Slack_Test extends TestCase {
 			->with( $price )
 			->andReturn( $price );
 
-		$this->assertSame( [
-			'Price' => '&euro;25.00',
-			'Availability' => 'In stock',
-		], $this->instance->filter_enhanced_data( $data, $presentation ) );
+		$this->assertSame(
+			[
+				'Price'        => '&euro;25.00',
+				'Availability' => 'In stock',
+			],
+			$this->instance->filter_enhanced_data( $data, $presentation )
+		);
 	}
-
 
 	/**
 	 * Mocks the Indexable presentation.
@@ -95,7 +97,7 @@ class Slack_Test extends TestCase {
 	private function mock_presentation( $model ) {
 		$presentation = Mockery::mock();
 
-		$presentation->model   = $model;
+		$presentation->model = $model;
 
 		return $presentation;
 	}

--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -41,7 +41,7 @@ class Slack_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the enhanced data is correctly filtered
+	 * Tests that the enhanced data is correctly filtered.
 	 *
 	 * @covers ::filter_enhanced_data
 	 */
@@ -90,9 +90,9 @@ class Slack_Test extends TestCase {
 	/**
 	 * Mocks the Indexable presentation.
 	 *
-	 * @param object $model   The model.
+	 * @param object $model The model.
 	 *
-	 * @return Mockery\MockInterface The mock presentation
+	 * @return Mockery\MockInterface The mock presentation.
 	 */
 	private function mock_presentation( $model ) {
 		$presentation = Mockery::mock();

--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes;
+
+use Brain\Monkey;
+use Mockery;
+use WPSEO_WooCommerce_Slack;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Slack_Test
+ *
+ * @coversDefaultClass \WPSEO_WooCommerce_Slack
+ */
+class Slack_Test extends TestCase {
+
+	/**
+	 * The Slack class under test.
+	 *
+	 * @var \WPSEO_WooCommerce_Slack
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the tests.
+	 */
+	public function setUp() {
+		$this->instance = new WPSEO_WooCommerce_Slack();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests that the right hooks are registered.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Filters\expectAdded( 'wpseo_enhanced_data' );
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests that the enhanced data is correctly filtered
+	 *
+	 * @covers ::filter_enhanced_data
+	 */
+	public function test_filter_enhanced_data() {
+		$data = [
+			'Written by'        => 'Agatha Christie',
+			'Est. reading time' => '15 minutes',
+		];
+
+		$model              = (object) [
+			'object_id'       => 13,
+			'object_type'     => 'post',
+			'object_sub_type' => 'product',
+		];
+		$product            = Mockery::mock( 'WC_Product' )->makePartial();
+		$price              = '&euro;25.00';
+
+		$product
+			->expects( 'get_price_html' )
+			->andReturn(  );
+		$product
+			->expects( 'is_on_backorder' )
+			->andReturn( false );
+		$product
+			->expects( 'is_in_stock' )
+			->andReturn( true );
+
+		$presentation = $this->mock_presentation( $model );
+
+		Monkey\Functions\expect( 'wc_get_product' )
+			->with( $model->object_id )
+			->andReturn( $product );
+		Monkey\Functions\expect( 'wp_strip_all_tags' )
+			->with( $price )
+			->andReturn( $price );
+
+		$this->assertSame( [
+			'Price' => '&euro;25.00',
+			'Availability' => 'In stock',
+		], $this->instance->filter_enhanced_data( $data, $presentation ) );
+	}
+
+
+	/**
+	 * Mocks the Indexable presentation.
+	 *
+	 * @param object $model   The model.
+	 *
+	 * @return Mockery\MockInterface The mock presentation
+	 */
+	private function mock_presentation( $model ) {
+		$presentation = Mockery::mock();
+
+		$presentation->model   = $model;
+
+		return $presentation;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Yoast/wordpress-seo#16183 introduces a filter on the new Enhanced Slack data. We want to use this filter to show custom data for products.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hooks on the new Yoast SEO `wpseo_enhanced_data` filter to show product data whan sharing on Slack

## Relevant technical choices:

* The translations for "Price" and "Availability", as well as "In stock, "On backorder" and "Out of stock", could be taken from the WooCommerce translations instead of duplicating the strings in the Yoast WooCommerce SEO dictionary, but this not allowed by CS

## Test instructions

This PR can be tested by following these steps:

* Checkout and build, making sure you have using Yoast SEO in which Yoast/wordpress-seo#16183 has been merged.
* Visit a product on the front end and inspect the source.
* check that just before the schema there are tags like these ones:
```
	<meta name="twitter:label1" value="Price">
	<meta name="twitter:data1" value="&pound;100.00">
	<meta name="twitter:label2" value="Availability">
	<meta name="twitter:data2" value="In stock">
```
* Also check these product-related tags are missing in standard posts/pages, where the original "Written by"+"Est. reading time" are used.


Fixes [P3-204]
