### PR TITLE
P2-1091 implement abstract indexable tag presenter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
         - chmod 600 ./deploy_keys/wpseo_woo_deploy
         - eval $(ssh-agent -s)
         - ssh-add ./deploy_keys/wpseo_woo_deploy
+        - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+        -composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
       before_deploy:
         - nvm install node
         - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -74,6 +76,7 @@ cache:
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   - export SECURITYCHECK_DIR=/tmp/security-checker
+  - composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
   - |
     if [[ "$CHECKJS" == "1" ]]; then
       nvm install $TRAVIS_NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - eval $(ssh-agent -s)
         - ssh-add ./deploy_keys/wpseo_woo_deploy
         - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-        -composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
+        - composer config --global github-oauth.github.com $GITHUB_OAUTH_TOKEN
       before_deploy:
         - nvm install node
         - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/classes/presenters/woocommerce-abstract-product-presenter.php
+++ b/classes/presenters/woocommerce-abstract-product-presenter.php
@@ -20,6 +20,13 @@ abstract class WPSEO_WooCommerce_Abstract_Product_Presenter extends Abstract_Ind
 	protected $product;
 
 	/**
+	 * The tag format including placeholders.
+	 *
+	 * @var string
+	 */
+	protected $tag_format = self::META_PROPERTY_CONTENT;
+
+	/**
 	 * WPSEO_WooCommerce_Abstract_Product_Presenter constructor.
 	 *
 	 * @param \WC_Product $product The product.

--- a/classes/presenters/woocommerce-pinterest-product-availability-presenter.php
+++ b/classes/presenters/woocommerce-pinterest-product-availability-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter extends WPSEO_WooCommerce_Abstract_Product_Availability_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="og:availability" content="%s" />';
+	protected $key = 'og:availability';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/presenters/woocommerce-product-availability-presenter.php
+++ b/classes/presenters/woocommerce-product-availability-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Product_Availability_Presenter extends WPSEO_WooCommerce_Abstract_Product_Availability_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="product:availability" content="%s" />';
+	protected $key = 'product:availability';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/presenters/woocommerce-product-brand-presenter.php
+++ b/classes/presenters/woocommerce-product-brand-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Product_Brand_Presenter extends WPSEO_WooCommerce_Abstract_Product_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="product:brand" content="%s" />';
+	protected $key = 'product:brand';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/presenters/woocommerce-product-condition-presenter.php
+++ b/classes/presenters/woocommerce-product-condition-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Product_Condition_Presenter extends WPSEO_WooCommerce_Abstract_Product_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="product:condition" content="%s" />';
+	protected $key = 'product:condition';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/presenters/woocommerce-product-price-amount-presenter.php
+++ b/classes/presenters/woocommerce-product-price-amount-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Product_Price_Amount_Presenter extends WPSEO_WooCommerce_Abstract_Product_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="product:price:amount" content="%s" />';
+	protected $key = 'product:price:amount';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/presenters/woocommerce-product-price-currency-presenter.php
+++ b/classes/presenters/woocommerce-product-price-currency-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Product_Price_Currency_Presenter extends WPSEO_WooCommerce_Abstract_Product_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="product:price:currency" content="%s" />';
+	protected $key = 'product:price:currency';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/presenters/woocommerce-product-retailer-item-id-presenter.php
+++ b/classes/presenters/woocommerce-product-retailer-item-id-presenter.php
@@ -11,11 +11,11 @@
 class WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter extends WPSEO_WooCommerce_Abstract_Product_Presenter {
 
 	/**
-	 * The tag format including placeholders.
+	 * The tag key name.
 	 *
 	 * @var string
 	 */
