### PR TITLE
Unit Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpcs.xml
 phpunit.xml
 yarn-error.log
 /js/dist/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,12 +79,12 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" && "$PHPLINT" == "1" ]]; then
-    composer install --no-interaction --ignore-platform-reqs
+  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_retry composer install --no-interaction --ignore-platform-reqs
   elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$PHPLINT" == "1" ]]; then
-    composer install --no-interaction
+    travis_retry composer install --no-interaction
   elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "deploy" ]]; then
-    composer install --no-dev --no-interaction
+    travis_retry composer install --no-dev --no-interaction
   fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn global add grunt-cli; yarn install; fi
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar; fi
@@ -107,7 +107,7 @@ before_script:
   if [[ "$PHPUNIT" == "1" ]]; then
     git clone --depth=1 --branch="trunk" https://github.com/Yoast-dist/wordpress-seo.git $WP_DEVELOP_DIR/src/wp-content/plugins/wordpress-seo
     cd /tmp/wordpress/src/wp-content/plugins/wordpress-seo
-    composer install --no-dev --no-scripts --no-interaction --ignore-platform-reqs
+    travis_retry composer install --no-dev --no-scripts --no-interaction --ignore-platform-reqs
     cd -
   fi
 
@@ -151,6 +151,13 @@ script:
 - |
   if [[ "$PHPUNIT" == "1"  ]]; then
     travis_fold start "PHP.tests" && travis_time_start
+    composer test
+    travis_time_finish && travis_fold end "PHP.tests"
+  fi
+- |
+  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_fold start "PHP.tests" && travis_time_start
+    travis_retry composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs --no-interaction &&
     composer test
     travis_time_finish && travis_fold end "PHP.tests"
   fi

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,9 @@
     },
     "require-dev": {
         "yoast/yoastcs": "^2.1.0",
-        "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0",
-        "brain/monkey": "^2.5",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "php-parallel-lint/php-console-highlighter": "^0.5"
+        "php-parallel-lint/php-console-highlighter": "^0.5",
+        "yoast/wp-test-utils": "^0.1.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
             "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
         ],
         "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist"
+            "@php ./vendor/phpunit/phpunit/phpunit"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "546e9b7b72232160ef6b0813ad43bcf6",
+    "content-hash": "0c8e9b92820fcf676f8066bee16371b4",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -895,38 +895,38 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -954,7 +954,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1914,16 +1914,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
@@ -1935,7 +1935,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-main": "1.19-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1952,12 +1956,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1968,20 +1972,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T09:01:57+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.27",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
                 "shasum": ""
             },
             "require": {
@@ -1998,11 +2016,6 @@
                 "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
@@ -2027,36 +2040,48 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2078,7 +2103,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2125,6 +2150,127 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "time": "2020-11-25T02:59:57+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.5.0",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^0.2.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "unit-testing",
+                "wordpress"
+            ],
+            "time": "2020-11-25T12:40:18+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
 		processIsolation="false"
 		stopOnError="false"
 		stopOnFailure="false"
@@ -23,7 +24,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<directory>./classes</directory>
 			<file>./wpseo-woocommerce.php</file>
 		</whitelist>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,45 +2,28 @@
 
 namespace Yoast\WP\Woocommerce\Tests;
 
-use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use Brain\Monkey;
 use Mockery;
+use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
 /**
  * TestCase base class.
  */
