### PR TITLE
P1-488 Shoppingdata Availability typography

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1226,8 +1226,8 @@ class Yoast_WooCommerce_SEO {
 		$google_preview['availability'] = str_replace( '-', ' ', $product->get_availability()['class'] );
 
 		// Because the backorder availability value is not supported in the Google Product snippet, we output preorder in the schema, and thus the preview.
-		if ( $google_preview[ 'availability' ] === 'available on backorder' ) {
-			$google_preview[ 'availability' ] = 'preorder';
+		if ( $google_preview['availability'] === 'available on backorder' ) {
+			$google_preview['availability'] = 'preorder';
 		}
 
 		if ( $this->should_show_price() ) {

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1225,6 +1225,11 @@ class Yoast_WooCommerce_SEO {
 		$google_preview['reviewCount']  = $product->get_rating_count();
 		$google_preview['availability'] = str_replace( '-', ' ', $product->get_availability()['class'] );
 
+		// Because the backorder availability value is not supported in the Google Product snippet, we output preorder in the schema, and thus the preview.
+		if ( $google_preview[ 'availability' ] === 'available on backorder' ) {
+			$google_preview[ 'availability' ] = 'preorder';
+		}
+
 		if ( $this->should_show_price() ) {
 			$google_preview['price'] = $this->get_product_var_price();
 		}

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1223,7 +1223,7 @@ class Yoast_WooCommerce_SEO {
 		$product                        = $this->get_product();
 		$google_preview['rating']       = floatval( $product->get_average_rating() );
 		$google_preview['reviewCount']  = $product->get_rating_count();
-		$google_preview['availability'] = str_replace("-", " ", $product->get_availability()['class'] );
+		$google_preview['availability'] = str_replace( '-', ' ', $product->get_availability()['class'] );
 
 		if ( $this->should_show_price() ) {
 			$google_preview['price'] = $this->get_product_var_price();

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1223,7 +1223,8 @@ class Yoast_WooCommerce_SEO {
 		$product                        = $this->get_product();
 		$google_preview['rating']       = floatval( $product->get_average_rating() );
 		$google_preview['reviewCount']  = $product->get_rating_count();
-		$google_preview['availability'] = $product->get_availability()['class'];
+		$google_preview['availability'] = str_replace("-", " ", $product->get_availability()['class'] );
+
 		if ( $this->should_show_price() ) {
 			$google_preview['price'] = $this->get_product_var_price();
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Availability string that was dispatched to WP SEO had dashes between words. That needs to be spaces.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces hyphens in the WooCommerce availability status with spaces.
* Replaces the "available on backorder" in the WooCommerce availability status with "preorder", because that is what is output on the frontend. Backorder is not a value supported by Google.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch together with WP SEO 16.3-beta or Trunk and the P1-488 branch of the Javascript monorepo
* Or for QA, use the latest 16.3 beta of WP SEO, that has the monorepo change in it.
* Edit a Product and check whether in the Google preview, the description of the Availability is written with a starting capital and spaces. For instance: "In stock"


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-488
