### PR TITLE
Added unit tests for WooCommerce schema presenter.

### DIFF
--- a/tests/classes/presenters/schema-presenter-test.php
+++ b/tests/classes/presenters/schema-presenter-test.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
+
+use Mockery;
+use WPSEO_WooCommerce_Schema_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
+
+/**
+ * Class Schema_Presenter_Test
+ *
+ * @package Yoast\WP\Woocommerce\Tests\Classes\Presenters
+ *
+ * @coversDefaultClass WPSEO_WooCommerce_Schema_Presenter
+ */
+class Schema_Presenter_Test extends TestCase {
+
+	/**
+	 * The schema presenter under test.
+	 *
+	 * @var WPSEO_WooCommerce_Schema_Presenter
+	 */
+	protected $instance;
+
+	/**
+	 * The (CSS) classes to use in the tests.
+	 *
+	 * @var string[]
+	 */
+	protected $classes;
+
+	/**
+	 * The schema graph to use in the tests.
+	 *
+	 * @var array
+	 */
+	protected $graph;
+
+	/**
+	 * Sets up the tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
+
+		$this->graph = [
+			[
+				'@type' => 'Product',
+				'@id'   => 'http://basic.wordpress.test/product/hippopotamus/#product',
+				'name'  => 'Hippopotamus',
+			],
+		];
+
+		$this->classes = [
+			'yoast-schema-graph',
+			'yoast-schema-graph--woo',
+			'yoast-schema-graph--footer',
+		];
+
+		$this->instance = new WPSEO_WooCommerce_Schema_Presenter( $this->graph, $this->classes );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		self::assertSame( $this->graph, self::getPropertyValue( $this->instance, 'graph' ) );
+		self::assertSame( $this->classes, self::getPropertyValue( $this->instance, 'classes' ) );
+	}
+
+	/**
+	 * Tests the `present` method.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 */
+	public function test_present() {
+		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
+		$utils->expects( 'format_json_encode' )
+			->andReturnUsing(
+				function( $array ) {
+					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
+					return \json_encode( $array );
+				}
+			);
+
+		$output = $this->instance->present();
+
+		self::assertSame(
+			'<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . PHP_EOL,
+			$output
+		);
+	}
+
+	/**
+	 * Tests the `__toString` method.
+	 *
+	 * @covers ::__toString
+	 */
+	public function test_to_string() {
+		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
+		$utils->expects( 'format_json_encode' )
+			->andReturnUsing(
+				function( $array ) {
+					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
+					return \json_encode( $array );
+				}
+			);
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to test if the correct HTML is output.
+		echo $this->instance;
+		$this->expectOutputContains(
+			'<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . PHP_EOL
+		);
+	}
+}
+
+
+


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds unit tests for the newly introduced `WPSEO_WooCommerce_Schema_Presenter`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run unit tests with code coverage enabled.
* See that all of the unit tests pass and the code coverage of `WPSEO_WooCommerce_Schema_Presenter` is 100%.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A, this PR just adds extra unit tests. It does no impact any functionality within the plugin.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A, this PR just adds extra unit tests. It does no impact any functionality within the plugin.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
