### PR TITLE
Set the minimum required WP version to 5.6

### DIFF
--- a/classes/woocommerce-dependencies.php
+++ b/classes/woocommerce-dependencies.php
@@ -18,7 +18,7 @@ class Yoast_WooCommerce_Dependencies {
 	 * @return bool True when the dependencies are okay.
 	 */
 	public function check_dependencies( $wp_version ) {
-		if ( ! version_compare( $wp_version, '5.3', '>=' ) ) {
+		if ( ! version_compare( $wp_version, '5.6', '>=' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'wordpress_upgrade_error' ] );
 
 			return false;

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -20,7 +20,7 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @covers Yoast_WooCommerce_Dependencies::check_woocommerce_exists
 	 */
 	public function test_check_dependencies() {
-		$valid_wp_version        = '5.3';
+		$valid_wp_version        = '5.6';
 		$valid_yoast_seo_version = '16.4';
 
 		$class = Mockery::mock( Yoast_WooCommerce_Dependencies_Double::class )->makePartial();
@@ -32,7 +32,7 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 		// Valid WordPress version.
 		$class->expects( 'check_woocommerce_exists' )->once()->andReturn( true );
 		$class->expects( 'get_yoast_seo_version' )->once()->andReturn( $valid_yoast_seo_version );
-		$actual = $class->check_dependencies( '5.3' );
+		$actual = $class->check_dependencies( '5.6' );
 		$this->assertTrue( $actual );
 
 		// WooCommerce in-active.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We support the last two released versions of WordPress.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum WordPress version to 5.6.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* No need to test this PR.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
