### PR TITLE
Tests: improve used assertions and expectations

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,13 +17,6 @@ abstract class TestCase extends YoastTestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		Monkey\Functions\stubs(
-			[
-				// Using `null` makes that function return it's first argument.
-				'is_admin'       => false,
-			]
-		);
-
 		Monkey\Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
 			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -44,7 +44,7 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function test_construct() {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false, true );
 
-		$this->assertEquals( $this->product, $this->getPropertyValue( $instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $instance, 'product' ) );
 		$this->assertSame( false, $this->getPropertyValue( $instance, 'is_on_backorder' ) );
 		$this->assertSame( true, $this->getPropertyValue( $instance, 'is_in_stock' ) );
 	}

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -44,7 +44,7 @@ class Product_Availability_Presenter_Test extends TestCase {
 	public function test_construct() {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false, true );
 
-		$this->assertEquals( $this->product, $this->getPropertyValue( $instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $instance, 'product' ) );
 		$this->assertSame( false, $this->getPropertyValue( $instance, 'is_on_backorder' ) );
 		$this->assertSame( true, $this->getPropertyValue( $instance, 'is_in_stock' ) );
 	}

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -60,7 +60,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -51,7 +51,7 @@ class Product_Condition_Presenter_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -51,7 +51,7 @@ class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
 	 * @covers \WPSEO_WooCommerce_Abstract_Product_Presenter::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -51,7 +51,7 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -51,7 +51,7 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -49,7 +49,7 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertEquals( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
+		$this->assertSame( $this->product, $this->getPropertyValue( $this->instance, 'product' ) );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1114,7 +1114,7 @@ class Schema_Test extends TestCase {
 			);
 
 		$instance->change_product( $data, $product );
-		$this->assertEquals( $expected, $instance->data );
+		$this->assertSame( $expected, $instance->data );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -33,7 +33,8 @@ class Schema_Test extends TestCase {
 		parent::set_up();
 
 		if ( ! \defined( 'WC_VERSION' ) ) {
-			\define( 'WC_VERSION', '3.8.1' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+			\define( 'WC_VERSION', '3.8.1' );
 		}
 
 		Monkey\Functions\expect( 'get_option' )

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -93,7 +93,7 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 		$wpseo_version = '14.0';
 		\define( 'WPSEO_VERSION', $wpseo_version );
 
-		$this->assertEquals( $wpseo_version, $class->get_yoast_seo_version() );
+		$this->assertSame( $wpseo_version, $class->get_yoast_seo_version() );
 	}
 
 	/**

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -155,19 +155,18 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @param string $expected Expected output.
 	 */
 	private function error_message_test( $function, $expected ) {
-		\ob_start();
+		$this->stubEscapeFunctions();
+
 		$class = Mockery::mock( Yoast_WooCommerce_Dependencies_Double::class )->makePartial();
 
 		Functions\stubs(
 			[
-				'esc_url'   => null,
 				'admin_url' => null,
 			]
 		);
-		$class->$function();
-		$output = \ob_get_contents();
-		\ob_end_clean();
 
-		$this->assertEquals( $expected, $output, $function );
+		$this->expectOutputString( $expected );
+
+		$class->$function();
 	}
 }

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -44,12 +44,17 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	/**
 	 * Test loading our view.
 	 *
+	 * @dataProvider data_add_yoast_seo_fields
+	 *
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::add_yoast_seo_fields
+	 *
+	 * @param string $expected_output Substring expected to be found in the actual output.
 	 */
-	public function test_add_yoast_seo_fields() {
-		\ob_start();
+	public function test_add_yoast_seo_fields( $expected_output ) {
+		if ( defined( 'WPSEO_WOO_PLUGIN_FILE' ) === false ) {
+			\define( 'WPSEO_WOO_PLUGIN_FILE', './wpseo-woocommerce.php' );
+		}
 
-		\define( 'WPSEO_WOO_PLUGIN_FILE', './wpseo-woocommerce.php' );
 		$this->stubTranslationFunctions();
 		$this->stubEscapeFunctions();
 
@@ -64,14 +69,22 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 			]
 		);
 
+		$this->expectOutputContains( $expected_output );
+
 		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 		$instance->add_yoast_seo_fields();
+	}
 
