### PR TITLE
P3-464 Fix product price schema output

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -211,17 +211,8 @@ class WPSEO_WooCommerce_Schema {
 				$data['offers'][ $key ]['@id']   = YoastSEO()->meta->for_current_page()->site_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
 				$data['offers'][ $key ]['price'] = $price;
 
-				$data['offers'][ $key ]['priceSpecification']['price']         = $price;
-				$data['offers'][ $key ]['priceSpecification']['priceCurrency'] = get_woocommerce_currency();
-
-				if ( wc_tax_enabled() ) {
-					// Only show this property if tax calculation has been enabled in WooCommerce.
-					$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
-				}
-				else {
-					// Remove `valueAddedTaxIncluded` property from Schema output by WooCommerce.
-					unset( $data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] );
-				}
+				$data['offers'][ $key ]['priceSpecification']['@type']                 = 'PriceSpecification';
+				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = ( wc_tax_enabled() && WPSEO_WooCommerce_Utils::prices_have_tax_included() );
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
 				$data['offers'][ $key ]['@id']    = YoastSEO()->meta->for_current_page()->site_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -221,7 +221,7 @@ class WPSEO_WooCommerce_Schema {
 
 			// Alter availability when product is "on backorder".
 			if ( $product->is_on_backorder() ) {
-				$data['offers'][ $key ]['availability'] = 'http://schema.org/PreOrder';
+				$data['offers'][ $key ]['availability'] = 'https://schema.org/PreOrder';
 			}
 		}
 
