### PR TITLE
Output a product gallery image before defaulting to the site-wide social default

### DIFF
--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -162,7 +162,12 @@ class YoastWooCommercePlugin {
 	 */
 	addProductGalleryImageAsFallback( fallbacks ) {
 		if ( productGalleryFallbackImage ) {
-			fallbacks.push( { productGalleryImage: productGalleryFallbackImage } );
+			// We want to go last, i.e. before the site-wide default social image.
+			const insertAtIndex = fallbacks.findIndex( fallbackImageObject => {
+				return Object.keys( fallbackImageObject )[ 0 ] === "siteWideImage";
+			} );
+
+			fallbacks.splice( insertAtIndex, 0, { productGalleryImage: productGalleryFallbackImage } );
 		}
 
 		return fallbacks;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A product gallery image should override the site wide default OG image.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a Product Gallery image would not have priority over the site-wide default OpenGraph image in the Social Previews.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test together with Premium (16.3).
* Set a "site-wide" default OG image, in SEO -> social -> Facebook.
* Add a new product in WooCommerce.
* Navigate to the Social Previews.
* Verify that, without any further images on the page (no content image, no product image, no product gallery image), the sitewide image you just set is visible in the previews.
* Now, as you add the following images, they should override the default preview image in order:
	* Add a product gallery image. As a preview you should now see the first product gallery image.
	* Add an image in the content. As a preview you should now see the image in the content.
	* Add a product image. As a preview you should now see the product image.
	* Add a Twitter Image. For the Twitter preview you should now see the Twitter image you just set. Facebook -> still the product image.
	* Add a Facebook Image. For Facebook you should now see the Facebook image you just set, for Twitter, the Twitter Image.
	* Remove the Twitter image. For Twitter, you should now see Facebook image.

* That's basically how it goes, play around with the order. The order in priorities is:
`(For twitter only: Twitter Image) > Facebook image > featured/product image > content image > product gallery image > site-wide OG default image`.
* As always, make sure the schema output matches the preview (so we don't show erroneous previews).
* **NOTE that on the frontend multiple OG images can be output, which will be converted to a slider by some consumers, but we don't have that functionality in our previews (yet?)**


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-489
