### PR TITLE
Added schema presenter.

### DIFF
--- a/classes/presenters/woocommerce-schema-presenter.php
+++ b/classes/presenters/woocommerce-schema-presenter.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin file.
+ *
+ * @package WPSEO/WooCommerce
+ */
+
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
+
+/**
+ * Presents the schema output inside a script tag.
+ */
+class WPSEO_WooCommerce_Schema_Presenter extends Abstract_Indexable_Presenter {
+
+	/**
+	 * The Schema to output.
+	 *
+	 * @var array
+	 */
+	protected $graph;
+
+	/**
+	 * The classes to add to the script tag.
+	 *
+	 * @var string[]
+	 */
+	protected $classes;
+
+	/**
+	 * WPSEO_WooCommerce_Schema_Presenter constructor.
+	 *
+	 * @param array    $graph   The schema graph.
+	 * @param string[] $classes The classes to add to the script tag.
+	 */
+	public function __construct( $graph, $classes ) {
+		$this->graph   = $graph;
+		$this->classes = $classes;
+	}
+
+	/**
+	 * Gets the raw schema value as an associative array.
+	 *
+	 * @return array The raw schema.
+	 */
+	public function get() {
+		return $this->graph;
+	}
+
+	/**
+	 * Presents the schema in a script tag.
+	 *
+	 * @return string The schema in a script tag.
+	 */
+	public function present() {
+		$graph = $this->get();
+
+		$schema = [
+			'@context' => 'https://schema.org',
+			'@graph'   => $graph,
+		];
+
+		$classes_string = \implode( ' ', $this->classes );
+
+		$output = \WPSEO_Utils::format_json_encode( $schema );
+		$output = \str_replace( "\n", \PHP_EOL . "\t", $output );
+		return '<script type="application/ld+json" class="' . \esc_attr( $classes_string ) . '">' . $output . '</script>';
+	}
+
+	/**
+	 * Returns the output as string.
+	 *
+	 * @return string The output.
+	 */
+	public function __toString() {
+		return $this->present();
+	}
+}

