### PR TITLE
Cache product identifiers, make sure that they are always available.

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1172,12 +1172,38 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
+	 * Retrieves a product identifier.
+	 *
+	 * @param string $type The type of identifier to retrieve. E.g. 'gtin8' or 'isbn'.
+	 *
+	 * @return string The product identifier.
+	 */
+	protected function get_product_identifier( $type ) {
+		$request_helper = new Request_Helper();
+
+		/*
+		 * On product overview pages in REST requests, do not cache the global identifiers.
+		 * Otherwise each product would get the same ids.
+		 */
+		if ( ! \is_singular() && $request_helper->is_rest_request() ) {
+			$this->get_product_global_identifiers();
+		}
+
+		// Cache the global identifiers.
+		if ( empty( $this->global_identifiers ) ) {
+			$this->get_product_global_identifiers();
+		}
+
+		return isset( $this->global_identifiers[ $type ] ) ? $this->global_identifiers[ $type ] : '';
+	}
+
+	/**
 	 * Retrieves the product GTIN8 identifier.
 	 *
 	 * @return string The product GTIN8 identifier.
 	 */
 	public function get_product_var_gtin8() {
-		return isset( $this->global_identifiers['gtin8'] ) ? $this->global_identifiers['gtin8'] : '';
+		return $this->get_product_identifier( 'gtin8' );
 	}
 
 	/**
@@ -1186,7 +1212,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN12 / UPC identifier.
 	 */
 	public function get_product_var_gtin12() {
-		return isset( $this->global_identifiers['gtin12'] ) ? $this->global_identifiers['gtin12'] : '';
+		return $this->get_product_identifier( 'gtin12' );
 	}
 
 	/**
@@ -1195,7 +1221,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN13 / EAN identifier.
 	 */
 	public function get_product_var_gtin13() {
-		return isset( $this->global_identifiers['gtin13'] ) ? $this->global_identifiers['gtin13'] : '';
+		return $this->get_product_identifier( 'gtin13' );
 	}
 
 	/**
@@ -1204,7 +1230,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product GTIN14 / ITF-14 identifier.
 	 */
 	public function get_product_var_gtin14() {
-		return isset( $this->global_identifiers['gtin14'] ) ? $this->global_identifiers['gtin14'] : '';
+		return $this->get_product_identifier( 'gtin14' );
 	}
 
 	/**
@@ -1213,7 +1239,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product ISBN identifier.
 	 */
 	public function get_product_var_isbn() {
-		return isset( $this->global_identifiers['isbn'] ) ? $this->global_identifiers['isbn'] : '';
+		return $this->get_product_identifier( 'isbn' );
 	}
 
 	/**
@@ -1222,7 +1248,7 @@ class Yoast_WooCommerce_SEO {
 	 * @return string The product MPN identifier.
 	 */
 	public function get_product_var_mpn() {
-		return isset( $this->global_identifiers['mpn'] ) ? $this->global_identifiers['mpn'] : '';
+		return $this->get_product_identifier( 'mpn' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the product identifier replacement variables `%%wc_gtin8%%`, `%%wc_gtin12%%`, `%%wc_gtin13%%`, `%%wc_gtin14%%`, `%%wc_isbn%%` and `%%wc_mpn%%` would not work in meta descriptions when retrieving posts using REST requests.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For acceptance testers:
* The WooCommerce SEO dev environment is currently broken. See [this issue](https://yoast.atlassian.net/browse/P2-1151) and [this PR](https://github.com/Yoast/wpseo-woocommerce/pull/704).
* A workaround is to remove `wordpress-seo` from the `composer.json` temporarily.
	* You can do this by executing this command: `composer remove --dev yoast/wordpress-seo`.
	* Do not commit these changes, but remove them again.   

#### REST response of a single product
* Create a WooCommerce product.
* Add a GTIN-8, GTIN-12, GTIN-13, GTIN-14, ISBN and MPN identifier in the WooCommerce metabox, in the SEO tab.
* Add the `%%wc_gtin8%%`, `%%wc_gtin12%%`, `%%wc_gtin13%%`, `%%wc_gtin14%%`, `%%wc_isbn%%` and `%%wc_mpn%%` replace variables to the metadescription in the Yoast SEO metabox.
* Save the product.
* Note the post ID of the product (can be found in the URL of the editor, e.g. `/wp-admin/post.php?post=12666&action=edit` for a post with ID 12666).
* Retrieve the product using the REST API by going to `<your-site-domain>/wp-json/wp/v2/product/<id>`.
* The meta description inside of the Yoast head of the response should include the identifiers you entered for the product.

#### REST response of a page of products
* Create another product, add the identifiers and edit de meta description as in the steps above.
* Retrieve a page of products using the REST API by going to `wp-json/wp/v2/product`.
* The meta descriptions inside of the Yoast head of the response should include the identifiers you entered for the products.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
