### PR TITLE
Composer: update to YoastCS 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,7 @@
         "yoast/i18n-module": "^3.1.1"
     },
     "require-dev": {
-        "yoast/yoastcs": "^2.1.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
-        "php-parallel-lint/php-console-highlighter": "^0.5",
+        "yoast/yoastcs": "^2.2.0",
         "yoast/wp-test-utils": "^0.2.1",
         "yoast/wordpress-seo": "dev-trunk@dev"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edcf6f6e01e7664d0ca272333f11ec8a",
+    "content-hash": "37e412c1a70b731cf0eb2dffd842c262",
     "packages": [
         {
             "name": "yoast/i18n-module",
@@ -726,16 +726,16 @@
         },
         {
             "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "772a954e5f119f6f5871d015b23eabed8cbdadfb"
+                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/772a954e5f119f6f5871d015b23eabed8cbdadfb",
-                "reference": "772a954e5f119f6f5871d015b23eabed8cbdadfb",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/761f3806e30239b5fcd90a0a45d41dc2138de192",
+                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192",
                 "shasum": ""
             },
             "require": {
@@ -749,7 +749,7 @@
             "require-dev": {
                 "nette/tester": "^1.3 || ^2.0",
                 "php-parallel-lint/php-console-highlighter": "~0.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "suggest": {
                 "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
@@ -777,9 +777,9 @@
             "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
             "support": {
                 "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.0"
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.1"
             },
-            "time": "2021-04-07T14:42:48+00:00"
+            "time": "2021-08-13T05:35:13+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -2753,29 +2753,29 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298"
+                "reference": "0b82e890bda80571fe054166ef2535cb9cb54a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8cc5cb79b950588f05a45d68c3849ccfcfef6298",
-                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/0b82e890bda80571fe054166ef2535cb9cb54a13",
+                "reference": "0b82e890bda80571fe054166ef2535cb9cb54a13",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
+                "php-parallel-lint/php-console-highlighter": "^0.5.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-                "squizlabs/php_codesniffer": "^3.5.0",
-                "wp-coding-standards/wpcs": "^2.2.0"
+                "squizlabs/php_codesniffer": "^3.6.0",
+                "wp-coding-standards/wpcs": "^2.3.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpcompatibility/php-compatibility": "^9.2.0",
+                "phpcompatibility/php-compatibility": "^9.3.5",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -2804,7 +2804,7 @@
                 "issues": "https://github.com/Yoast/yoastcs/issues",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2020-10-27T09:51:49+00:00"
+            "time": "2021-09-22T14:11:31+00:00"
         }
     ],
     "aliases": [],
@@ -2821,5 +2821,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
## Context

* Update dev tools

## Summary

This PR can be summarized in the following changelog entry:

* Updates dev tools

## Relevant technical choices:

Composer: update to YoastCS 2.2.0

... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

Refs:
* https://github.com/Yoast/yoastcs/releases
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ if the build passes we're good (and it won't, but that's not due to this change, the CS part passes)