### PR TITLE
Update filtering of the social images fallback.

### DIFF
--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -164,7 +164,7 @@ class YoastWooCommercePlugin {
 		if ( productGalleryFallbackImage ) {
 			/*
 			 * We want to insert the image before the Global Social Template image,
-			 * otherise before the site-wide default social image.
+			 * otherwise before the site-wide default social image.
 			 */
 			const insertAtIndex = fallbacks.findIndex( fallbackImageObject => {
 				if ( Object.keys( fallbackImageObject )[ 0 ] === "socialImage" ) {

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -162,8 +162,15 @@ class YoastWooCommercePlugin {
 	 */
 	addProductGalleryImageAsFallback( fallbacks ) {
 		if ( productGalleryFallbackImage ) {
-			// We want to go last, i.e. before the site-wide default social image.
+			/*
+			 * We want to insert the image before the Global Social Template image,
+			 * otherise before the site-wide default social image.
+			 */
 			const insertAtIndex = fallbacks.findIndex( fallbackImageObject => {
+				if ( Object.keys( fallbackImageObject )[ 0 ] === "socialImage" ) {
+					return true;
+				}
+
 				return Object.keys( fallbackImageObject )[ 0 ] === "siteWideImage";
 			} );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update the product gallery image fallback logic to take into account the upcoming Social default image.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the the product gallery image fallback logic to take into account the Social default image.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Prerequisites:**
- activate Yoast SEO Free, switched to the `P3-574-social-templates-previews` branch and build it
- activate Yoast SEO Premium trunk and build it
- activate WooCommerce 
- activate Woo SEO, switched to this branch `P3-600-update-filtering-social-images-fallback` and build it 
- make sure the Global Social Template feature flag is enabled by setting this constant in your wp-config.php file: `define( 'YOAST_SEO_SOCIAL_TEMPLATES', true );`

**Test instructions:**
- go to SEO > Social > Facebook, set a default image, and save
- go to SEO > Search Appearance > Content Types > Products, set a default social image, and save
- create a product, and:
  - insert some text and two images in the content 
  - set a Product image (this is the equivalent of the "Featured image")
  - add two images in the Product gallery
- go to the Yoast SEO Premium meta box > Social tab 
- check the FB and Twitter previews display the "Product image" (the equivalent of the "Featured image")
- set a FB image 
- check both the FB and Twitter previews display the FB image 
- set a Twitter image 
- check the Twitter preview displays the Twitter image 
- remove the Twitter image and check the Twitter preview displays the FB image 
- remove the FB image and check both previews display the "Product image"
- remove the Product image and check both previews display the first image in the content 
- remove the first image in the content and check both previews display the other image that's in the content (you may need to click outside of the TinyMCE editor to trigger a content change event)
- remove the image that's left in the content and check both previews display the first image in the Product gallery 
- remove the first image in the Product gallery (hover the image and click the X icon) and check both previews display the other image in the Product gallery 
- remove the image that's left in the Product gallery and check both previews display the social image set under SEO > Search Appearance > Content Types > Products
- save the Product post 
- in another browser tab, go to SEO > Search Appearance > Content Types > Products, and remove the Social default image
- switch to the browser tab where you're editing the Product, refresh, and check both social previews display the default image set under SEO > Social > Facebook
- in the other browser tab, go to SEO > Social > Facebook, and remove the default image 
- in the other browser tab, refresh the Product page, and check both social previews display the empty image placeholder

**Test with Premium deactivated:**
- deactivate Premium 
- on Free, there are no social previews so we only need to check the output on the front end
- repeat the steps above
- when removing the images of the Product gallery, save the product 
- view the source of the product page 
- check the `og:image` tag is set to the image set under SEO > Social > Facebook and that is NOT the Social default image


**Previous versions:**
There's no need to test previous versions as the JavaScript filter this Product gallery image fallback relies on is new:
- will be released in Yoast SEO Free 16.3 - https://github.com/Yoast/wordpress-seo/pull/16798
- and will be released in Woo SEO 14.0 - https://github.com/Yoast/wpseo-woocommerce/pull/669



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-600]