### PR TITLE
Composer: update BrainMonkey with dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "yoast/yoastcs": "^2.1.0",
         "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
-        "brain/monkey": "^2.4",
+        "brain/monkey": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "php-parallel-lint/php-console-highlighter": "^0.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3a69cac3c0e3c94386cd62e753ce02c",
+    "content-hash": "546e9b7b72232160ef6b0813ad43bcf6",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -55,16 +55,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.11",
+            "version": "2.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0"
+                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
-                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea",
                 "shasum": ""
             },
             "require": {
@@ -95,20 +95,20 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2019-10-26T07:10:56+00:00"
+            "time": "2019-12-22T17:52:09+00:00"
         },
         {
             "name": "brain/monkey",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "b3ce8b619c26db6abd01b9dcfd6a2c0254060956"
+                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/b3ce8b619c26db6abd01b9dcfd6a2c0254060956",
-                "reference": "b3ce8b619c26db6abd01b9dcfd6a2c0254060956",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/f2295a57da59ff88621cd959dbdb4b288feefd19",
+                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19",
                 "shasum": ""
             },
             "require": {
@@ -117,9 +117,9 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || ^0.7",
                 "phpcompatibility/php-compatibility": "^9.3.0",
-                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^5.7.9 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -161,7 +161,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2019-11-24T16:03:21+00:00"
+            "time": "2020-10-09T06:55:33+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -285,20 +285,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0"
+                "php": "^5.3|^7.0|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -306,14 +306,13 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "^1.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -323,41 +322,40 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD"
+                "BSD-3-Clause"
             ],
             "description": "This is the PHP port of Hamcrest Matchers",
             "keywords": [
                 "test"
             ],