-abstract class TestCase extends PHPUnit_TestCase {
+abstract class TestCase extends YoastTestCase {
 
 	/**
 	 * Test setup.
 	 */
-	protected function setUp() {
+	protected function set_up() {
+		parent::set_up();
 
-		parent::setUp();
-		Monkey\setUp();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
 
 		Monkey\Functions\stubs(
 			[
 				// Using `null` makes that function return it's first argument.
-				'esc_attr'       => null,
-				'esc_html'       => null,
-				'esc_textarea'   => null,
-				'__'             => null,
-				'_x'             => null,
-				'esc_html__'     => null,
-				'esc_html_x'     => null,
-				'esc_attr_x'     => null,
 				'is_admin'       => false,
-				'is_multisite'   => false,
-				'site_url'       => 'https://www.example.org',
-				'wp_json_encode' => static function( $data, $options = 0, $depth = 512 ) {
-					// phpcs:ignore Yoast.Yoast.AlternativeFunctions -- Mocks the wp_json_encode function.
-					return \json_encode( $data, $options, $depth );
-				},
-				'wp_slash'       => null,
-				'absint'         => static function( $value ) {
-					return \abs( \intval( $value ) );
-				},
 			]
 		);
 
@@ -53,13 +36,5 @@ abstract class TestCase extends PHPUnit_TestCase {
 			->zeroOrMoreTimes()
 			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
 			->andReturn( [] );
-	}
-
-	/**
-	 * Test tear down.
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,9 +17,6 @@ abstract class TestCase extends YoastTestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->stubEscapeFunctions();
-		$this->stubTranslationFunctions();
-
 		Monkey\Functions\stubs(
 			[
 				// Using `null` makes that function return it's first argument.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,31 +2,15 @@
 /**
  * PHPUnit bootstrap file
  *
- * @package WPSEO/WooCommerce/Tests
+ * @package WPSEO\WooCommerce\Tests
  */
 
-define( 'ABSPATH', true );
 define( 'WPSEO_INDEXABLES', true );
-
-define( 'MINUTE_IN_SECONDS', 60 );
-define( 'HOUR_IN_SECONDS', 3600 );
-define( 'DAY_IN_SECONDS', 86400 );
-define( 'WEEK_IN_SECONDS', 604800 );
-define( 'MONTH_IN_SECONDS', 2592000 );
-define( 'YEAR_IN_SECONDS', 31536000 );
-
-define( 'DB_HOST', 'nowhere' );
-define( 'DB_NAME', 'none' );
-define( 'DB_USER', 'nobody' );
-define( 'DB_PASSWORD', 'nothing' );
-
-if ( function_exists( 'opcache_reset' ) ) {
-	opcache_reset();
-}
 
 if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
 	exit( 1 );
 }
 
+require_once __DIR__ . '/../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -24,12 +24,12 @@ class OpenGraph_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() {
+	public function set_up() {
+		parent::set_up();
+
 		$this->instance = Mockery::mock( WPSEO_WooCommerce_OpenGraph::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -25,8 +25,8 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -44,9 +44,9 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_construct() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, true );
 
-		$this->assertAttributeEquals( $this->product, 'product', $instance );
-		$this->assertAttributeSame( false, 'is_on_backorder', $instance );
-		$this->assertAttributeSame( true, 'is_in_stock', $instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $instance, 'product' ) );
+		$this->assertSame( false, $this->getPropertyValue( $instance, 'is_on_backorder' ) );
+		$this->assertSame( true, $this->getPropertyValue( $instance, 'is_in_stock' ) );
 	}
 
 	/**
@@ -57,7 +57,10 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_tag_format() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false );
 
-		$this->assertAttributeSame( '<meta property="og:availability" content="%s" />', 'tag_format', $instance );
+		$this->assertSame(
+			'<meta property="og:availability" content="%s" />',
+			$this->getPropertyValue( $instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -44,9 +44,9 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_construct() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, true );
 
-		$this->assertAttributeEquals( $this->product, 'product', $instance );
-		$this->assertAttributeSame( false, 'is_on_backorder', $instance );
-		$this->assertAttributeSame( true, 'is_in_stock', $instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $instance, 'product' ) );
+		$this->assertSame( false, $this->getPropertyValue( $instance, 'is_on_backorder' ) );
+		$this->assertSame( true, $this->getPropertyValue( $instance, 'is_in_stock' ) );
 	}
 
 	/**
@@ -57,7 +57,10 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_tag_format() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false );
 
-		$this->assertAttributeSame( '<meta property="product:availability" content="%s" />', 'tag_format', $instance );
+		$this->assertSame(
+			'<meta property="product:availability" content="%s" />',
+			$this->getPropertyValue( $instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -25,8 +25,8 @@ class Product_Availability_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -60,7 +60,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**
@@ -69,7 +69,10 @@ class Product_Brand_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeSame( '<meta property="product:brand" content="%s" />', 'tag_format', $this->instance );
+		$this->assertSame(
+			'<meta property="product:brand" content="%s" />',
+			$this->getPropertyValue( $this->instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -40,8 +40,8 @@ class Product_Brand_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Product_Brand_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -51,7 +51,7 @@ class Product_Condition_Presenter_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**
@@ -60,7 +60,10 @@ class Product_Condition_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeSame( '<meta property="product:condition" content="%s" />', 'tag_format', $this->instance );
+		$this->assertSame(
+			'<meta property="product:condition" content="%s" />',
+			$this->getPropertyValue( $this->instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -33,8 +33,8 @@ class Product_Condition_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -91,6 +91,6 @@ class Product_Condition_Presenter_Test extends TestCase {
 		$actual = $this->instance->get();
 
 		$this->assertSame( '123', $actual );
-		$this->assertInternalType( 'string', $actual );
+		$this->assertIsString( $actual );
 	}
 }

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -33,8 +33,8 @@ class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -51,7 +51,7 @@ class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -51,7 +51,7 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**
@@ -60,7 +60,10 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeEquals( '<meta property="product:price:amount" content="%s" />', 'tag_format', $this->instance );
+		$this->assertSame(
+			'<meta property="product:price:amount" content="%s" />',
+			$this->getPropertyValue( $this->instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -34,8 +34,8 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -107,6 +107,6 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 		$actual = $this->instance->get();
 
 		$this->assertSame( '11', $actual );
-		$this->assertInternalType( 'string', $actual );
+		$this->assertIsString( $actual );
 	}
 }

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -34,8 +34,8 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -51,7 +51,7 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**
@@ -60,7 +60,10 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeSame( '<meta property="product:price:currency" content="%s" />', 'tag_format', $this->instance );
+		$this->assertSame(
+			'<meta property="product:price:currency" content="%s" />',
+			$this->getPropertyValue( $this->instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -32,8 +32,8 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	/**
 	 * Initializes the test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -49,7 +49,7 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->product, 'product', $this->instance );
+		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**
@@ -58,7 +58,10 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	 * @coversNothing
 	 */
 	public function test_tag_format() {
-		$this->assertAttributeSame( '<meta property="product:retailer_item_id" content="%s" />', 'tag_format', $this->instance );
+		$this->assertSame(
+			'<meta property="product:retailer_item_id" content="%s" />',
+			$this->getPropertyValue( $this->instance, 'tag_format' )
+		);
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -8,7 +8,7 @@ use Mockery;
 use WPSEO_WooCommerce_Schema;
 use Yoast\WP\Woocommerce\Tests\Doubles\Schema_Double;
 use Yoast\WP\Woocommerce\Tests\Mocks\Schema_IDs;
-use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 /**
  * Class WooCommerce_Schema_Test.
@@ -21,6 +21,13 @@ class Schema_Test extends TestCase {
 
 	/**
 	 * Test setup.
+	 *
+	 * Note: this test class doesn't extend the `Yoast\WP\Woocommerce\Tests\TestCase` class
+	 * as the default stubs declared in the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase` interfer
+	 * with some mockery expectations set in the tests in this class.
+	 *
+	 * So, this test has to st the `get_option` and `get_site_option` expectations explicitly in this
+	 * `set_up()` method as these are not inherited from the parent TestCase.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -28,6 +35,16 @@ class Schema_Test extends TestCase {
 		if ( ! \defined( 'WC_VERSION' ) ) {
 			\define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		}
+
+		Monkey\Functions\expect( 'get_option' )
+			->zeroOrMoreTimes()
+			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->andReturn( [] );
+
+		Monkey\Functions\expect( 'get_site_option' )
+			->zeroOrMoreTimes()
+			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->andReturn( [] );
 
 		Mockery::mock( 'overload:Yoast\WP\SEO\Config\Schema_IDs', new Schema_IDs() );
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -22,8 +22,9 @@ class Schema_Test extends TestCase {
 	/**
 	 * Test setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
+
 		if ( ! \defined( 'WC_VERSION' ) ) {
 			\define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 		}

--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -73,6 +73,8 @@ class Slack_Test extends TestCase {
 
 		$presentation = $this->mock_presentation( $model );
 
+		$this->stubTranslationFunctions();
+
 		Monkey\Functions\expect( 'wc_get_product' )
 			->with( $model->object_id )
 			->andReturn( $product );
@@ -121,6 +123,8 @@ class Slack_Test extends TestCase {
 			->andReturn( true );
 
 		$presentation = $this->mock_presentation( $model );
+
+		$this->stubTranslationFunctions();
 
 		Monkey\Functions\expect( 'wc_get_product' )
 			->with( $model->object_id )

--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -24,10 +24,10 @@ class Slack_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		$this->instance = new WPSEO_WooCommerce_Slack();
+	public function set_up() {
+		parent::set_up();
 
-		parent::setUp();
+		$this->instance = new WPSEO_WooCommerce_Slack();
 	}
 
 	/**

--- a/tests/classes/twitter-test.php
+++ b/tests/classes/twitter-test.php
@@ -24,10 +24,10 @@ class Twitter_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		$this->instance = new WPSEO_WooCommerce_Twitter();
+	public function set_up() {
+		parent::set_up();
 
-		parent::setUp();
+		$this->instance = new WPSEO_WooCommerce_Twitter();
 	}
 
 	/**

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -102,6 +102,8 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @covers Yoast_WooCommerce_Dependencies::woocommerce_missing_error
 	 */
 	public function test_woocommerce_missing_error() {
+		$this->stubTranslationFunctions();
+
 		$expected = '<div class="error"><p>Please <a href="plugin-install.php?tab=search&type=term&s=woocommerce&plugin-search-input=Search+Plugins">install &amp; activate WooCommerce</a> to allow the Yoast WooCommerce SEO module to work.</p></div>';
 
 		$this->error_message_test( 'woocommerce_missing_error', $expected );
@@ -113,6 +115,8 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @covers Yoast_WooCommerce_Dependencies::yoast_seo_missing_error
 	 */
 	public function test_yoast_seo_missing_error() {
+		$this->stubTranslationFunctions();
+
 		$expected = '<div class="error"><p>Please <a href="plugin-install.php?tab=search&type=term&s=yoast+seo&plugin-search-input=Search+Plugins">install &amp; activate Yoast SEO</a> to allow the Yoast WooCommerce SEO module to work.</p></div>';
 
 		$this->error_message_test( 'yoast_seo_missing_error', $expected );
@@ -124,6 +128,8 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @covers Yoast_WooCommerce_Dependencies::wordpress_upgrade_error
 	 */
 	public function test_wordpress_upgrade_error() {
+		$this->stubTranslationFunctions();
+
 		$expected = '<div class="error"><p>Please upgrade WordPress to the latest version to allow WordPress and the Yoast WooCommerce SEO module to work properly.</p></div>';
 
 		$this->error_message_test( 'wordpress_upgrade_error', $expected );
@@ -135,6 +141,8 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @covers Yoast_WooCommerce_Dependencies::yoast_seo_upgrade_error
 	 */
 	public function test_yoast_seo_upgrade_error() {
+		$this->stubTranslationFunctions();
+
 		$expected = '<div class="error"><p>Please upgrade the Yoast SEO plugin to the latest version to allow the Yoast WooCommerce SEO module to work.</p></div>';
 
 		$this->error_message_test( 'yoast_seo_upgrade_error', $expected );

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -50,14 +50,14 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 		\ob_start();
 
 		\define( 'WPSEO_WOO_PLUGIN_FILE', './wpseo-woocommerce.php' );
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
 		Functions\stubs(
 			[
 				'get_the_ID'      => 123,
 				'get_post_meta'   => 'gtin8',
 				'plugin_dir_path' => './',
-				'_e'              => null,
-				'esc_attr'        => null,
-				'esc_html_e'      => null,
 				'wp_nonce_field'  => static function ( $action, $name ) {
 					return '<input type="hidden" id="" name="' . $name . '" value="' . $action . '" />';
 				},
@@ -191,12 +191,8 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::input_field_for_identifier
 	 */
 	public function test_input_field_for_identifier() {
-		Functions\stubs(
-			[
-				'esc_attr' => null,
-				'esc_html' => null,
-			]
-		);
+
+		$this->stubEscapeFunctions();
 
 		\ob_start();
 		$instance = new Yoast_Tab_Double();

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -118,11 +118,6 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 				'wp_is_post_revision' => false,
 				'wp_verify_nonce'     => true,
 				'update_post_meta'    => true,
-				'wp_strip_all_tags'   => static function ( $value ) {
-					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
-					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
-					return \strip_tags( $value );
-				},
 			]
 		);
 
@@ -144,12 +139,6 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 				'wp_is_post_revision' => false,
 				'wp_verify_nonce'     => true,
 				'update_post_meta'    => true,
-				'wp_unslash'          => null,
-				'wp_strip_all_tags'   => static function ( $value ) {
-					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
-					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
-					return \strip_tags( $value );
-				},
 			]
 		);
 
@@ -169,16 +158,6 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::validate_data
 	 */
 	public function test_validate_data() {
-		Functions\stubs(
-			[
-				'wp_strip_all_tags' => static function ( $value ) {
-					// Ignoring WPCS's warning about using `wp_strip_all_tags` because we're *doing that*.
-					// @phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
-					return \strip_tags( $value );
-				},
-			]
-		);
-
 		$instance = new Yoast_Tab_Double();
 		$this->assertTrue( $instance->validate_data( '12345' ) );
 		$this->assertFalse( $instance->validate_data( '12345<script>' ) );

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -70,8 +70,8 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 		$output = \ob_get_contents();
 		\ob_end_clean();
 
-		$this->assertContains( 'yoast_seo[gtin8]', $output );
-		$this->assertContains( '<div id="yoast_seo" class="panel woocommerce_options_panel">', $output );
+		$this->assertStringContainsString( 'yoast_seo[gtin8]', $output );
+		$this->assertStringContainsString( '<div id="yoast_seo" class="panel woocommerce_options_panel">', $output );
 	}
 
 	/**
@@ -179,9 +179,9 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 		$output = \ob_get_contents();
 		\ob_end_clean();
 
-		$this->assertContains( 'gtin8', $output );
-		$this->assertContains( 'GTIN 8', $output );
-		$this->assertContains( '12345678', $output );
-		$this->assertContains( 'yoast_identifier_gtin8', $output );
+		$this->assertStringContainsString( 'gtin8', $output );
+		$this->assertStringContainsString( 'GTIN 8', $output );
+		$this->assertStringContainsString( '12345678', $output );
+		$this->assertStringContainsString( 'yoast_identifier_gtin8', $output );
 	}
 }


### PR DESCRIPTION
## Context

* Preparation for compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* Preparation for compatibility with PHP 8

## Relevant technical choices:

Similar to the other test update PRs, this PR will be easiest to review by looking at each commit individually.

### Composer: allow overload of the PHPUnit config file

### Composer: require Yoast/wp-test-utils

* Adds a dev dependency to the `yoast/wp-test-utils` package, which will also make the PHPUnit Polyfills available.
* As that package already requires and manages the installable versions for BrainMonkey and PHPUnit, remove these as explicit requirements from `require- dev` in favour of letting the WP Test Utils package manage the versions.

The install is done based on PHP 5.6 and includes updating the dependencies from PHPUnit itself within the constraints of maintaining compatibility with  PHP 5.6.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test cases for use by the plugins.

Refs:
* https://github.com/Yoast/wp-test-utils
* https://github.com/Yoast/PHPUnit-Polyfills/

### Tests: use the bootstrap file from WP Test Utils

... and remove everything which is already done within that file.

### Tests: switch over to the Yoast\WPTestUtils\BrainMonkey\YoastTestCase

All test  classes for the BrainMonkey based unit tests in the WooCommerceSEO test suite have a  WooCommerceSEO native `TestCase` as a parent class.

This switches the parent of that  `TestCase` from the PHPUnit native TestCase to the `Yoast\WPTestUtils \BrainMonkey\YoastTestCase`.

The `YoastTestCase`:
* Inherits PHPUnit cross- version compatibility from the PHPUnit Polyfills TestCase.
* Inherits the  BrainMonkey set up and teardown and Mockery expectation counting as assertions from the BrainMonkey TestCase.
* And natively adds a number of stubs for  commonly used WP functions.

This switch over includes:
* Removing the addition of  function stubs which are already added via the `YoastTestCase` class.
* Removing  the `tearDown()` method. This will be inherited from the `YoastTestCase` now.
* Renaming the `setUp()` method to `set_up()` in various test classes for PHPUnit  cross-version compatibility.

### Tests: switch over to the Yoast\WPTestUtils\BrainMonkey\TestCase for one specific test class

Three tests within the `Schema_Test` test class set expectations for the `wp_strip_all_tags()` method.

However, the `wp_strip_all_tags()` method is now stubbed by default in the `YoastTestCase` `set_up()` method, which in effects means that the calls to the `wp_strip_all_tags()` method are not seen by Mockery and the expectations would not be met.

To maintain the existing test behaviour:
* The parent `TestCase` for this test class is switched from the `Yoast\WP\Woocommerce\Tests\TestCase` to the `Yoast\WPTestUtils\BrainMonkey\TestCase` which doesn't contain the stubbing of the `wp_strip_all_tags()` method;
* The expectations for the `get_option*()` methods are copied from the `Yoast\WP\Woocommerce\Tests\TestCase` `set_up()` method to the `set_up()` method in this test class.class
* And the reason for using a different parent `TestCase` are documented in the `set_up()` method docblock.

### TestCase: remove the generic stubbing of the translation and escaping functions

Only a very limited number of test need these stubs, so we may as well only load them if and when needed.

Includes removing some stubbing being done in certain test functions for a limited set of these function, which were a) previously already covered in the test `setUp()` and b) are better served by using the dedicated functions for stubbing the complete set of functions.

### Test: remove in test stubs which are handled in the set up

A number of generic function stubs are now provided via the `set_up()` function in the base `TestCase`, so individual test functions don't need to duplicate these stubs.

### Tests: modernize used assertions

The PHPUnit Polyfills allows for using PHPUnit  9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it switches out the following assertions:
* `assertInternalType()` to `assertIs [Type]()`.
* `assertContains()` with string haystacks for `assertStringContainsString()`.

### Tests: remove use of `assertAttribute*()` assertions

The `assertAttribute*()` assertion methods were deprecated in PHPUnit 8.x and removed in PHPUnit 9.

The reasoning for that was that `protected` and `private` properties are implementation details and should not be tested directly, but via the methods in the class.

For now, I've elected to maintain the existing test behaviour, while making it work in a PHPUnit cross-version compatible manner.

This is done by:
1. Using a test helper method introduced provided via PHPUnit Polyfills (0.2.0) to get the value of a non-public property.
2. Changing the assertion for the tests from `assertAttribute*()` to `assert*()`

At a later point in time, it should be re-examined whether these implementation details should be tested in this way.

### Travis: run the unit tests against PHP 8/nightly

Now the BrainMonkey based tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

However, as the integration tests are not (yet) compatible with PHPUnit > 5.7, we need to add a separate condition block to the `script` section.

In this block, we run a `composer update` for just and only the test dependencies on PHP 8 to make sure that the test dependencies available are compatible with PHP 8.
And as the `composer.json` contains a hard-coded `platform.php` setting, we use `ignore-platform-reqs`  to get round that setting.

Includes:
* Adding `travis_retry` to `composer install`-like commands to get round builds stalling on the connection with Packagist, especially on older PHP versions.
* Adding the PHPUnit cache file which is generated when using PHPUnit 8/9 to `.gitignore`.

### PHPUnit config: minor tweaks

* Improve the code coverage configuration:
    - Add `addUncoveredFilesFromWhitelist` and  `processUncoveredFilesFromWhitelist` directives with sensible values.
    - Add the `forceCoversAnnotation` attribute to only record code coverage  for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently 48.28%.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer test` on any PHP version below 8.0 and see the tests pass, including a more accurate assertion count (548 compared to 131 previously, due to Mockery expectations now being counted).
    This confirms that the changes to the `TestCase` works correctly cross-version as the PHPUnit version installed based on the `composer.lock` file will be PHPUnit 5.7.27.
3. Switch to PHP 8.
4. Run `composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs`
5. Run `composer test` to see the tests running and passing on PHP 8 in combination with PHPUnit 9.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 9.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage base on the BrainMonkey based tests alone, as noted above, is only ~48%.