### PR TITLE
Add fallback when context is null and also fallback when product is null (also fixes: P2-1149)

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -682,7 +682,10 @@ class Yoast_WooCommerce_SEO {
 		$request_helper = new Request_Helper();
 
 		if ( ! $request_helper->is_rest_request() ) {
-			// This is a frontend request.
+			if ( \is_null( $context ) ) {
+				$context = YoastSEO()->meta->for_current_page()->context;
+			}
+
 			if ( is_a( $context, Meta_Tags_Context::class ) ) {
 				if ( $context->indexable->object_sub_type === 'product' ) {
 					$the_post = \get_post( $context->indexable->object_id );
@@ -812,6 +815,11 @@ class Yoast_WooCommerce_SEO {
 	protected function get_product_short_description( $product = null ) {
 		if ( is_null( $product ) ) {
 			$product = $this->get_product();
+		}
+
+		// Safety check for PHPv8.0. Issue: https://yoast.atlassian.net/browse/P2-1149.
+		if ( is_null( $product ) ) {
+			return '';
 		}
 
 		if ( method_exists( $product, 'get_short_description' ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes https://yoast.atlassian.net/browse/P2-1148
* Fixes https://yoast.atlassian.net/browse/P2-1149

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error was thrown on the frontend of product pages when using the `%%wc_shortdesc%%` snippet variable while running PHP 8.0.
* Fixes a bug where the `%%wc_price%%`, `%%wc_sku%%`, `%%wc_shortdesc%%` and `%%wc_brand%%` snippet variable values were not displayed on the frontend.

## Relevant technical choices:

* Added a fallback in the get_product() method for cases where $context is not used in the get_method() call
* Added a fallback for cases where get_product returns null in the get_product_short_description() method, to avoid potential Fatal Errors in PHPv8.0
* The `YoastSEO()` surface will always be available, because the minimum Yoast SEO version is set to 16.7 (and the surface was introduced 6 months before that release)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new product
* Either configure %%wc_price%% in the product Search Appearance Product default or manually on a product as meta title/description
* Check the frontend of that product. Confirm that the meta decription tag actually contains that dynamic value. With 14.2, it doesn't contain it.

Also, for the PHPv8.0 bug:
* Create a new product while on PHPv8.0
* Fill in a product short description
* Add the %%wc_shortdesc%% variable to the Meta Description field
* Publish the product and visit it in the frontend
* Check for no Fatal Errors


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