-            "time": "2016-01-20T08:20:44+00:00"
+            "time": "2020-07-09T08:09:16+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "1.3.0",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "5571962a4f733fbb57bede39778f71647fae8e66"
+                "reference": "60fa2f67f6e4d3634bb4a45ff3171fa52215800d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/5571962a4f733fbb57bede39778f71647fae8e66",
-                "reference": "5571962a4f733fbb57bede39778f71647fae8e66",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/60fa2f67f6e4d3634bb4a45ff3171fa52215800d",
+                "reference": "60fa2f67f6e4d3634bb4a45ff3171fa52215800d",
                 "shasum": ""
             },
             "require": {
-                "hamcrest/hamcrest-php": "~2.0",
+                "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.6.0",
-                "sebastian/comparator": "^1.2.4|^3.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+                "phpunit/phpunit": "^5.7.10|^6.5|^7.5|^8.5|^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -395,7 +393,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-11-24T07:54:50+00:00"
+            "time": "2020-08-11T18:10:21+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -40,9 +40,9 @@ class OpenGraph_Test extends TestCase {
 	public function test_construct() {
 		$og = new WPSEO_WooCommerce_OpenGraph();
 
-		$this->assertTrue( \has_filter( 'language_attributes', [ $og, 'product_namespace' ] ) );
-		$this->assertTrue( \has_filter( 'wpseo_opengraph_type', [ $og, 'return_type_product' ] ) );
-		$this->assertTrue( \has_action( 'wpseo_add_opengraph_additional_images', [ $og, 'set_opengraph_image' ] ) );
+		$this->assertSame( 11, \has_filter( 'language_attributes', [ $og, 'product_namespace' ] ) );
+		$this->assertSame( 10, \has_filter( 'wpseo_opengraph_type', [ $og, 'return_type_product' ] ) );
+		$this->assertSame( 10, \has_action( 'wpseo_add_opengraph_additional_images', [ $og, 'set_opengraph_image' ] ) );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -43,8 +43,9 @@ class Schema_Test extends TestCase {
 	public function test_construct() {
 		$schema = new WPSEO_WooCommerce_Schema( '3.9' );
 
-		$this->assertTrue( \has_filter( 'woocommerce_structured_data_product', [ $schema, 'change_product' ] ) );
-		$this->assertTrue(
+		$this->assertSame( 10, \has_filter( 'woocommerce_structured_data_product', [ $schema, 'change_product' ] ) );
+		$this->assertSame(
+			10,
 			\has_filter(
 				'woocommerce_structured_data_type_for_page',
 				[
@@ -53,8 +54,8 @@ class Schema_Test extends TestCase {
 				]
 			)
 		);
-		$this->assertTrue( \has_filter( 'wpseo_schema_webpage', [ $schema, 'filter_webpage' ] ) );
-		$this->assertTrue( \has_action( 'wp_footer', [ $schema, 'output_schema_footer' ] ) );
+		$this->assertSame( 10, \has_filter( 'wpseo_schema_webpage', [ $schema, 'filter_webpage' ] ) );
+		$this->assertSame( 10, \has_action( 'wp_footer', [ $schema, 'output_schema_footer' ] ) );
 
 		$this->assertFalse(
 			\has_filter(
@@ -74,7 +75,7 @@ class Schema_Test extends TestCase {
 	 */
 	public function test_construct_old_wc() {
 		$schema = new WPSEO_WooCommerce_Schema( '3.8' );
-		$this->assertTrue( \has_filter( 'woocommerce_structured_data_review', [ $schema, 'change_reviewed_entity' ] ) );
+		$this->assertSame( 10, \has_filter( 'woocommerce_structured_data_review', [ $schema, 'change_reviewed_entity' ] ) );
 	}
 
 	/**

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -19,9 +19,9 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 */
 	public function test_construct() {
 		$instance = new WPSEO_WooCommerce_Yoast_Tab();
-		$this->assertTrue( \has_filter( 'woocommerce_product_data_tabs', [ $instance, 'yoast_seo_tab' ] ) );
-		$this->assertTrue( \has_action( 'woocommerce_product_data_panels', [ $instance, 'add_yoast_seo_fields' ] ) );
-		$this->assertTrue( \has_action( 'save_post', [ $instance, 'save_data' ] ) );
+		$this->assertSame( 10, \has_filter( 'woocommerce_product_data_tabs', [ $instance, 'yoast_seo_tab' ] ) );
+		$this->assertSame( 10, \has_action( 'woocommerce_product_data_panels', [ $instance, 'add_yoast_seo_fields' ] ) );
+		$this->assertSame( 10, \has_action( 'save_post', [ $instance, 'save_data' ] ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Updated test dependency

## Summary
This PR can be summarized in the following changelog entry:

* Updated test dependency

## Relevant technical choices:

### Composer: update BrainMonkey with dependencies

Updated:
* BrainMonkey from v 2.4.0 to 2.5.0.
    Note: this version contains a test breaking change which will be addressed in a subsequent commit if applicable for this repo.
* Mockery from v 1.3.0 to 1.3.3.
    Improved support for PHP 8.
* Hamcrest-php from v 2.0.0 to 2.0.1
    ... which claims compatibility with PHP 8.
* Patchwork from v 2.1.11 to 2.1.12
    This fixes [two issues](antecedent/patchwork#99) which _might_ be relevant for us.

Refs:
* https://github.com/Brain-WP/BrainMonkey/releases
* https://github.com/mockery/mockery/releases
* https://github.com/hamcrest/hamcrest-php/releases
* https://github.com/antecedent/patchwork/releases

### Tests: update for changed BrainMonkey has_filter() behaviour

The WP native `has_filter()` function returns a boolean if no function name is given, or the priority as an integer if a specific function is being checked or `false` if the function is not attached.

The BrainMonkey mock of the `has_filter()` function previously always returned a boolean.

As of version 2.5.0, it will emulate the WP native function better and return the priority.

This updates the affected tests to check based on the new behaviour of the mock.

Refs:
* https://developer.wordpress.org/reference/functions/has_filter/
* https://github.com/Brain-WP/BrainMonkey/releases



## Test instructions


* _N/A_ if the tests pass, we're good.
