### PR TITLE
Integration Tests: make the testsuite x-version compatible and test against PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,19 @@ jobs:
   fast_finish: true
   include:
     - php: 7.3.24
-      env: WP_VERSION=5.5 WP_MULTISITE=1 PHPUNIT=1 PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION=lts/*
+      env: WP_VERSION=5.6 WP_MULTISITE=1 PHPUNIT=1 PHPCS=1 CHECKJS=1 SECURITY=1 TRAVIS_NODE_VERSION=lts/*
     - php: 5.6
-      env: WP_VERSION=5.4 PHPLINT=1 PHPUNIT=1
-    - php: 7.4
       env: WP_VERSION=5.5 PHPLINT=1 PHPUNIT=1
+    - php: 7.4
+      env: WP_VERSION=5.6 PHPLINT=1 PHPUNIT=1
     - php: 7.0
       env: WP_VERSION=master WP_MULTISITE=1 PHPUNIT=1
+    - php: 8.0
+      env: WP_VERSION=5.6 PHPLINT=1 PHPUNIT=1
     - php: "nightly"
       env: PHPLINT=1
     - stage: deploy
-      env: WP_VERSION=5.5
+      env: WP_VERSION=5.6
       if: tag IS present
       before_install:
         - openssl aes-256-cbc -K $encrypted_2b922af4d08d_key -iv $encrypted_2b922af4d08d_iv -in ./deploy_keys/wpseo_woo_deploy.enc -out ./deploy_keys/wpseo_woo_deploy -d
@@ -79,7 +81,7 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer install --no-interaction --ignore-platform-reqs
   elif [[ "$PHPCS" == "1" || "$PHPUNIT" == "1" || "$PHPLINT" == "1" ]]; then
     travis_retry composer install --no-interaction
@@ -143,20 +145,28 @@ script:
   fi
 # PHP Tests
 - |
-  if [[ "$PHPUNIT" == "1" ]]; then
+  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
     composer integration-test
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 - |
-  if [[ "$PHPUNIT" == "1"  ]]; then
+  if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    travis_fold start "PHP.tests" && travis_time_start
+    travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+    composer integration-test
+    travis_time_finish && travis_fold end "PHP.tests"
+  fi
+- |
+  if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
     composer test
     travis_time_finish && travis_fold end "PHP.tests"
   fi
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_fold start "PHP.tests" && travis_time_start
+    travis_retry composer remove --dev phpunit/phpunit --no-update &&
     travis_retry composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs --no-interaction &&
     composer test
     travis_time_finish && travis_fold end "PHP.tests"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/wp-test-utils": "^0.1.1"
+        "yoast/wp-test-utils": "^0.2.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c8e9b92820fcf676f8066bee16371b4",
+    "content-hash": "c95973c520673e37a37f56aa2c61fc34",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -99,16 +99,16 @@
         },
         {
             "name": "brain/monkey",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19"
+                "reference": "7042140000b4b18034c0c0010d86274a00f25442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/f2295a57da59ff88621cd959dbdb4b288feefd19",
-                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/7042140000b4b18034c0c0010d86274a00f25442",
+                "reference": "7042140000b4b18034c0c0010d86274a00f25442",
                 "shasum": ""
             },
             "require": {
@@ -161,7 +161,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2020-10-09T06:55:33+00:00"
+            "time": "2020-10-13T17:56:14+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1350,23 +1350,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1391,7 +1391,13 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1990,7 +1996,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.46",
+            "version": "v3.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -2212,20 +2218,20 @@
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.1.1",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942"
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/206df89cfefe4d2cbdf354e4a6212869de8bd942",
-                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/c5cdabd58f2aa6f2a93f734cf48125f880c90101",
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101",
                 "shasum": ""
             },
             "require": {
-                "brain/monkey": "^2.5.0",
+                "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
                 "yoast/phpunit-polyfills": "^0.2.0"
             },
@@ -2270,7 +2276,7 @@
                 "unit-testing",
                 "wordpress"
             ],
-            "time": "2020-11-25T12:40:18+00:00"
+            "time": "2020-12-09T15:26:02+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @package WPSEO/WooCommerce/Tests
  */
 
