### PR TITLE
P1 345 woocommerce snippet in google preview

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1221,7 +1221,7 @@ class Yoast_WooCommerce_SEO {
 		$google_preview = [];
 		$product       = $this->get_product();
 		$google_preview['rating']       = floatval( $product->get_average_rating() );
-		$google_preview['review_count'] = $product->get_rating_count();
+		$google_preview['reviewCount'] = $product->get_rating_count();
 		$google_preview['availability'] = $product->get_availability()[ 'class' ];
 		if ( $this->should_show_price() ) {
 			$google_preview['price'] = $this->get_product_var_price();
@@ -1233,7 +1233,7 @@ class Yoast_WooCommerce_SEO {
 			'woo_desc_short'          => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
 			'woo_desc_good'           => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
 			'woo_desc_long'           => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
-			'woo_google_preview_data' => $google_preview,
+			'wooGooglePreviewData' => $google_preview,
 		];
 	}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -76,6 +76,7 @@ class Yoast_WooCommerce_SEO {
 		else {
 			// Initialize schema & OpenGraph.
 			add_action( 'init', [ $this, 'initialize_opengraph' ] );
+			add_action( 'init', [ $this, 'initialize_schema' ] );
 			add_action( 'init', [ $this, 'initialize_twitter' ] );
 			add_action( 'init', [ $this, 'initialize_slack' ] );
 			add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1218,11 +1218,11 @@ class Yoast_WooCommerce_SEO {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$version       = $asset_manager->flatten_version( self::VERSION );
 
-		$google_preview = [];
-		$product       = $this->get_product();
+		$google_preview                 = [];
+		$product                        = $this->get_product();
 		$google_preview['rating']       = floatval( $product->get_average_rating() );
-		$google_preview['reviewCount'] = $product->get_rating_count();
-		$google_preview['availability'] = $product->get_availability()[ 'class' ];
+		$google_preview['reviewCount']  = $product->get_rating_count();
+		$google_preview['availability'] = $product->get_availability()['class'];
 		if ( $this->should_show_price() ) {
 			$google_preview['price'] = $this->get_product_var_price();
 		}
@@ -1233,7 +1233,7 @@ class Yoast_WooCommerce_SEO {
 			'woo_desc_short'          => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
 			'woo_desc_good'           => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
 			'woo_desc_long'           => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
-			'wooGooglePreviewData' => $google_preview,
+			'wooGooglePreviewData'    => $google_preview,
 		];
 	}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -76,7 +76,6 @@ class Yoast_WooCommerce_SEO {
 		else {
 			// Initialize schema & OpenGraph.
 			add_action( 'init', [ $this, 'initialize_opengraph' ] );
-			add_action( 'init', [ $this, 'initialize_schema' ] );
 			add_action( 'init', [ $this, 'initialize_twitter' ] );
 			add_action( 'init', [ $this, 'initialize_slack' ] );
 			add_filter( 'wpseo_frontend_presenters', [ $this, 'add_frontend_presenter' ] );
@@ -1219,12 +1218,22 @@ class Yoast_WooCommerce_SEO {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$version       = $asset_manager->flatten_version( self::VERSION );
 
+		$google_preview = [];
+		$product       = $this->get_product();
+		$google_preview['rating']       = floatval( $product->get_average_rating() );
+		$google_preview['review_count'] = $product->get_rating_count();
+		$google_preview['availability'] = $product->get_availability()[ 'class' ];
+		if ( $this->should_show_price() ) {
+			$google_preview['price'] = $this->get_product_var_price();
+		}
+
 		return [
-			'script_url'     => plugins_url( 'js/dist/yoastseo-woo-worker-' . $version . '.js', self::get_plugin_file() ),
-			'woo_desc_none'  => __( 'You should write a short description for this product.', 'yoast-woo-seo' ),
-			'woo_desc_short' => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
-			'woo_desc_good'  => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
-			'woo_desc_long'  => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
+			'script_url'              => plugins_url( 'js/dist/yoastseo-woo-worker-' . $version . '.js', self::get_plugin_file() ),
+			'woo_desc_none'           => __( 'You should write a short description for this product.', 'yoast-woo-seo' ),
+			'woo_desc_short'          => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
+			'woo_desc_good'           => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
+			'woo_desc_long'           => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
+			'woo_google_preview_data' => $google_preview,
 		];
 	}
 

--- a/config/webpack/webpack.config.default.js
+++ b/config/webpack/webpack.config.default.js
@@ -1,6 +1,7 @@
 const _defaultsDeep = require( "lodash.defaultsdeep" );
 const path = require( "path" );
 const pkg = require( "../../package.json" );
+const { camelCaseDash } = require( "@wordpress/dependency-extraction-webpack-plugin/lib/util" );
 const UnminifiedWebpackPlugin = require( "unminified-webpack-plugin" );
 const CaseSensitivePathsPlugin = require( "case-sensitive-paths-webpack-plugin" );
 const { flattenVersionForFile } = require( "../grunt/lib/version.js" );
@@ -9,6 +10,22 @@ const webpack = require( "webpack" );
 const externals = {
 	yoastseo: "yoast.analysis",
 };
+
+/**
+ * WordPress dependencies.
+ */
+const wordpressPackages = [
+	"@wordpress/hooks",
+	"@wordpress/data",
+];
+
+// WordPress packages.
+const wordpressExternals = wordpressPackages.reduce( ( memo, packageName ) => {
+	const name = camelCaseDash( packageName.replace( "@wordpress/", "" ) );
+
+	memo[ packageName ] = `window.wp.${ name }`;
+	return memo;
+}, {} );
 
 const pluginVersionSlug = flattenVersionForFile( pkg.yoast.pluginVersion );
 
@@ -24,7 +41,10 @@ const defaultConfig = {
 		path: path.join( __dirname, "../../", "js/dist" ),
 		filename: "[name]-" + pluginVersionSlug + ".js",
 	},
-	externals: externals,
+	externals: {
+		...externals,
+		...wordpressExternals,
+	},
 	optimization: {
 		minimize: true,
 	},

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -76,9 +76,8 @@ class YoastWooCommercePlugin {
 	 * @returns {void}
 	 */
 	dispatchGooglePreviewData() {
-		const googlePreviewData = window.wpseoWooL10n.wooGooglePreviewData;
-
-		if ( dispatch && googlePreviewData  ) {
+		if ( window.wpseoWooL10n.wooGooglePreviewData ) {
+			const googlePreviewData = window.wpseoWooL10n.wooGooglePreviewData;
 			dispatch( "yoast-seo/editor" ).setShoppingData( googlePreviewData );
 		}
 	}

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -29,6 +29,8 @@ class YoastWooCommercePlugin {
 		this.registerModifications();
 
 		this.bindEvents();
+
+		this.dispatchL10nData();
 	}
 
 	/**
@@ -65,6 +67,19 @@ class YoastWooCommercePlugin {
 		}
 
 		jQuery( ".add_product_images" ).find( "a" ).on( "click", this.bindLinkEvent.bind( this ) );
+	}
+
+	/**
+	 * Dispatches data from window.wpseoWooL10n to the Yoast SEO editor store.
+	 *
+	 * @returns {void}
+	 */
+	dispatchL10nData() {
+		const googlePreviewData = window.wpseoWooL10n.wooGooglePreviewData;
+		const dispatch = window.wp.data.dispatch( "yoast-seo/editor" );
+		if ( dispatch && googlePreviewData  ) {
+			dispatch.setShoppingData( googlePreviewData );
+		}
 	}
 
 	/**

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -76,10 +76,7 @@ class YoastWooCommercePlugin {
 	 * @returns {void}
 	 */
 	dispatchGooglePreviewData() {
-		if ( window.wpseoWooL10n.wooGooglePreviewData ) {
-			const googlePreviewData = window.wpseoWooL10n.wooGooglePreviewData;
-			dispatch( "yoast-seo/editor" ).setShoppingData( googlePreviewData );
-		}
+		dispatch( "yoast-seo/editor" ).setShoppingData( window.wpseoWooL10n.wooGooglePreviewData );
 	}
 
 	/**

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -1,7 +1,6 @@
 /* global YoastSEO, wpseoWooL10n, tinyMCE */
 
 import { getExcerpt, addExcerptEventHandlers, isTinyMCEAvailable } from "./yoastseo-woo-handle-excerpt-editors";
-import { addFilter } from "@wordpress/hooks";
 import { dispatch } from "@wordpress/data";
 
 const PLUGIN_NAME = "YoastWooCommerce";

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -1,6 +1,8 @@
 /* global YoastSEO, wpseoWooL10n, tinyMCE */
 
 import { getExcerpt, addExcerptEventHandlers, isTinyMCEAvailable } from "./yoastseo-woo-handle-excerpt-editors";
+import { addFilter } from "@wordpress/hooks";
+import { dispatch } from "@wordpress/data";
 
 const PLUGIN_NAME = "YoastWooCommerce";
 
@@ -76,9 +78,9 @@ class YoastWooCommercePlugin {
 	 */
 	dispatchGooglePreviewData() {
 		const googlePreviewData = window.wpseoWooL10n.wooGooglePreviewData;
-		const dispatch = window.wp.data.dispatch( "yoast-seo/editor" );
+
 		if ( dispatch && googlePreviewData  ) {
-			dispatch.setShoppingData( googlePreviewData );
+			dispatch( "yoast-seo/editor" ).setShoppingData( googlePreviewData );
 		}
 	}
 

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -30,7 +30,7 @@ class YoastWooCommercePlugin {
 
 		this.bindEvents();
 
-		this.dispatchL10nData();
+		this.dispatchGooglePreviewData();
 	}
 
 	/**
@@ -70,11 +70,11 @@ class YoastWooCommercePlugin {
 	}
 
 	/**
-	 * Dispatches data from window.wpseoWooL10n to the Yoast SEO editor store.
+	 * Dispatches the product data from window.wpseoWooL10n to the Yoast SEO editor store.
 	 *
 	 * @returns {void}
 	 */
-	dispatchL10nData() {
+	dispatchGooglePreviewData() {
 		const googlePreviewData = window.wpseoWooL10n.wooGooglePreviewData;
 		const dispatch = window.wp.data.dispatch( "yoast-seo/editor" );
 		if ( dispatch && googlePreviewData  ) {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "yoast": {
     "pluginVersion": "13.9"
+  },
+  "dependencies": {
+    "@wordpress/dependency-extraction-webpack-plugin": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,6 +273,14 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@wordpress/dependency-extraction-webpack-plugin@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.0.tgz#1640e8d8b83b22e3a136f82ff5217ab6ae9bcca6"
+  integrity sha512-lxdQ6qkHFiL1y7C/tHi/pxnFMaBa4AzBI/NcQ2+yJXwUqO746KYO9A6zEueQxa3mpEH3kT4r98C/p+MEf8xAsg==
+  dependencies:
+    json2php "^0.0.4"
+    webpack-sources "^2.2.0"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4385,6 +4393,11 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json2php@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/json2php/-/json2php-0.0.4.tgz#6bd85a1dda6a5dd7e91022bb24403cc1b7c2ee34"
+  integrity sha1-a9haHdpqXdfpECK7JEA8wbfC7jQ=
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -6710,7 +6723,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -7572,6 +7585,14 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@^4.16.2:
   version "4.41.2"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want our Google Preview to reflect how the search result for a product looks in Google. So when the necessary data for Product schema is available, it should show up in the Google Preview, like this:

![image](https://user-images.githubusercontent.com/69148430/114363157-68b4eb00-9b78-11eb-8cd7-0fe4a67d6b0f.png)

![image](https://user-images.githubusercontent.com/69148430/114363186-70748f80-9b78-11eb-93a6-154e5b35468f.png)

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* When used together with the latest version of Wordpress SEO or Wordpress SEO Premium, the Google Preview for products now shows the rating, number of reviews, price and availability like in Google.

## Relevant technical choices:

* For the sake of simplicity we decided to directly dispatch to the WPSEO store.
* Since the needed data is not yet available in WooCommerce's stores, this data is static for now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test together with the related branches on Free and the Monorepo, of for QA with the latest RC/Beta of Free/Premium 16.2
* Edit a product and save it
* Refresh the page
* Repeat this process with different data added and:
** Verify that when a review has been entered the rating and number of reviews will show up in the Google Preview
** Verify that when a price has been entered the price shows op in the Google Preview
** Verify that when the availability is set or changed it shows up in the Google Preview
* Please check the mobile as well as the desktop view
* Please note that a change is only reflected in the preview after a save and refresh

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-345
