### PR TITLE
add filter so we can prevent priceValidUntil from being removed  #526

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -232,7 +232,9 @@ class WPSEO_WooCommerce_Schema {
 			 */
 
 			if ( ! $product->is_on_sale() || ! $product->get_date_on_sale_to() ) {
-				unset( $offers[ $key ]['priceValidUntil'] );
+				if( apply_filters( 'wp_seo_schema_not_on_sale_remove_priceValidUntil', true, $product, $offer ) ) {
+					unset( $offers[ $key ][ 'priceValidUntil' ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Yoast is removing priceValidUntil without giving me any control over preventing this action. I believe there should be a higher-level filter that allows us to filter it one final time before outputting, but that doesn't quite exist. #526 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

Fixes a bug where Yoast doesn't give us a way to prevent priceValidUntil from being removed on some products in certain scenarios.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Not sure what to put here. Can prevent this behavior globally with the following filter:
`add_filter( 'wp_seo_schema_not_on_sale_remove_priceValidUntil', '__return_false' );`

or with specific products with the $product object that's passed


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

Schema / Structured Data

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #526
