### PR TITLE
P1 511 rating outputs disabling

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1219,9 +1219,6 @@ class Yoast_WooCommerce_SEO {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$version       = $asset_manager->flatten_version( self::VERSION );
 
-$reviews_enabled = wc_reviews_enabled();
-$rating_enabled  = wc_review_ratings_enabled();
-
 		$google_preview                 = [];
 		$product                        = $this->get_product();
 		$google_preview['availability'] = str_replace( '-', ' ', $product->get_availability()['class'] );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1219,10 +1219,11 @@ class Yoast_WooCommerce_SEO {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$version       = $asset_manager->flatten_version( self::VERSION );
 
+$reviews_enabled = wc_reviews_enabled();
+$rating_enabled  = wc_review_ratings_enabled();
+
 		$google_preview                 = [];
 		$product                        = $this->get_product();
-		$google_preview['rating']       = floatval( $product->get_average_rating() );
-		$google_preview['reviewCount']  = $product->get_review_count();
 		$google_preview['availability'] = str_replace( '-', ' ', $product->get_availability()['class'] );
 
 		// Because the backorder availability value is not supported in the Google Product snippet, we output preorder in the schema, and thus the preview.
@@ -1232,6 +1233,11 @@ class Yoast_WooCommerce_SEO {
 
 		if ( $this->should_show_price() ) {
 			$google_preview['price'] = $this->get_product_var_price();
+		}
+
+		if ( wc_reviews_enabled() && wc_review_ratings_enabled() ) {
+			$google_preview['rating']      = floatval( $product->get_average_rating() );
+			$google_preview['reviewCount'] = $product->get_review_count();
 		}
 
 		return [

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1222,7 +1222,7 @@ class Yoast_WooCommerce_SEO {
 		$google_preview                 = [];
 		$product                        = $this->get_product();
 		$google_preview['rating']       = floatval( $product->get_average_rating() );
-		$google_preview['reviewCount']  = $product->get_rating_count();
+		$google_preview['reviewCount']  = $product->get_review_count();
 		$google_preview['availability'] = str_replace( '-', ' ', $product->get_availability()['class'] );
 
 		// Because the backorder availability value is not supported in the Google Product snippet, we output preorder in the schema, and thus the preview.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WooCommerce has an option to disable ratings or reviews. When one of those is disabled, we don't output schema for both the rating and the reviewCount. The Google preview should reflect this.
* We displayed the number of ratings in our Google preview, that needed to be the number of reviews like er output in our Schema. 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where after disabling the rating or reviews in WooCommerce, they still were present in our Google Preview.
* Fixes an unreleased bug where the number of ratings was displayed in our Google Preview instead of the number of reviews.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable this branch or latest RC of SEO for WooCommerce and WordPress SEO 16.3(RC)
* In WooCommerce -> Settings -> Product uncheck _Star ratings should be required, not optional_ and save
* For a product, add some reviews, some with and some without a rating
* Edit that product and check that the Google preview displays the rating and the total number of reviews
* In WooCommerce -> Settings -> Product uncheck _Enable star rating on reviews_ and save
* Refresh the edit page of your product and confirm that neither the rating nor the number of reviews are present in the google preview
* In WooCommerce -> Settings -> Product uncheck _Enable product reviews_ and save
* Refresh the edit page of your product and confirm that neither the rating nor the number of reviews are present in the google preview

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-511
