### PR TITLE
Apply the wpseo_schema_product filter to make the Product type filterable

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -132,6 +132,13 @@ class WPSEO_WooCommerce_Schema {
 
 		$this->data['review'][] = $data;
 
+		/**
+		 * Filter: 'wpseo_schema_review' - Allow changing the Review type.
+		 *
+		 * @api array $data The Schema Review data.
+		 */
+		$this->data = apply_filters( 'wpseo_schema_review', $this->data );
+
 		return [];
 	}
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -8,7 +8,7 @@
 use Yoast\WP\SEO\Config\Schema_IDs;
 
 /**
- * Class WPSEO_WooCommerce_Schema
+ * Class WPSEO_WooCommerce_Schema.
  */
 class WPSEO_WooCommerce_Schema {
 
@@ -162,6 +162,13 @@ class WPSEO_WooCommerce_Schema {
 		$this->add_manufacturer( $product );
 		$this->add_color( $product );
 		$this->add_global_identifier( $product );
+
+		/**
+		 * Filter: 'wpseo_schema_product' - Allow changing the Product type.
+		 *
+		 * @api array $data The Schema Product data.
+		 */
+		$this->data = apply_filters( 'wpseo_schema_product', $this->data );
 
 		return [];
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1033,6 +1033,8 @@ class Schema_Test extends TestCase {
 			],
 		];
 
+		Monkey\Filters\expectApplied( 'wpseo_schema_product' )->once();
+
 		$expected = [
 			'@type'            => 'Product',
 			'@id'              => $canonical . '#product',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* https://yoast.atlassian.net/browse/P2-504

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the Schema `Product` type filterable.

## Relevant technical choices:

* I looked for all occurrences of the filter `woocommerce_structured_data_***` in the code and found these three:
    * `woocommerce_structured_data_product`.
    * `woocommerce_structured_data_type_for_page`.
    * `woocommerce_structured_data_review`.
* The `woocommerce_structured_data_product` filter triggers the `change_product` method, which changes the Schema `Product` type. I added a call to our `wpseo_schema_product` filter to make the `Product` type filterable.
* The `woocommerce_structured_data_type_for_page` filter triggers the `remove_woo_breadcrumbs` method, which removes the Woo breadcrumbs from the Schema output. I did not add a call to a Yoast filter here, since `remove_woo_breadcrumbs` only has the responsibility to remove the Woo breadcrumbs.
* The `woocommerce_structured_data_review` filter triggers the `change_reviewed_entity` method. However, [the review filter is applied](https://github.com/woocommerce/woocommerce/blob/02cf0dfaed5923513de0c88add597d1560c2cfd2/includes/class-wc-structured-data.php#L368) in a method that is [no longer used, but not deprecated either](https://github.com/woocommerce/woocommerce/pull/24278#discussion_r312598861). Because the WooCommerce developers mention that they might reintroduce this method, and if so we don't want our code to break, I added a call to our `wpseo_schema_review` filter. But because `woocommerce_structured_data_review` is currently never applied, this change is not testable now. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test the `Product` type filter.**
* Open the page source of a WooCommerce product page in the browser.
* Look for the WooCommerce Schema output (tip: search for `"@type": "Product"`).
    * If you don't see the Schema output, this should be fixable by adding a price to your product.
* Make sure the following code is executed, for example by adding it to `functions.php` of your theme.

```
	add_filter( 'wpseo_schema_product', 'example_change_product' );
	function example_change_product( $data ) {
		$data['cats'] = 'exist';
		return $data;
	}
```

* Refresh the page source.
* See that `"cats": "exist"` has been added to your Product Schema, and that the rest of the Schema is unchanged.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The WooCommerce Schema output.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wpseo-woocommerce/issues/526