-		$output = \ob_get_contents();
-		\ob_end_clean();
-
-		$this->assertStringContainsString( 'yoast_seo[gtin8]', $output );
-		$this->assertStringContainsString( '<div id="yoast_seo" class="panel woocommerce_options_panel">', $output );
+	/**
+	 * Data provider for the `test_add_yoast_seo_fields()` test.
+	 *
+	 * @return array
+	 */
+	public function data_add_yoast_seo_fields() {
+		return [
+			[ 'yoast_seo[gtin8]' ],
+			[ '<div id="yoast_seo" class="panel woocommerce_options_panel">' ],
+		];
 	}
 
 	/**
@@ -167,21 +180,32 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	/**
 	 * Test our input fields are outputted correctly.
 	 *
+	 * @dataProvider data_input_field_for_identifier
+	 *
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::input_field_for_identifier
+	 *
+	 * @param string $expected_output Substring expected to be found in the actual output.
 	 */
-	public function test_input_field_for_identifier() {
-
+	public function test_input_field_for_identifier( $expected_output ) {
 		$this->stubEscapeFunctions();
 
-		\ob_start();
+		$this->expectOutputContains( $expected_output );
+
 		$instance = new Yoast_Tab_Double();
 		$instance->input_field_for_identifier( 'gtin8', 'GTIN 8', '12345678' );
-		$output = \ob_get_contents();
-		\ob_end_clean();
+	}
 
-		$this->assertStringContainsString( 'gtin8', $output );
-		$this->assertStringContainsString( 'GTIN 8', $output );
-		$this->assertStringContainsString( '12345678', $output );
-		$this->assertStringContainsString( 'yoast_identifier_gtin8', $output );
+	/**
+	 * Data provider for the `test_input_field_for_identifier()` test.
+	 *
+	 * @return array
+	 */
+	public function data_input_field_for_identifier() {
+		return [
+			[ 'gtin8' ],
+			[ 'GTIN 8' ],
+			[ '12345678' ],
+			[ 'yoast_identifier_gtin8' ],
+		];
 	}
 }


### PR DESCRIPTION
## Context

* Improve test quality

## Summary
This PR can be summarized in the following changelog entry:

* Improve test quality


## Relevant technical choices:

### QA: use the most specific PHPUnit assertion possible

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available have been extended hugely over the years.

To have the most reliable tests, the most specific assertion should be used.

This implements this for this plugin.

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame

### Unit tests: use `expectOutput*()`

PHPUnit contains a native `expectOutputString()` and a `expectOutputRegex()` method to set expectations for generated output and WP Test Utils introduces a new `expectOutputContains()` method to complement these.
PHPUnit also contains a `getActualOutput()` method to get access to the generated output if other handling would be needed.

Any tests generating output should use these methods to set expectations instead of using the PHP native `ob_*()` output buffering functions.

This switches out the custom code using the `ob_*()` functions in favour of using the PHPUnit native or the WP Test Utils `expectOutput*()` methods.

**Important**: each test should only have one (1) output expectation. Subsequent expectations being set will overwrite the original expectation. In effect, that means that only the last set expectation will ever be tested.

This goes for both the PHPUnit native `expectOutput*()` methods as well as the WP Test Utils `expectOutputContains()` method.

To that end, when there were multiple expectations for one test, these tests have been refactored to be run multiple times in combination with a data provider. That way, each expectation will be tested separately.

### Unit tests/TestCase: remove redundant stub

This stub is not used, so can be removed.

### CS: minor readability improvement 

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the test builds pass, we're good.