-	protected $tag_format = '<meta property="product:retailer_item_id" content="%s" />';
+	protected $key = 'product:retailer_item_id';
 
 	/**
 	 * Gets the raw value of a presentation.

--- a/classes/woocommerce-dependencies.php
+++ b/classes/woocommerce-dependencies.php
@@ -39,7 +39,7 @@ class Yoast_WooCommerce_Dependencies {
 			return false;
 		}
 
-		// At least 16.7, in which we added the yoast_head and yoast_head_json functionality to the plugin.
+		// At least 16.7, in which we added the yoast_head_json functionality to the plugin.
 		if ( ! version_compare( $wordpress_seo_version, '16.7-RC0', '>=' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'yoast_seo_upgrade_error' ] );
 

--- a/classes/woocommerce-dependencies.php
+++ b/classes/woocommerce-dependencies.php
@@ -39,8 +39,8 @@ class Yoast_WooCommerce_Dependencies {
 			return false;
 		}
 
-		// At least 16.4, in which we've implemented the enhanced Google preview for products.
-		if ( ! version_compare( $wordpress_seo_version, '16.4-RC0', '>=' ) ) {
+		// At least 16.7, in which we added the yoast_head and yoast_head_json functionality to the plugin.
+		if ( ! version_compare( $wordpress_seo_version, '16.7-RC0', '>=' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'yoast_seo_upgrade_error' ] );
 
 			return false;

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -6,6 +6,7 @@
  */
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Helpers\Request_Helper;
 
 /**
  * Class Yoast_WooCommerce_SEO
@@ -675,7 +676,9 @@ class Yoast_WooCommerce_SEO {
 			return wc_get_product( get_the_ID() );
 		}
 
-		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		$request_helper = new Request_Helper();
+
+		if ( ! $request_helper->is_rest_request() ) {
 			// This is a frontend request.
 			if ( is_a( $context, Meta_Tags_Context::class ) ) {
 				if ( $context->indexable->object_sub_type === "product" ) {

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -682,8 +682,12 @@ class Yoast_WooCommerce_SEO {
 			}
 		}
 
-		if ( ! is_singular( 'product' ) ) {
-			return null;
+		// if ( ! is_singular( 'product' ) ) {
+		// 	return null;
+		// }
+		global $post;
+		if ( ! empty( $post ) ) {
+			return wc_get_product( $post );
 		}
 
 		return wc_get_product( get_queried_object_id() );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -161,6 +161,7 @@ class Yoast_WooCommerce_SEO {
 	 * Adds the WooCommerce OpenGraph presenter.
 	 *
 	 * @param \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter[] $presenters The presenter instances.
+	 * @param \Yoast\WP\SEO\Context\Meta_Tags_Context                 $context The meta tags context.
 	 *
 	 * @return \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter[] The extended presenters.
 	 */
@@ -665,6 +666,8 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @since 4.3
 	 *