@@ -475,7 +475,7 @@ class WPSEO_WooCommerce_Schema {
 		$variations = $product->get_available_variations();
 
 		$currency           = get_woocommerce_currency();
-		$prices_include_tax = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+		$prices_include_tax = ( wc_tax_enabled() && WPSEO_WooCommerce_Utils::prices_have_tax_included() );
 		$decimals           = wc_get_price_decimals();
 		$data               = [];
 		$product_id         = $product->get_id();
@@ -489,16 +489,12 @@ class WPSEO_WooCommerce_Schema {
 				'@id'                => YoastSEO()->meta->for_current_page()->site_url . '#/schema/offer/' . $product_id . '-' . $key,
 				'name'               => $product_name . ' - ' . $variation_name,
 				'price'              => wc_format_decimal( $variation['display_price'], $decimals ),
+				'priceCurrency'      => $currency,
 				'priceSpecification' => [
-					'price'         => wc_format_decimal( $variation['display_price'], $decimals ),
-					'priceCurrency' => $currency,
+					'@type'                 => 'PriceSpecification',
+					'valueAddedTaxIncluded' => $prices_include_tax
 				],
 			];
-
-			if ( wc_tax_enabled() ) {
-				// Only add this property if tax calculation has been enabled in WooCommerce.
-				$offer['priceSpecification']['valueAddedTaxIncluded'] = $prices_include_tax;
-			}
 
 			$data[] = $offer;
 		}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -211,6 +211,8 @@ class WPSEO_WooCommerce_Schema {
 				$data['offers'][ $key ]['@id']   = YoastSEO()->meta->for_current_page()->site_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
 				$data['offers'][ $key ]['price'] = $price;
 
+				$data['offers'][ $key ]['priceCurrency'] = get_woocommerce_currency();
+
 				$data['offers'][ $key ]['priceSpecification']['@type']                 = 'PriceSpecification';
 				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = ( wc_tax_enabled() && WPSEO_WooCommerce_Utils::prices_have_tax_included() );
 			}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -215,6 +215,11 @@ class WPSEO_WooCommerce_Schema {
 
 				$data['offers'][ $key ]['priceSpecification']['@type']                 = 'PriceSpecification';
 				$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = ( wc_tax_enabled() && WPSEO_WooCommerce_Utils::prices_have_tax_included() );
+
+				// Remove priceSpecification price property from Schema output by WooCommerce.
+				unset( $data['offers'][ $key ]['priceSpecification']['price'] );
+				// Remove priceSpecification priceCurrency property from Schema output by WooCommerce.
+				unset( $data['offers'][ $key ]['priceSpecification']['priceCurrency'] );
 			}
 			if ( $offer['@type'] === 'AggregateOffer' ) {
 				$data['offers'][ $key ]['@id']    = YoastSEO()->meta->for_current_page()->site_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -492,7 +492,7 @@ class WPSEO_WooCommerce_Schema {
 				'priceCurrency'      => $currency,
 				'priceSpecification' => [
 					'@type'                 => 'PriceSpecification',
-					'valueAddedTaxIncluded' => $prices_include_tax
+					'valueAddedTaxIncluded' => $prices_include_tax,
 				],
 			];
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -228,11 +228,11 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'price'              => '49.00',
 					'priceSpecification' => [
-						'price'         => '49.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 					'priceCurrency'      => 'GBP',
-					'availability'       => 'http://schema.org/InStock',
+					'availability'       => 'https://schema.org/InStock',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
 						'@type' => 'Organization',
@@ -297,11 +297,11 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'price'              => '49.00',
 					'priceSpecification' => [
-						'price'         => '49.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 					'priceCurrency'      => 'GBP',
-					'availability'       => 'http://schema.org/PreOrder',
+					'availability'       => 'https://schema.org/PreOrder',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
 						'@type' => 'Organization',
@@ -369,7 +369,7 @@ class Schema_Test extends TestCase {
 					'highPrice'     => '12.00',
 					'offerCount'    => 3,
 					'priceCurrency' => 'GBP',
-					'availability'  => 'http://schema.org/InStock',
+					'availability'  => 'https://schema.org/InStock',
 					'url'           => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'        => [
 						'@type' => 'Organization',
@@ -541,7 +541,7 @@ class Schema_Test extends TestCase {
 			'highPrice'     => '12.00',
 			'offerCount'    => 3,
 			'priceCurrency' => 'GBP',
-			'availability'  => 'http://schema.org/InStock',
+			'availability'  => 'https://schema.org/InStock',
 			'url'           => 'https://example.com/product/customizable-responsive-toolset/',
 			'seller'        => [
 				'@type' => 'Organization',
@@ -556,8 +556,8 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - l',
 					'price'              => 10,
 					'priceSpecification' => [
-						'price'         => 10,
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 				],
 				[
@@ -566,8 +566,8 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - m',
 					'price'              => 8,
 					'priceSpecification' => [
-						'price'         => 8,
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 				],
 				[
@@ -576,8 +576,8 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - xl',
 					'price'              => 12,
 					'priceSpecification' => [
-						'price'         => 12,
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],
@@ -647,7 +647,7 @@ class Schema_Test extends TestCase {
 					'highPrice'     => '12.00',
 					'offerCount'    => 3,
 					'priceCurrency' => 'GBP',
-					'availability'  => 'http://schema.org/InStock',
+					'availability'  => 'https://schema.org/InStock',
 					'url'           => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'        => [
 						'@type' => 'Organization',
@@ -704,7 +704,7 @@ class Schema_Test extends TestCase {
 					'highPrice'     => '12.00',
 					'offerCount'    => 3,
 					'priceCurrency' => 'GBP',
-					'availability'  => 'http://schema.org/InStock',
+					'availability'  => 'https://schema.org/InStock',
 					'url'           => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'        => [
 						'@type' => 'Organization',
@@ -1079,13 +1079,14 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'price'              => '1.00',
 					'url'                => $canonical,
+					'priceCurrency'      => 'GBP',
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
 					'priceSpecification' => [
-						'price'         => '1.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],
@@ -1256,18 +1257,19 @@ class Schema_Test extends TestCase {
 			'url'              => $canonical,
 			'description'      => '',
 			'sku'              => 'sku1234',
-			'offers'           => [
+			'offers' => [
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
+					'priceCurrency'      => 'GBP',
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
 					'priceSpecification' => [
-						'price'         => '1.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],
@@ -1428,18 +1430,19 @@ class Schema_Test extends TestCase {
 			'url'              => $canonical,
 			'description'      => '',
 			'sku'              => 'sku1234',
-			'offers'           => [
+			'offers' => [
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
+					'priceCurrency'      => 'GBP',
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
 					'priceSpecification' => [
-						'price'         => '1.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],
@@ -1580,11 +1583,11 @@ class Schema_Test extends TestCase {
 					'price'              => '49.00',
 					'priceValidUntil'    => '2020-03-24',
 					'priceSpecification' => [
-						'price'         => '49.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 					'priceCurrency'      => 'GBP',
-					'availability'       => 'http://schema.org/InStock',
+					'availability'       => 'https://schema.org/InStock',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
 						'@type' => 'Organization',
@@ -1689,11 +1692,11 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'price'              => '49.00',
 					'priceSpecification' => [
-						'price'         => '49.00',
-						'priceCurrency' => 'GBP',
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
 					],
 					'priceCurrency'      => 'GBP',
-					'availability'       => 'http://schema.org/InStock',
+					'availability'       => 'https://schema.org/InStock',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
 						'@type' => 'Organization',
@@ -1706,6 +1709,7 @@ class Schema_Test extends TestCase {
 
 		$expected_output                     = $input;
 		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output['offers'][0]['priceSpecification']['@type'] = 'PriceSpecification';
 		$expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] = true;
 
 		$base_url = 'http://example.com';

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -555,6 +555,7 @@ class Schema_Test extends TestCase {
 					'@id'                => 'https://example.com/#/schema/offer/209643-0',
 					'name'               => 'Customizable responsive toolset - l',
 					'price'              => 10,
+					'priceCurrency'      => 'GBP',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
@@ -565,6 +566,7 @@ class Schema_Test extends TestCase {
 					'@id'                => 'https://example.com/#/schema/offer/209643-1',
 					'name'               => 'Customizable responsive toolset - m',
 					'price'              => 8,
+					'priceCurrency'      => 'GBP',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
@@ -575,6 +577,7 @@ class Schema_Test extends TestCase {
 					'@id'                => 'https://example.com/#/schema/offer/209643-2',
 					'name'               => 'Customizable responsive toolset - xl',
 					'price'              => 12,
+					'priceCurrency'      => 'GBP',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
@@ -1046,6 +1049,10 @@ class Schema_Test extends TestCase {
 						'name'  => 'WP',
 						'url'   => $base_url,
 					],
+					'priceSpecification' => [
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
+					],
 				],
 			],
 			'review'      => [
@@ -1223,10 +1230,14 @@ class Schema_Test extends TestCase {
 			'sku'         => 'sku1234',
 			'offers'      => [
 				[
-					'@type'  => 'Offer',
-					'price'  => '1.00',
-					'url'    => $canonical,
-					'seller' => [
+					'@type'              => 'Offer',
+					'price'              => '1.00',
+					'url'                => $canonical,
+					'priceSpecification' => [
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
+					],
+					'seller'             => [
 						'@type' => 'Organization',
 						'name'  => 'WP',
 						'url'   => $base_url,

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1257,7 +1257,7 @@ class Schema_Test extends TestCase {
 			'url'              => $canonical,
 			'description'      => '',
 			'sku'              => 'sku1234',
-			'offers' => [
+			'offers'           => [
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
@@ -1430,7 +1430,7 @@ class Schema_Test extends TestCase {
 			'url'              => $canonical,
 			'description'      => '',
 			'sku'              => 'sku1234',
-			'offers' => [
+			'offers'           => [
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
@@ -1709,7 +1709,7 @@ class Schema_Test extends TestCase {
 
 		$expected_output                     = $input;
 		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
-		$expected_output['offers'][0]['priceSpecification']['@type'] = 'PriceSpecification';
+		$expected_output['offers'][0]['priceSpecification']['@type']                 = 'PriceSpecification';
 		$expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] = true;
 
 		$base_url = 'http://example.com';

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1041,10 +1041,10 @@ class Schema_Test extends TestCase {
 			'sku'         => 'sku1234',
 			'offers'      => [
 				[
-					'@type'  => 'Offer',
-					'price'  => '1.00',
-					'url'    => $canonical,
-					'seller' => [
+					'@type'              => 'Offer',
+					'price'              => '1.00',
+					'url'                => $canonical,
+					'seller'             => [
 						'@type' => 'Organization',
 						'name'  => 'WP',
 						'url'   => $base_url,

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1137,7 +1137,7 @@ class Schema_Test extends TestCase {
 			);
 
 		$instance->change_product( $data, $product );
-		$this->assertSame( $expected, $instance->data );
+		$this->assertEquals( $expected, $instance->data );
 	}
 
 	/**
@@ -1320,7 +1320,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertSame( $expected, $instance->data );
+		$this->assertEquals( $expected, $instance->data );
 	}
 
 	/**
@@ -1493,7 +1493,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertSame( $expected, $instance->data );
+		$this->assertEquals( $expected, $instance->data );
 	}
 
 	/**

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1086,15 +1086,15 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'price'              => '1.00',
 					'url'                => $canonical,
-					'priceCurrency'      => 'GBP',
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
-					'@id'                => $base_url . '#/schema/offer/1-0',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
 					],
+					'@id'                => $base_url . '#/schema/offer/1-0',
+					'priceCurrency'      => 'GBP',
 				],
 			],
 			'review'           => [
@@ -1137,7 +1137,7 @@ class Schema_Test extends TestCase {
 			);
 
 		$instance->change_product( $data, $product );
-		$this->assertEquals( $expected, $instance->data );
+		$this->assertSame( $expected, $instance->data );
 	}
 
 	/**
@@ -1272,16 +1272,16 @@ class Schema_Test extends TestCase {
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
-					'priceCurrency'      => 'GBP',
 					'url'                => $canonical,
-					'seller'             => [
-						'@id' => $base_url . '#organization',
-					],
-					'@id'                => $base_url . '#/schema/offer/1-0',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
 					],
+					'seller'             => [
+						'@id' => $base_url . '#organization',
+					],
+					'@id'                => $base_url . '#/schema/offer/1-0',
+					'priceCurrency'      => 'GBP',
 				],
 			],
 			'review'           => [
@@ -1320,7 +1320,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertEquals( $expected, $instance->data );
+		$this->assertSame( $expected, $instance->data );
 	}
 
 	/**
@@ -1445,12 +1445,12 @@ class Schema_Test extends TestCase {
 				[
 					'@type'              => 'Offer',
 					'price'              => '1.00',
-					'priceCurrency'      => 'GBP',
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
+					'priceCurrency'      => 'GBP',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
@@ -1493,7 +1493,7 @@ class Schema_Test extends TestCase {
 		];
 
 		$instance->change_product( $data, $product );
-		$this->assertEquals( $expected, $instance->data );
+		$this->assertSame( $expected, $instance->data );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Change the Schema output generated for product price specifications to prevent warnings from Google Search Console.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See JIRA issue PRODUCT-252 for the change.(Note by Andrea: PRODUCT-252 just redirects to P3-464 now)
* install and activate Yoast SEO, WooCommerce, and Woo SEO (switched to this branch and built)
* create a new Product
* in the "Product data" meta box, keep the default type "Simple product", add a price, and publish
* check the Product Schema output in the front end (note that it's separate from the main Schema output)
* note that a simple Product has only one "offer" entry with a `"@type"` value of `"Offer"`
* check the `priceSpecification` property does NOT have `price` and `priceCurrency` properties
* check it does have a `@type` value of `PriceSpecification`
* check the `priceCurrency` property is present one level up as property of the offer
* create a new Product
* in the "Product data" meta box, set the type to "Variable product"
* in the "Product data" meta box, go to the "Attributes" tab
* create a new Custom product attribute and add some values e.g. create a "Size" attribute and then add the values Small, Medium, Large
* check the checkbox "Used for variations" and hit "Save attribute"
* in the "Product data" meta box, go to the "Variations" tab
* add 3 variations based on the 3 sizes, set a price for each variation, and hit "Save changes"
* publish the product and check the Product Schema output in the front end
* note that a variable Product will have a `"@type"` value of `"AggregateOffer"`
* within the aggregate offer there will be 3 offers with a `"@type"` value of `"Offer"`
* check each offer `priceSpecification` property does NOT have `price` and `priceCurrency` properties
* check they do have a `@type` value of `PriceSpecification`
* check the `priceCurrency` property is present one level up as property of each of the offers and one more level up as property of the `AggregateOffer`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P3-464
