### PR TITLE
Exclude videos in Images assessment in Woo product pages

### DIFF
--- a/js/src/initializers/product-assessor.js
+++ b/js/src/initializers/product-assessor.js
@@ -16,6 +16,7 @@ export default function initialize() {
 	analysisWorker._configuration.customAnalysisType = "productPage";
 	// Store product pages.
 	analysisWorker.setCustomSEOAssessorClass( productSEOAssessor.default, "productPage", {
+		countVideos: false,
 		introductionKeyphraseUrlTitle: "https://yoa.st/33e",
 		introductionKeyphraseCTAUrl: "https://yoa.st/33f",
 		keyphraseLengthUrlTitle: "https://yoa.st/33i",
@@ -52,6 +53,7 @@ export default function initialize() {
 		keyphraseDistributionCTAUrl: "https://yoa.st/33u",
 	} );
 	analysisWorker.setCustomCornerstoneSEOAssessorClass( productCornerstoneSEOAssessor.default, "productPage", {
+		countVideos: false,
 		introductionKeyphraseUrlTitle: "https://yoa.st/33e",
 		introductionKeyphraseCTAUrl: "https://yoa.st/33f",
 		keyphraseLengthUrlTitle: "https://yoa.st/33i",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Our video count in the images assessment is based on `video` tags. However, these tags aren't added when we add a video from a URL (e.g., linking a Youtube video). So those videos aren't recognized in the assessment, which results in incorrect feedback. For this reason, we will exclude videos in Images assessment in WooCommerce.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Excludes videos in Images assessment in WooCommerce product pages analysis.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

This PR should be tested with [its accompanying PR](https://github.com/Yoast/wordpress-seo/pull/17381) in Free.
* Build the Free plugin 
* Run ` composer require yoast/wordpress-seo:dev-LINGO-1011-exclude-videos-from-images-assessment-in-woo@dev`
* Build WooCommerce SEO plugin
* Add a product without any images or videos
* Confirm that the Images assessment returns with red bullet and `Images: No images appear on this page. Add some!`
* Add an image to the text
* Confirm that the Images assessment returns with orange bullet and `Images: Only 1 image appears on this page. We recommend at least 4. Add more relevant images!`
* Upload a video and add it to the text
* Confirm that the Images assessment still returns with orange bullet and `Images: Only 1 image appears on this page. We recommend at least 4. Add more relevant images!`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-1011
