### PR TITLE
P3-239 Fix checking for backorder

### DIFF
--- a/classes/woocommerce-slack.php
+++ b/classes/woocommerce-slack.php
@@ -36,12 +36,14 @@ class WPSEO_WooCommerce_Slack {
 			$show_price = apply_filters( 'Yoast\WP\Woocommerce\og_price', true ) && ! ( $product_type === 'variable' || $product_type === 'grouped' );
 
 			$availability = __( 'Out of stock', 'yoast-woo-seo' );
-			if ( $product->is_on_backorder() ) {
-				$availability = __( 'On backorder', 'yoast-woo-seo' );
-			}
 
+			// Should be checked before backorder because it's true for both cases.
 			if ( $product->is_in_stock() ) {
 				$availability = __( 'In stock', 'yoast-woo-seo' );
+			}
+
+			if ( $product->is_on_backorder() ) {
+				$availability = __( 'On backorder', 'yoast-woo-seo' );
 			}
 
 			if ( $show_price ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Enhanced Slack sharing feature is currently broken on products that are "On back order"-

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Fixes a bug where the Enhanced Slack sharing showed wrong availability for products on backorder

## Relevant technical choices:

* This happened beacuse `product->is_in_stock()` returns `true` for backorder products too, so it must be checked first.

## Test instructions

This PR can be tested by following these steps:
* Checkout and build, making sure you have using Yoast SEO in which Yoast/wordpress-seo#16183 has been merged (`release/15.2` will be fine) + WooCommerce with some products
* Visit a product which is on backorder on the front end and inspect the source.
* check that just before the schema there are tags like these ones:
```
	<meta name="twitter:label1" value="Price">
	<meta name="twitter:data1" value="&pound;100.00">
	<meta name="twitter:label2" value="Availability">
	<meta name="twitter:data2" value="On backorder">
```
* Visit a product which is in stock on the front end and inspect the source.
* check that just before the schema there are tags like these ones:
```
	<meta name="twitter:label1" value="Price">
	<meta name="twitter:data1" value="&pound;100.00">
	<meta name="twitter:label2" value="Availability">
	<meta name="twitter:data2" value="In stock">
```

Fixes [P3-239]