+	 * @param \Yoast\WP\SEO\Context\Meta_Tags_Context $context The meta tags context.
+	 *
 	 * @return WC_Product|null
 	 */
 	private function get_product( $context = null ) {
@@ -681,18 +684,18 @@ class Yoast_WooCommerce_SEO {
 		if ( ! $request_helper->is_rest_request() ) {
 			// This is a frontend request.
 			if ( is_a( $context, Meta_Tags_Context::class ) ) {
-				if ( $context->indexable->object_sub_type === "product" ) {
+				if ( $context->indexable->object_sub_type === 'product' ) {
 					$the_post = \get_post( $context->indexable->object_id );
 					return wc_get_product( $the_post );
 				}
 			}
 
 			return null;
-		} 
+		}
 
 		// This is a REST API request.
 		global $post;
-		if ( ! empty( $post ) && property_exists( $post, 'post_type' ) && $post->post_type === "product" ) {
+		if ( ! empty( $post ) && property_exists( $post, 'post_type' ) && $post->post_type === 'product' ) {
 			return wc_get_product( $post );
 		}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -676,9 +676,9 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		if ( is_a( $context, Meta_Tags_Context::class ) ) {
-			if ( $context->indexable->object_sub_type === "post" ) {
+			if ( $context->indexable->object_type === "post" ) {
 				$the_post = \get_post( $context->indexable->object_id );
-				wc_get_product( $the_post );
+				return wc_get_product( $the_post );
 			}
 		}
 

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -675,22 +675,25 @@ class Yoast_WooCommerce_SEO {
 			return wc_get_product( get_the_ID() );
 		}
 
-		if ( is_a( $context, Meta_Tags_Context::class ) ) {
-			if ( $context->indexable->object_type === "post" ) {
-				$the_post = \get_post( $context->indexable->object_id );
-				return wc_get_product( $the_post );
+		if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+			// This is a frontend request.
+			if ( is_a( $context, Meta_Tags_Context::class ) ) {
+				if ( $context->indexable->object_sub_type === "product" ) {
+					$the_post = \get_post( $context->indexable->object_id );
+					return wc_get_product( $the_post );
+				}
 			}
-		}
 
-		// if ( ! is_singular( 'product' ) ) {
-		// 	return null;
-		// }
+			return null;
+		} 
+
+		// This is a REST API request.
 		global $post;
-		if ( ! empty( $post ) ) {
+		if ( ! empty( $post ) && property_exists( $post, 'post_type' ) && $post->post_type === "product" ) {
 			return wc_get_product( $post );
 		}
 
-		return wc_get_product( get_queried_object_id() );
+		return null;
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "config": {
         "platform": {
             "php": "5.6.40"
+        },
+        "preferred-install": {
+            "yoast/wordpress-seo": "source"
         }
     },
     "require": {
@@ -38,7 +41,15 @@
         "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "php-parallel-lint/php-console-highlighter": "^0.5",
-        "yoast/wp-test-utils": "^0.2.1"
+        "yoast/wp-test-utils": "^0.2.1",
+        "yoast/wordpress-seo": "dev-trunk@dev"
+    },
+    "extra": {
+        "installer-paths": {
+            "vendor/{$vendor}/{$name}": [
+                "type:wordpress-plugin"
+            ]
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -50,7 +61,7 @@
             "Yoast\\WP\\Woocommerce\\Composer\\Actions::check_coding_standards"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/vendor/*"
         ],
         "check-staged-cs": [
             "@check-cs --filter=GitStaged"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,12 @@
             "yoast/wordpress-seo": "source"
         }
     },
+    "repositories": {
+        "wordpress-seo": {
+            "type": "vcs",
+            "url": "https://github.com/yoast/wordpress-seo"
+        }
+    },
     "require": {
         "php": ">=5.6",
         "yoast/i18n-module": "^3.1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c95973c520673e37a37f56aa2c61fc34",
+    "content-hash": "d1806eba1ae18c1fdcf124dd0ce33571",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -174,6 +174,156 @@
                 "source": "https://github.com/Brain-WP/BrainMonkey"
             },
             "time": "2020-10-13T17:56:14+00:00"
+        },
+        {
+            "name": "composer/installers",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "https://composer.github.io/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Eliasis",
+                "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
+                "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
+                "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
+                "SMF",
+                "Starbug",
+                "Thelia",
+                "Whmcs",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "attogram",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "cockpit",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "eZ Platform",
+                "elgg",
+                "expressionengine",
+                "fuelphp",
+                "grav",
+                "installer",
+                "itop",
+                "joomla",
+                "known",
+                "kohana",
+                "laravel",
+                "lavalite",
+                "lithium",
+                "magento",
+                "majima",
+                "mako",
+                "mediawiki",
+                "miaoxing",
+                "modulework",
+                "modx",
+                "moodle",
+                "osclass",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "processwire",
+                "puppet",
+                "pxcms",
+                "reindex",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "sydes",
+                "sylius",
+                "symfony",
+                "tastyigniter",
+                "typo3",
+                "wordpress",
+                "yawik",
+                "zend",
+                "zikula"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-28T06:42:17+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -2322,25 +2472,25 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "0.2.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
-                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5d257d5a6977137016f3df440ce640ce72ffd61a",
+                "reference": "5d257d5a6977137016f3df440ce640ce72ffd61a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": ">=5.4",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
                 "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
@@ -2381,30 +2531,98 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2020-11-25T02:59:57+00:00"
+            "time": "2021-06-21T03:13:22+00:00"
         },
         {
-            "name": "yoast/wp-test-utils",
-            "version": "0.2.1",
+            "name": "yoast/wordpress-seo",
+            "version": "dev-trunk",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101"
+                "url": "https://github.com/Yoast-dist/wordpress-seo.git",
+                "reference": "8ee029ed3c73cf622d98f0e73c734b7faf9b7990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/c5cdabd58f2aa6f2a93f734cf48125f880c90101",
-                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101",
+                "url": "https://api.github.com/repos/Yoast-dist/wordpress-seo/zipball/8ee029ed3c73cf622d98f0e73c734b7faf9b7990",
+                "reference": "8ee029ed3c73cf622d98f0e73c734b7faf9b7990",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "^1.9.0",
+                "php": "^5.6.20||^7.0",
+                "yoast/i18n-module": "^3.1.1"
+            },
+            "require-dev": {
+                "humbug/php-scoper": "^0.13.4",
+                "league/oauth2-client": "2.4.1",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "phpunit/phpunit": "^5.7",
+                "psr/container": "1.0.0",
+                "psr/log": "^1.0",
+                "symfony/config": "^3.4",
+                "symfony/dependency-injection": "^3.4",
+                "yoast/php-development-environment": "^1.0",
+                "yoast/wp-test-utils": "^0.2.1",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "classmap": [
+                    "admin/",
+                    "inc/",
+                    "vendor_prefixed/",
+                    "src/",
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoa.st/1--"
+                }
+            ],
+            "description": "Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.",
+            "homepage": "https://yoa.st/1ui",
+            "keywords": [
+                "seo",
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://wordpress.org/support/plugin/wordpress-seo",
+                "issues": "https://github.com/Yoast/wordpress-seo/issues",
+                "source": "https://github.com/Yoast/wordpress-seo",
+                "wiki": "https://github.com/Yoast/wordpress-seo/wiki"
+            },
+            "time": "2021-07-02T10:12:11+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "0.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/896f7640d86162ff7a0dc6ce59f8837f284521c5",
+                "reference": "896f7640d86162ff7a0dc6ce59f8837f284521c5",
                 "shasum": ""
             },
             "require": {
                 "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
-                "yoast/phpunit-polyfills": "^0.2.0"
+                "yoast/phpunit-polyfills": "^1.0.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
                 "yoast/yoastcs": "^2.1.0"
             },
             "type": "library",
@@ -2447,7 +2665,7 @@
                 "issues": "https://github.com/Yoast/wp-test-utils/issues",
                 "source": "https://github.com/Yoast/wp-test-utils"
             },
-            "time": "2020-12-09T15:26:02+00:00"
+            "time": "2021-06-21T03:45:02+00:00"
         },
         {
             "name": "yoast/yoastcs",
@@ -2507,7 +2725,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "yoast/wordpress-seo": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -2517,5 +2737,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1806eba1ae18c1fdcf124dd0ce33571",
+    "content-hash": "edcf6f6e01e7664d0ca272333f11ec8a",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -2538,13 +2538,13 @@
             "version": "dev-trunk",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Yoast-dist/wordpress-seo.git",
-                "reference": "8ee029ed3c73cf622d98f0e73c734b7faf9b7990"
+                "url": "https://github.com/Yoast/wordpress-seo.git",
+                "reference": "1d8a15c778d50d9efeb1c9f403244be76ed98aed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast-dist/wordpress-seo/zipball/8ee029ed3c73cf622d98f0e73c734b7faf9b7990",
-                "reference": "8ee029ed3c73cf622d98f0e73c734b7faf9b7990",
+                "url": "https://api.github.com/repos/Yoast/wordpress-seo/zipball/1d8a15c778d50d9efeb1c9f403244be76ed98aed",
+                "reference": "1d8a15c778d50d9efeb1c9f403244be76ed98aed",
                 "shasum": ""
             },
             "require": {
@@ -2566,6 +2566,7 @@
                 "yoast/wp-test-utils": "^0.2.1",
                 "yoast/yoastcs": "^2.1.0"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "classmap": [
@@ -2576,7 +2577,90 @@
                     "lib/"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "classmap": [
+                    "tests/",
+                    "config/"
+                ]
+            },
+            "scripts": {
+                "test": [
+                    "@php ./vendor/phpunit/phpunit/phpunit"
+                ],
+                "integration-test": [
+                    "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
+                ],
+                "lint": [
+                    "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude vendor_prefixed --exclude node_modules --exclude .git"
+                ],
+                "lint-files": [
+                    "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint"
+                ],
+                "lint-branch": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::lint_branch"
+                ],
+                "lint-staged": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::lint_staged"
+                ],
+                "cs": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
+                ],
+                "check-cs-thresholds": [
+                    "@putenv YOASTCS_THRESHOLD_ERRORS=276",
+                    "@putenv YOASTCS_THRESHOLD_WARNINGS=223",
+                    "Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
+                ],
+                "check-cs-summary": [
+                    "@check-cs-warnings --report=summary"
+                ],
+                "check-cs": [
+                    "@check-cs-warnings -n"
+                ],
+                "check-cs-errors": [
+                    "echo You can now just use check-cs, running that command now.",
+                    "composer check-cs"
+                ],
+                "check-cs-warnings": [
+                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+                ],
+                "check-staged-cs": [
+                    "@check-cs-warnings --filter=GitStaged"
+                ],
+                "check-branch-cs": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::check_branch_cs"
+                ],
+                "fix-cs": [
+                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+                ],
+                "prefix-dependencies": [
+                    "composer prefix-oauth2-client",
+                    "composer prefix-symfony"
+                ],
+                "prefix-oauth2-client": [
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/league/oauth2-client --config=config/php-scoper/oauth2-client.inc.php --force --quiet",
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/guzzlehttp --config=config/php-scoper/guzzlehttp.inc.php --force --quiet",
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/psr --config=config/php-scoper/psr.inc.php --force --quiet"
+                ],
+                "prefix-symfony": [
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/symfony/dependency-injection --config=config/php-scoper/dependency-injection.inc.php --force --quiet"
+                ],
+                "compile-di": [
+                    "rm -f ./src/generated/container.php",
+                    "rm -f ./src/generated/container.php.meta",
+                    "composer du --no-scripts",
+                    "Yoast\\WP\\SEO\\Composer\\Actions::compile_dependency_injection_container"
+                ],
+                "post-autoload-dump": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::prefix_dependencies",
+                    "composer compile-di"
+                ],
+                "generate-migration": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::generate_migration"
+                ],
+                "generate-unit-test": [
+                    "Yoast\\WP\\SEO\\Composer\\Actions::generate_unit_test"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -2594,12 +2678,12 @@
                 "wordpress"
             ],
             "support": {
-                "forum": "https://wordpress.org/support/plugin/wordpress-seo",
                 "issues": "https://github.com/Yoast/wordpress-seo/issues",
-                "source": "https://github.com/Yoast/wordpress-seo",
-                "wiki": "https://github.com/Yoast/wordpress-seo/wiki"
+                "forum": "https://wordpress.org/support/plugin/wordpress-seo",
+                "wiki": "https://github.com/Yoast/wordpress-seo/wiki",
+                "source": "https://github.com/Yoast/wordpress-seo"
             },
-            "time": "2021-07-02T10:12:11+00:00"
+            "time": "2021-07-02T12:48:24+00:00"
         },
         {
             "name": "yoast/wp-test-utils",

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -29,7 +29,6 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
 		$this->product = Mockery::mock( 'WC_Product' );
 	}
 

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Mockery;
 use WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
@@ -29,8 +30,6 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 		parent::set_up();
 
 		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 	}
 
@@ -58,7 +57,7 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 		$instance = new WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter( $this->product, false );
 
 		$this->assertSame(
-			'<meta property="og:availability" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Mockery;
 use WPSEO_WooCommerce_Product_Availability_Presenter;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
@@ -27,9 +28,6 @@ class Product_Availability_Presenter_Test extends TestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
 
 		$this->product = Mockery::mock( 'WC_Product' );
 	}
@@ -58,7 +56,7 @@ class Product_Availability_Presenter_Test extends TestCase {
 		$instance = new WPSEO_WooCommerce_Product_Availability_Presenter( $this->product, false );
 
 		$this->assertSame(
-			'<meta property="product:availability" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_WooCommerce_Product_Brand_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Class Product_Brand_Presenter_Test.
@@ -67,7 +68,7 @@ class Product_Brand_Presenter_Test extends TestCase {
 	 */
 	public function test_tag_format() {
 		$this->assertSame(
-			'<meta property="product:brand" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $this->instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -43,9 +43,6 @@ class Product_Brand_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Product_Brand_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 
 		$this->instance          = new WPSEO_WooCommerce_Product_Brand_Presenter( $this->product );

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -36,9 +36,6 @@ class Product_Condition_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 
 		$this->instance = new WPSEO_WooCommerce_Product_Condition_Presenter( $this->product );

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey\Filters;
 use Mockery;
 use WPSEO_WooCommerce_Product_Condition_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Class Product_Condition_Presenter_Test.
@@ -58,7 +59,7 @@ class Product_Condition_Presenter_Test extends TestCase {
 	 */
 	public function test_tag_format() {
 		$this->assertSame(
-			'<meta property="product:condition" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $this->instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -36,9 +36,6 @@ class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 
 		$this->instance = new WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter( $this->product );

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -36,9 +36,6 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 
 		$this->instance = new WPSEO_WooCommerce_Product_Price_Amount_Presenter( $this->product );

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_WooCommerce_Product_Price_Amount_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Class Product_Price_Amount_Presenter_Test.
@@ -57,7 +58,7 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	 */
 	public function test_tag_format() {
 		$this->assertSame(
-			'<meta property="product:price:amount" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $this->instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey\Functions;
 use Mockery;
 use WPSEO_WooCommerce_Product_Price_Currency_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Class Product_Price_Currency_Presenter_Test.
@@ -57,7 +58,7 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	 */
 	public function test_tag_format() {
 		$this->assertSame(
-			'<meta property="product:price:currency" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $this->instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -36,9 +36,6 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 
 		$this->instance = new WPSEO_WooCommerce_Product_Price_Currency_Presenter( $this->product );

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 use Mockery;
 use WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
  * Class Product_Retailer_Item_ID_Presenter_Test.
@@ -56,7 +57,7 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	 */
 	public function test_tag_format() {
 		$this->assertSame(
-			'<meta property="product:retailer_item_id" content="%s" />',
+			Abstract_Indexable_Tag_Presenter::META_PROPERTY_CONTENT,
 			$this->getPropertyValue( $this->instance, 'tag_format' )
 		);
 	}

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -35,9 +35,6 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		// Needs to exist as WPSEO_WooCommerce_Abstract_Product_Presenter depends on it.
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter' );
-
 		$this->product = Mockery::mock( 'WC_Product' );
 
 		$this->instance = new WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter( $this->product );

--- a/tests/classes/presenters/schema-presenter-test.php
+++ b/tests/classes/presenters/schema-presenter-test.php
@@ -42,7 +42,6 @@ class Schema_Presenter_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->stubEscapeFunctions();
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
 
 		$this->graph = [
 			[

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -50,7 +50,6 @@ class Schema_Test extends TestCase {
 			->andReturn( [] );
 
 		Mockery::mock( 'overload:Yoast\WP\SEO\Config\Schema_IDs', new Schema_IDs() );
-		Mockery::mock( 'overload:Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter' );
 
 		$this->set_instance();
 	}

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -21,7 +21,7 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 */
 	public function test_check_dependencies() {
 		$valid_wp_version        = '5.6';
-		$valid_yoast_seo_version = '16.4';
+		$valid_yoast_seo_version = '16.7';
 
 		$class = Mockery::mock( Yoast_WooCommerce_Dependencies_Double::class )->makePartial();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Made WooCommerce SEO compatible with new Abstract Indexable Tag Presenter in free 16.7

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds support for the headless functionality introduced in Yoast SEO 16.7.
* Bumps the minimum required version for Yoast SEO to 16.7.
* If you delete your primary location without updating your primary location in the Local SEO settings, ánd you have only one location left, meta tags will fall back to use this location instead.

## Relevant technical choices:

* added key and tag format to make the presenter compatible with the Abstract_Indexable_Tag_Presenter that's new in free 16.7

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check out https://github.com/Yoast/wordpress-seo/tree/release/16.7
* Create a WooCommerce product
* Inspect the front end and make sure WooCommerce tags are present. Notably, check for `product:price:amount` (make sure you have an actual price that's not 0), `product:price:currency`, `og:availability`, `product:availability`, `product:condition`.
* note the post Id, you'll need that in the rest API call.
* Go to `basic.wordpress.test/wp-json/wp/v2/product/{your-post-id}`
* Make sure the above meta tags are available in yoast_head and yoast_head_json (in yoast_head_json, tags have their `:` replaced with `_` btw.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA have to also test the additional item below when testing the RC:

* Confirm that the Yoast Free plugin is NOT added in the  /vendor dir in the RC (much like it doesn't with already released versions.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Inspect the frontend and for the existence of the `<script type="application/ld+json" class="yoast-schema-graph yoast-schema-graph--woo yoast-schema-graph--footer">` item in the footer of the page. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