--- a/classes/presenters/woocommerce-schema-presenter.php
+++ b/classes/presenters/woocommerce-schema-presenter.php
@@ -63,7 +63,7 @@ class WPSEO_WooCommerce_Schema_Presenter extends Abstract_Indexable_Presenter {
 
 		$output = \WPSEO_Utils::format_json_encode( $schema );
 		$output = \str_replace( "\n", \PHP_EOL . "\t", $output );
-		return '<script type="application/ld+json" class="' . \esc_attr( $classes_string ) . '">' . $output . '</script>';
+		return '<script type="application/ld+json" class="' . \esc_attr( $classes_string ) . '">' . $output . '</script>' . PHP_EOL;
 	}
 
 	/**

--- a/classes/presenters/woocommerce-schema-presenter.php
+++ b/classes/presenters/woocommerce-schema-presenter.php
@@ -62,7 +62,6 @@ class WPSEO_WooCommerce_Schema_Presenter extends Abstract_Indexable_Presenter {
 		$classes_string = \implode( ' ', $this->classes );
 
 		$output = \WPSEO_Utils::format_json_encode( $schema );
-		$output = \str_replace( "\n", \PHP_EOL . "\t", $output );
 		return '<script type="application/ld+json" class="' . \esc_attr( $classes_string ) . '">' . $output . '</script>' . PHP_EOL;
 	}
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -92,7 +92,7 @@ class WPSEO_WooCommerce_Schema {
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to output HTML. If we escape this we break it.
 		echo new WPSEO_WooCommerce_Schema_Presenter(
-			$this->data,
+			[ $this->data ],
 			[
 				'yoast-schema-graph',
 				'yoast-schema-graph--woo',

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -86,11 +86,19 @@ class WPSEO_WooCommerce_Schema {
 	 * @return bool False when there's nothing to output, true when we did output something.
 	 */
 	public function output_schema_footer() {
-		if ( empty( $this->data ) || $this->data === [] ) {
+		if ( empty( $this->data ) || $this->data === [] || ! is_array( $this->data ) ) {
 			return false;
 		}
 
-		WPSEO_Utils::schema_output( [ $this->data ], 'yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer' );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to output HTML. If we escape this we break it.
+		echo new WPSEO_WooCommerce_Schema_Presenter(
+			$this->data,
+			[
+				'yoast-schema-graph',
+				'yoast-schema-graph--woo',
+				'yoast-schema-graph--footer',
+			]
+		);
 
 		return true;
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -32,6 +32,8 @@ class Schema_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		if ( ! \defined( 'WC_VERSION' ) ) {
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 			\define( 'WC_VERSION', '3.8.1' );
@@ -48,6 +50,7 @@ class Schema_Test extends TestCase {
 			->andReturn( [] );
 
 		Mockery::mock( 'overload:Yoast\WP\SEO\Config\Schema_IDs', new Schema_IDs() );
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
 
 		$this->set_instance();
 	}
@@ -104,16 +107,23 @@ class Schema_Test extends TestCase {
 		$schema = new Schema_Double();
 
 		$schema->data = [];
-		$this->assertFalse( $schema->output_schema_footer() );
+		self::assertFalse( $schema->output_schema_footer() );
 
 		$data = [ 'test' ];
 
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
-		$utils->expects( 'schema_output' )->once()->andSet( 'output', $data );
+		$utils->expects( 'format_json_encode' )
+			->andReturnUsing(
+				function( $array ) {
+					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
+					return \json_encode( $array );
+				}
+			);
 
 		$schema->data = $data;
 		$schema->output_schema_footer();
-		$this->assertSame( $data, $utils->output );
+
+		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":["test"]}</script>' );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -109,7 +109,11 @@ class Schema_Test extends TestCase {
 		$schema->data = [];
 		self::assertFalse( $schema->output_schema_footer() );
 
-		$data = [ 'test' ];
+		$data = [
+			'@type' => 'Product',
+			'@id'   => 'http://basic.wordpress.test/product/hippopotamus/#product',
+			'name'  => 'Hippopotamus',
+		];
 
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
@@ -123,7 +127,7 @@ class Schema_Test extends TestCase {
 		$schema->data = $data;
 		$schema->output_schema_footer();
 
-		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":["test"]}</script>' . PHP_EOL );
+		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . PHP_EOL );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -123,7 +123,7 @@ class Schema_Test extends TestCase {
 		$schema->data = $data;
 		$schema->output_schema_footer();
 
-		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":["test"]}</script>' );
+		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":["test"]}</script>' . PHP_EOL );
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3452,9 +3452,9 @@ grunt-eslint@^21.0.0:
     chalk "^2.1.0"
     eslint "^5.16.0"
 
-"grunt-glotpress@git+https://github.com/Yoast/grunt-glotpress.git#master":
+"grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
   version "0.3.0"
-  resolved "git+https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
+  resolved "https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
   dependencies:
     request "^2.88.0"
     request-promise-native "^1.0.7"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The old code used `WPSEO_Utils::schema_output`, which we deprecated.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a deprecation notice would be shown in the PHP debug log when visiting a product page.

## Relevant technical choices:

* Added a new presenter, since...
	* the graph has already been generated and can be passed directly to the presenter.
	* the `Schema_Presenter` does not have the ability to add additional classes to the `script` tag.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Starting with a vanilla installation: (debug logging enabled)
* Install, activate, and set up WooCommerce. (options below)
* Install and activate Yoast SEO (free or premium)
* Install and activate Yoast SEO WooCommerce
* Go to Admin > Products
* View a product
* Check the source code of the page, it should contain a `<script type="application/ld+json" class="yoast-schema-graph">` at the bottom of the page.
	* This script tag should contain a schema graph with one `Product` graph piece.
* Check the website's debug log, it should **not** contain the following deprecation warning:
  ```
  Deprecated:  WPSEO_Utils::schema_output is <strong>deprecated</strong> since version WPSEO 15.5 with no alternative available.
  ```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
