### PR TITLE
CS/QA: various minor fixes

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -127,24 +127,18 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 							if ( in_array( $dirty[ $key ], $valid_taxonomies, true ) ) {
 								$clean[ $key ] = $dirty[ $key ];
 							}
-							else {
-								if ( sanitize_title_with_dashes( $dirty[ $key ] ) === $dirty[ $key ] ) {
-									// Allow taxonomies which may not be registered yet.
-									$clean[ $key ] = $dirty[ $key ];
-								}
+							elseif ( sanitize_title_with_dashes( $dirty[ $key ] ) === $dirty[ $key ] ) {
+								// Allow taxonomies which may not be registered yet.
+								$clean[ $key ] = $dirty[ $key ];
 							}
 						}
-						else {
-							if ( $short && isset( $old[ $key ] ) ) {
-								if ( in_array( $old[ $key ], $valid_taxonomies, true ) ) {
-									$clean[ $key ] = $old[ $key ];
-								}
-								else {
-									if ( sanitize_title_with_dashes( $old[ $key ] ) === $old[ $key ] ) {
-										// Allow taxonomies which may not be registered yet.
-										$clean[ $key ] = $old[ $key ];
-									}
-								}
+						elseif ( $short && isset( $old[ $key ] ) ) {
+							if ( in_array( $old[ $key ], $valid_taxonomies, true ) ) {
+								$clean[ $key ] = $old[ $key ];
+							}
+							elseif ( sanitize_title_with_dashes( $old[ $key ] ) === $old[ $key ] ) {
+								// Allow taxonomies which may not be registered yet.
+								$clean[ $key ] = $old[ $key ];
 							}
 						}
 						break;

--- a/classes/woocommerce-permalink-watcher.php
+++ b/classes/woocommerce-permalink-watcher.php
@@ -5,9 +5,6 @@
  * @package WPSEO/WooCommerce
  */
 
-use Yoast\WP\Lib\Model;
-use Yoast\WP\SEO\WordPress\Wrapper;
-
 /**
  * The permalink watcher.
  *

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -626,17 +626,17 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @since 1.0
 	 *
-	 * @param bool   $bool      Whether or not to include this post type in the XML sitemap.
-	 * @param string $post_type The post type of the post.
+	 * @param bool   $include_in_sitemap Whether or not to include this post type in the XML sitemap.
+	 * @param string $post_type          The post type of the post.
 	 *
 	 * @return bool
 	 */
-	public function xml_sitemap_post_types( $bool, $post_type ) {
+	public function xml_sitemap_post_types( $include_in_sitemap, $post_type ) {
 		if ( $post_type === 'product_variation' || $post_type === 'shop_coupon' ) {
 			return true;
 		}
 
-		return $bool;
+		return $include_in_sitemap;
 	}
 
 	/**
@@ -644,17 +644,17 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @since 1.0
 	 *
-	 * @param bool   $bool     Whether or not to include this post type in the XML sitemap.
-	 * @param string $taxonomy The taxonomy to check against.
+	 * @param bool   $include_in_sitemap Whether or not to include this taxonomy in the XML sitemap.
+	 * @param string $taxonomy           The taxonomy to check against.
 	 *
 	 * @return bool
 	 */
-	public function xml_sitemap_taxonomies( $bool, $taxonomy ) {
+	public function xml_sitemap_taxonomies( $include_in_sitemap, $taxonomy ) {
 		if ( $taxonomy === 'product_type' || $taxonomy === 'product_shipping_class' || $taxonomy === 'shop_order_status' ) {
 			return true;
 		}
 
-		return $bool;
+		return $include_in_sitemap;
 	}
 
 	/**
@@ -723,25 +723,25 @@ class Yoast_WooCommerce_SEO {
 	/**
 	 * Make a string clear for display in meta data.
 	 *
-	 * @param string $string The input string.
+	 * @param string $text_string The input string.
 	 *
 	 * @return string The clean string.
 	 */
-	protected function clean_description( $string ) {
+	protected function clean_description( $text_string ) {
 		// Strip tags.
-		$string = wp_strip_all_tags( $string );
+		$text_string = wp_strip_all_tags( $text_string );
 
 		// Replace non breaking space entities with spaces.
-		$string = str_replace( '&nbsp;', ' ', $string );
+		$text_string = str_replace( '&nbsp;', ' ', $text_string );
 
 		// Replace non breaking uni-code spaces with spaces. Don't ask.
-		$string = str_replace( chr( 194 ) . chr( 160 ), ' ', $string );
+		$text_string = str_replace( chr( 194 ) . chr( 160 ), ' ', $text_string );
 
 		// Replace all double or more spaces with one space and trim our string.
-		$string = preg_replace( '/\s+/', ' ', $string );
-		$string = trim( $string );
+		$text_string = preg_replace( '/\s+/', ' ', $text_string );
+		$text_string = trim( $text_string );
 
-		return $string;
+		return $text_string;
 	}
 
 	/**

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -846,7 +846,7 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @param array $helpscout_settings The HelpScout settings.
 	 *
-	 * @return array $helpscout_settings The HelpScout settings with the News SEO beacon added.
+	 * @return array The HelpScout settings with the News SEO beacon added.
 	 */
 	public function filter_helpscout_beacon( $helpscout_settings ) {
 		$helpscout_settings['pages_ids']['wpseo_woo'] = '8535d745-4e80-48b9-b211-087880aa857d';

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -109,7 +109,7 @@ class Actions {
 	private static function filter_files( $files, $extension ) {
 		return \array_filter(
 			$files,
-			function( $file ) use ( $extension ) {
+			static function( $file ) use ( $extension ) {
 				return \substr( $file, ( 0 - \strlen( $extension ) ) ) === $extension;
 			}
 		);

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -2,11 +2,10 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_WooCommerce_Product_Price_Amount_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
-
-use function Brain\Monkey\Functions\expect;
 
 /**
  * Class Product_Price_Amount_Presenter_Test.
@@ -81,9 +80,9 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 			->once()
 			->andReturn( '1' );
 
-		expect( 'wc_get_price_decimals' )->once()->andReturn( 0 );
-		expect( 'wc_tax_enabled' )->once()->andReturn( false );
-		expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
+		Functions\expect( 'wc_get_price_decimals' )->once()->andReturn( 0 );
+		Functions\expect( 'wc_tax_enabled' )->once()->andReturn( false );
+		Functions\expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
 
 		$this->assertSame( '11', $this->instance->get() );
 	}
@@ -103,9 +102,9 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 			->once()
 			->andReturn( '1' );
 
-		expect( 'wc_get_price_decimals' )->once()->andReturn( 0 );
-		expect( 'wc_tax_enabled' )->once()->andReturn( false );
-		expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
+		Functions\expect( 'wc_get_price_decimals' )->once()->andReturn( 0 );
+		Functions\expect( 'wc_tax_enabled' )->once()->andReturn( false );
+		Functions\expect( 'wc_format_decimal' )->once()->with( '11', 0 )->andReturn( 11 );
 
 		$actual = $this->instance->get();
 

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -2,11 +2,10 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
+use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_WooCommerce_Product_Price_Currency_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
-
-use function Brain\Monkey\Functions\expect;
 
 /**
  * Class Product_Price_Currency_Presenter_Test.
@@ -72,7 +71,7 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	 * @covers ::get
 	 */
 	public function test_get() {
-		expect( 'get_woocommerce_currency' )->once()->andReturn( 'EUR' );
+		Functions\expect( 'get_woocommerce_currency' )->once()->andReturn( 'EUR' );
 
 		$this->assertSame( 'EUR', $this->instance->get() );
 	}

--- a/tests/classes/presenters/schema-presenter-test.php
+++ b/tests/classes/presenters/schema-presenter-test.php
@@ -81,9 +81,9 @@ class Schema_Presenter_Test extends TestCase {
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
 			->andReturnUsing(
-				static function( $array ) {
+				static function( $data ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
-					return \json_encode( $array );
+					return \json_encode( $data );
 				}
 			);
 
@@ -104,9 +104,9 @@ class Schema_Presenter_Test extends TestCase {
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
 			->andReturnUsing(
-				static function( $array ) {
+				static function( $data ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
-					return \json_encode( $array );
+					return \json_encode( $data );
 				}
 			);
 

--- a/tests/classes/presenters/schema-presenter-test.php
+++ b/tests/classes/presenters/schema-presenter-test.php
@@ -81,7 +81,7 @@ class Schema_Presenter_Test extends TestCase {
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
 			->andReturnUsing(
-				function( $array ) {
+				static function( $array ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
 					return \json_encode( $array );
 				}
@@ -104,7 +104,7 @@ class Schema_Presenter_Test extends TestCase {
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
 			->andReturnUsing(
-				function( $array ) {
+				static function( $array ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
 					return \json_encode( $array );
 				}

--- a/tests/classes/presenters/schema-presenter-test.php
+++ b/tests/classes/presenters/schema-presenter-test.php
@@ -90,7 +90,7 @@ class Schema_Presenter_Test extends TestCase {
 		$output = $this->instance->present();
 
 		self::assertSame(
-			'<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . PHP_EOL,
+			'<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . \PHP_EOL,
 			$output
 		);
 	}
@@ -113,7 +113,7 @@ class Schema_Presenter_Test extends TestCase {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to test if the correct HTML is output.
 		echo $this->instance;
 		$this->expectOutputContains(
-			'<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . PHP_EOL
+			'<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . \PHP_EOL
 		);
 	}
 }

--- a/tests/classes/presenters/schema-presenter-test.php
+++ b/tests/classes/presenters/schema-presenter-test.php
@@ -117,6 +117,3 @@ class Schema_Presenter_Test extends TestCase {
 		);
 	}
 }
-
-
-

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -118,7 +118,7 @@ class Schema_Test extends TestCase {
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
 			->andReturnUsing(
-				function( $array ) {
+				static function( $array ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
 					return \json_encode( $array );
 				}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -118,9 +118,9 @@ class Schema_Test extends TestCase {
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
 			->andReturnUsing(
-				static function( $array ) {
+				static function( $data ) {
 					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
-					return \json_encode( $array );
+					return \json_encode( $data );
 				}
 			);
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -127,7 +127,7 @@ class Schema_Test extends TestCase {
 		$schema->data = $data;
 		$schema->output_schema_footer();
 
-		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . PHP_EOL );
+		$this->expectOutputContains( '<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Product","@id":"http:\/\/basic.wordpress.test\/product\/hippopotamus\/#product","name":"Hippopotamus"}]}</script>' . \PHP_EOL );
 	}
 
 	/**

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -151,10 +151,10 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	/**
 	 * Test an error message's output.
 	 *
-	 * @param string $function Function to test.
-	 * @param string $expected Expected output.
+	 * @param string $function_under_test Function to test.
+	 * @param string $expected            Expected output.
 	 */
-	private function error_message_test( $function, $expected ) {
+	private function error_message_test( $function_under_test, $expected ) {
 		$this->stubEscapeFunctions();
 
 		$class = Mockery::mock( Yoast_WooCommerce_Dependencies_Double::class )->makePartial();
@@ -167,6 +167,6 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 
 		$this->expectOutputString( $expected );
 
-		$class->$function();
+		$class->$function_under_test();
 	}
 }

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -2,8 +2,8 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Classes;
 
-use Mockery;
 use Brain\Monkey\Functions;
+use Mockery;
 use Yoast\WP\Woocommerce\Tests\Doubles\Yoast_WooCommerce_Dependencies_Double;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -3,9 +3,9 @@
 namespace Yoast\WP\Woocommerce\Tests\Classes;
 
 use Brain\Monkey\Functions;
+use WPSEO_WooCommerce_Yoast_Tab;
 use Yoast\WP\Woocommerce\Tests\Doubles\Yoast_Tab_Double;
 use Yoast\WP\Woocommerce\Tests\TestCase;
-use WPSEO_WooCommerce_Yoast_Tab;
 
 /**
  * Class WooCommerce_Schema_Test.

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -51,7 +51,7 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @param string $expected_output Substring expected to be found in the actual output.
 	 */
 	public function test_add_yoast_seo_fields( $expected_output ) {
-		if ( defined( 'WPSEO_WOO_PLUGIN_FILE' ) === false ) {
+		if ( \defined( 'WPSEO_WOO_PLUGIN_FILE' ) === false ) {
 			\define( 'WPSEO_WOO_PLUGIN_FILE', './wpseo-woocommerce.php' );
 		}
 


### PR DESCRIPTION
## Context

* Code consistency

## Summary
This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

### CS: order import use statements alphabetically

### CS/QA: don't use `use function`

Always use `use` import statements for a class or a namespace, not for functions or constants directly to make it more obvious where something is coming from in the code.

As per Yoast/yoastcs#215

### CS: use elseif instead of an if nested within an else

... if the if statement is the only thing within the `else`.

This doesn't change anything functionally and simplifies the code.

### CS/QA: let static closures be static

### QA: remove unused use statements

### Docs: no named return value

The name of a return value does not get passed on, so has no significance in the docs.

### QA: use fully qualified names

.. for global functions and constants in namespaced files.

### CS/QA: rename various function parameters

... to prevent using a reserved keyword as a parameter name.

While this isn't forbidden, in PHP 8.0+ with named parameters this can lead to very confusing code, so better to use another name.

### CS: minor whitespace clean up 

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This PR does not contain any functional changes. If the build passes, we're good.