+use Yoast\WPTestUtils\WPIntegration;
+
 // Disable Xdebug backtrace.
 if ( function_exists( 'xdebug_disable' ) ) {
 	xdebug_disable();
@@ -12,10 +14,6 @@ if ( function_exists( 'xdebug_disable' ) ) {
 
 echo 'Welcome to the WordPress SEO WooCommerce test suite' . PHP_EOL;
 echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
-
-if ( getenv( 'WP_DEVELOP_DIR' ) !== false ) {
-	define( 'WP_DEVELOP_DIR', getenv( 'WP_DEVELOP_DIR' ) );
-}
 
 if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
@@ -25,27 +23,12 @@ $GLOBALS['wp_tests_options'] = [
 	'active_plugins' => [ 'wpseo-woocommerce/wpseo-woocommerce.php', 'wordpress-seo/wp-seo.php' ],
 ];
 
-if ( defined( 'WP_DEVELOP_DIR' ) ) {
-	if ( file_exists( WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php' ) ) {
-		require WP_DEVELOP_DIR . 'tests/phpunit/includes/bootstrap.php';
-	}
-	else {
-		echo PHP_EOL, 'ERROR: Please check the WP_DEVELOP_DIR environment variable. Based on the current value ', WP_DEVELOP_DIR, ' the WordPress native unit test bootstrap file could not be found.', PHP_EOL;
-		exit( 1 );
-	}
-}
-elseif ( file_exists( '../../../../tests/phpunit/includes/bootstrap.php' ) ) {
-	require '../../../../tests/phpunit/includes/bootstrap.php';
-}
-else {
-	echo PHP_EOL, 'ERROR: The WordPress native unit test bootstrap file could not be found. Please set the WP_DEVELOP_DIR environment variable either in your OS or in a custom phpunit.xml file.', PHP_EOL;
-	exit( 1 );
-}
+require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
-if ( file_exists( dirname( __DIR__ ) . '/vendor/autoload.php' ) === false ) {
-	echo PHP_EOL, 'ERROR: Run `composer install` to generate the autoload files before running the unit tests.', PHP_EOL;
-	exit( 1 );
-}
+/*
+ * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
+ */
+WPIntegration\bootstrap_it();
 
 if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-woocommerce/wpseo-woocommerce.php' ) === false ) {
 	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -51,6 +51,3 @@ if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-woocom
 	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
 	exit( 1 );
 }
-
-// Include unit test base class.
-require_once __DIR__ . '/framework/woocommerce-unittestcase.php';

--- a/integration-tests/bootstrap.php
+++ b/integration-tests/bootstrap.php
@@ -18,19 +18,53 @@ echo 'Version: 1.0' . PHP_EOL . PHP_EOL;
 if ( getenv( 'WP_PLUGIN_DIR' ) !== false ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
 }
-
-$GLOBALS['wp_tests_options'] = [
-	'active_plugins' => [ 'wpseo-woocommerce/wpseo-woocommerce.php', 'wordpress-seo/wp-seo.php' ],
-];
+else {
+	define( 'WP_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
+}
 
 require_once dirname( __DIR__ ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+// Determine the WP_TEST_DIR.
+$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
+
+// Give access to tests_add_filter() function.
+require_once rtrim( $_tests_dir, '/' ) . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+$yoast_woocommerce_load_plugins = static function () {
+	require_once WP_PLUGIN_DIR . '/wordpress-seo/wp-seo.php';
+	require_once dirname( __DIR__ ) . '/wpseo-woocommerce.php';
+};
+
+/**
+ * Filter the plugins URL to pretend the plugin is installed in the test environment.
+ *
+ * @param string $url    The complete URL to the plugins directory including scheme and path.
+ * @param string $path   Path relative to the URL to the plugins directory. Blank string
+ *                       if no path is specified.
+ * @param string $plugin The plugin file path to be relative to. Blank string if no plugin
+ *                       is specified.
+ *
+ * @return string
+ */
+$yoast_woocommerce_filter_plugin_path = static function ( $url, $path, $plugin ) {
+	$plugin_dir = dirname( __DIR__ );
+	if ( $plugin === $plugin_dir . '/wpseo-woocommerce.php' ) {
+		$url = str_replace( dirname( $plugin_dir ), '', $url );
+	}
+
+	return $url;
+};
+
+// Add plugin to active mu-plugins - to make sure it gets loaded.
+tests_add_filter( 'muplugins_loaded', $yoast_woocommerce_load_plugins );
+
+// Overwrite the plugin URL to not include the full path.
+tests_add_filter( 'plugins_url', $yoast_woocommerce_filter_plugin_path, 10, 3 );
 
 /*
  * Load WordPress, which will load the Composer autoload file, and load the MockObject autoloader after that.
  */
 WPIntegration\bootstrap_it();
-
-if ( ! defined( 'WP_PLUGIN_DIR' ) || file_exists( WP_PLUGIN_DIR . '/wpseo-woocommerce/wpseo-woocommerce.php' ) === false ) {
-	echo PHP_EOL, 'ERROR: Please check whether the WP_PLUGIN_DIR environment variable is set and set to the correct value. The unit test suite won\'t be able to run without it.', PHP_EOL;
-	exit( 1 );
-}

--- a/integration-tests/classes/option-woo-test.php
+++ b/integration-tests/classes/option-woo-test.php
@@ -11,15 +11,6 @@
 class WPSEO_Option_Woo_Test extends WPSEO_WooCommerce_UnitTestCase {
 
 	/**
-	 * Requires the test double.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		require_once './integration-tests/doubles/option-woo-double.php';
-	}
-
-	/**
 	 * Gets the data from the data provider.
 	 *
 	 * @dataProvider validate_option_values

--- a/integration-tests/framework/woocommerce-unittestcase.php
+++ b/integration-tests/framework/woocommerce-unittestcase.php
@@ -5,46 +5,9 @@
  * @package WPSEO/WooCommerce/Tests
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * TestCase base class for convenience methods.
  */
-class WPSEO_WooCommerce_UnitTestCase extends WP_UnitTestCase {
-
-	/**
-	 * Set up an HTTP post request.
-	 *
-	 * @param string $key   Array key.
-	 * @param mixed  $value Value.
-	 */
-	protected function set_post( $key, $value ) {
-		$_POST[ $key ]    = addslashes( $value );
-		$_REQUEST[ $key ] = $_POST[ $key ];
-	}
-
-	/**
-	 * Unset an HTTP post request.
-	 *
-	 * @param string $key Array key.
-	 */
-	protected function unset_post( $key ) {
-		unset( $_POST[ $key ], $_REQUEST[ $key ] );
-	}
-
-	/**
-	 * Fake a request to the WP front page.
-	 */
-	protected function go_to_home() {
-		$this->go_to( home_url( '/' ) );
-	}
-
-	/**
-	 * Test expected output.
-	 *
-	 * @param string $string Expected output string.
-	 */
-	protected function expectOutput( $string ) {
-		$output = ob_get_contents();
-		ob_clean();
-		$this->assertSame( $output, $string );
-	}
-}
+abstract class WPSEO_WooCommerce_UnitTestCase extends TestCase {}

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -9,6 +9,7 @@
 		convertErrorsToExceptions="true"
 		convertNoticesToExceptions="true"
 		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
 		processIsolation="false"
 		stopOnError="false"
 		stopOnFailure="false"
@@ -23,7 +24,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<directory>./classes</directory>
 			<file>./wpseo-woocommerce.php</file>
 		</whitelist>


### PR DESCRIPTION
## Context

* (Preparation for) compatibility with PHP 8

## Summary
This PR can be summarized in the following changelog entry:

* (Preparation for) compatibility with PHP 8

## Relevant technical choices:

:bulb: This PR will be easiest to review by going through the individual commits one by one.

### Tests: remove redundant file includes

As there is a `autoload-dev` in place, the Composer autoloader will automatically include the files.

Includes removing a method which has now become redundant.

### Composer: update Yoast/wp-test-utils to 0.2.1

A new version of the WP Test Utils package has been released which deals with the necessary work-arounds for the WP integration tests and adds utilities for this which individual plugins can use, like functions for the bootstrap and a `TestCase` which includes all the polyfills from the PHPUnit Polyfill repo.

The install is done based on PHP 5.6 (`config.platform.php` is set in the `composer.json` file).

Refs:
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.0
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.1

### WPSEO_WooCommerce_UnitTestCase: switch parent class

This switches the parent class of the `WPSEO_WooCommerce_UnitTestCase` to the WP Test Utils `Yoast\WPTestUtils\WPIntegration\TestCase`.

Includes:
* Removing the `expectOutput()` method.
    This method is not used in this test suite and shouldn't be needed anyway as PHPUnit has build-in `expectOutputString()` and `expectOutputRegex()` methods which should be used instead.
    Additionally, WP Test Utils contains an `expectOutputContains()` method to complement the PHPUnit native methods.
* Removing other methods which were unused in this test suite.
    This applies to all the other methods.

This leaves the `WPSEO_WooCommerce_UnitTestCase` as an opaque class.
I've elected to let it remain though for the following reasons:
* Allows for adding future _plugin-specific_ test helper methods.
* Convenience as all test cases for this plugin `extend` from this one and any future changes in inheritance would only need to be applied to this class to apply them effectively to all test classes for this plugin.

Lastly, this commit makes sure that the generic test case is declared as `abstract` as it doesn't contain any tests itself.

### Tests: use the bootstrap utilities from WP Test Utils

For integration tests, WP Test Utils contains a `bootstrap-functions.php` file with utility functions for a number of common patterns used in bootstrap files for WP integration tests.

As the order in which things get loaded is _**extremely**_ important for the integration tests, whenever possible, the `WPIntegration\bootstrap_it()` method should be used.

This method will:
- Verify that the Composer `autoload.php` file exists.
- Load WordPress.
    The location for WP can be configured by setting either the `WP_TESTS_DIR` or the `WP_DEVELOP_DIR` environment variable on an OS level or via a custom `phpunit.xml` file.
    If neither of these two environment variables is found, it is presumed that the plugin is installed in `src/wp-content/plugins/plugin-name`.
    _This is compatible with the old bootstrap setup and developers will not need to make any changes to their environment for this to work._
- While loading WordPress, the plugin will be loaded, including the Composer autoload file.
- And lastly, a custom autoloader will be added to handle the PHPUnit 7.x MockObject classes not being compatible with PHP 8.0.
    This custom autoloader will load the copies of the PHPUnit 9.x MockObject classes which are part of the WP native test suite as of WP 5.6 when PHP 8.x is detected, and will let the composer autoloader load the PHPUnit native versions when not on PHP 8.x.

If anything goes wrong during these steps, the WP Test Utils method will provide human readable error messages, similar to before.

### PHPUnit config: improve code coverage configuration

* Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
* Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently 3.80%.

### Travis: run the tests against PHP 8.0

Now the test setup has been made compatible for allowing to run the tests on PHP 8 using PHPUnit 7.x, the integration tests can be run on PHP 8.0 in the CI runs.

However, there are still some things to take into account for running the tests on PHP 8.0:
1. The `composer.json` file contains a `config.platfom.php` setting which is set to PHP 5.6 and the repo has a committed `composer.lock` file which locks the PHPUnit version to PHPUnit 5.x.
2. WP hard limits their test suite to PHPUnit 7.x (max), which means the plugin integration tests need to be run on PHPUnit 7.x as well.
    However, PHPUnit 7.x is also _required_ for running the tests on PHP 8.0, PHPUnit 5.x won't work.
3. The BrainMonkey based tests, however, should be run on PHPUnit 9.3+, which is the first PHPUnit version officially compatible with PHP 8.0.

Other relevant information:
* Since this Friday, Travis now has a PHP 8.0 image available.
* Any PHP 8 related fixes have gone into WP 5.6. Running the integration tests against earlier WP versions is futile.

So, keeping all of that in mind, this commit:
* Adds a new build against PHP 8.0, with `WP_VERSION` set to WP `5.6` as released on Tuesday, and the `PHPUNIT` flag set to `1` (= on).
* In the `install` section: makes sure that the `composer install` with `--ignore-platform-reqs` is used for PHP 8.x as otherwise the install would fail due to PHPUnit 5.x (as per the lock file) not being allowed to be installed on PHP 8.
* In the `script` section:
    - Have a separate condition-based script for running the integration tests on PHP 8 (or `nightly`, though they currently won't be run against `nightly`).
    - Within that script **hard** require PHPUnit 7..x.
    - As the `PHPUNIT` flag has been added, the conditions for the BrainMonkey based unit tests are also adjusted.
        These tests are no longer run against `nightly`, but are run against `8.0` when the `PHPUNIT` flag is enabled.
    - Within the BrainMonkey PHP 8 script: remove the PHPUnit 7.x version which was required for the integration tests.
        This will then allow the `composer update` of the Test Utils (which was already in place) to install PHPUnit 9.x for running these tests.

Includes updating the matrix for the release of WP 5.6.

### Bootstrap: use a different pattern to load the plugins

This should hopefully prevent a double include of the Composer autoloader which led to fatal "Cannot redeclare composerRequire...." errors.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run, 3) the tests pass, 4) the BrainMonkey tests are being run and also pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer integration-test` on any PHP version below 8.0 and see the tests pass.
    This confirms that the changes to the test bootstrap and the `TestCase` work correctly.
3. Switch to PHP 8.
4. Run `composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs`
5. If the `WP_PLUGIN_DIR` environment variable on your system points to a directory containing a dev copy of WPSEO, run `composer install --no-dev --no-scripts  --ignore-platform-reqs` in the WPSEO directory to make sure that the PHPUnit version from WPSEO won't interfere.
6. Run `composer integration-test` to see the tests running and passing on PHP 8 in combination with PHPUnit 7.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 7.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage of the BrainMonkey + integration tests combined, is nowhere near 100%.
