### PR TITLE
Added WooCommerce Schema presentation and generator.

### DIFF
--- a/classes/generators/woocommerce-schema-generator.php
+++ b/classes/generators/woocommerce-schema-generator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin file.
+ *
+ * @package WPSEO/WooCommerce
+ */
+
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Generators\Generator_Interface;
+
+/**
+ * Class WPSEO_WooCommerce_Schema_Generator
+ */
+class WPSEO_WooCommerce_Schema_Generator implements Generator_Interface {
+
+	/**
+	 * The schema graph.
+	 *
+	 * @var array
+	 */
+	protected $graph;
+
+	/**
+	 * WPSEO_WooCommerce_Schema_Generator constructor.
+	 *
+	 * @param array $graph The schema graph.
+	 */
+	public function __construct( $graph ) {
+		$this->graph = $graph;
+	}
+
+	/**
+	 * Generates the schema.
+	 *
+	 * @param Meta_Tags_Context $context The meta tags context of the current page.
+	 *
+	 * @return array The generated schema.
+	 */
+	public function generate( Meta_Tags_Context $context ) {
+		if ( ! is_array( $this->graph ) || empty( $this->graph ) ) {
+			return [];
+		}
+
+		return [
+			'@context' => 'https://schema.org',
+			'@graph'   => $this->graph,
+		];
+	}
+}

--- a/classes/presentations/woocommerce-product-presentation.php
+++ b/classes/presentations/woocommerce-product-presentation.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin file.
+ *
+ * @package WPSEO/WooCommerce
+ */
+
+use Yoast\WP\SEO\Generators\Generator_Interface;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+
+/**
+ * Class WPSEO_WooCommerce_Product_Presentation
+ */
+class WPSEO_WooCommerce_Product_Presentation extends Indexable_Presentation {
+
+	/**
+	 * A schema generator.
+	 *
+	 * @var Generator_Interface
+	 */
+	protected $schema_generator;
+
+	/**
+	 * Sets a custom schema generator.
+	 *
+	 * @param Generator_Interface $schema_generator The custom schema generator.
+	 */
+	public function set_schema_generator( $schema_generator ) {
+		$this->schema_generator = $schema_generator;
+	}
+
+	/**
+	 * Returns `false`, since it is not a prototype presentation.
+	 *
+	 * @return false not a prototype presentation.
+	 */
+	protected function is_prototype() {
+		return false;
+	}
+}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -6,6 +6,8 @@
  */
 
 use Yoast\WP\SEO\Config\Schema_IDs;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Presenters\Schema_Presenter;
 
 /**
  * Class WPSEO_WooCommerce_Schema.
@@ -90,7 +92,19 @@ class WPSEO_WooCommerce_Schema {
 			return false;
 		}
 
-		WPSEO_Utils::schema_output( [ $this->data ], 'yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer' );
+		$presenter = new Schema_Presenter();
+
+		$presentation = new WPSEO_WooCommerce_Product_Presentation();
+
+		$context_memoizer      = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$presentation->context = $context_memoizer->for_current_page();
+
+		$presentation->set_schema_generator( new WPSEO_WooCommerce_Schema_Generator( $this->data ) );
+
+		$presenter->presentation = $presentation;
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to output HTML. If we escape this we break it.
+		echo $presenter;
 
 		return true;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The old code used `WPSEO_Utils::schema_output`, which we deprecated.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a deprecation notice would be shown in the PHP debug log when visiting a product page.

## Relevant technical choices:

* Tried to adhere as much as possible to the new presenters / presentation API.
	* It feels forced though, so not really happy about it yet.
* It does not add the extra classes (`yoast-schema-graph--woo` and `yoast-schema-graph--footer`) yet.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Starting with a vanilla installation: (debug logging enabled)
* Install, activate, and set up WooCommerce. (options below)
* Install and activate Yoast SEO (free or premium)
* Install and activate Yoast SEO WooCommerce
* Go to Admin > Products
* View a product
* Check the source code of the page, it should contain a `<script type="application/ld+json" class="yoast-schema-graph">` at the bottom of the page.
	* This script tag should contain a schema graph with one `Product` graph piece.
* Check the website's debug log, it should **not** contain the following deprecation warning:
  ```
  Deprecated:  WPSEO_Utils::schema_output is <strong>deprecated</strong> since version WPSEO 15.5 with no alternative available.
  ```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
