### PR TITLE
CS: clean up after merges

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -161,7 +161,7 @@ class Yoast_WooCommerce_SEO {
 	 * Adds the WooCommerce OpenGraph presenter.
 	 *
 	 * @param \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter[] $presenters The presenter instances.
-	 * @param \Yoast\WP\SEO\Context\Meta_Tags_Context                 $context The meta tags context.
+	 * @param \Yoast\WP\SEO\Context\Meta_Tags_Context                 $context    The meta tags context.
 	 *
 	 * @return \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter[] The extended presenters.
 	 */
@@ -666,7 +666,7 @@ class Yoast_WooCommerce_SEO {
 	 *
 	 * @since 4.3
 	 *
-	 * @param \Yoast\WP\SEO\Context\Meta_Tags_Context $context The meta tags context.
+	 * @param \Yoast\WP\SEO\Context\Meta_Tags_Context|null $context The meta tags context.
 	 *
 	 * @return WC_Product|null
 	 */

--- a/tests/classes/opengraph-test.php
+++ b/tests/classes/opengraph-test.php
@@ -15,7 +15,7 @@ class OpenGraph_Test extends TestCase {
 	/**
 	 * Class instance to use for the test.
 	 *
-	 * @var \Mockery\MockInterface
+	 * @var Mockery\MockInterface
 	 */
 	protected $instance;
 

--- a/tests/classes/presenters/pinterest-product-availability-presenter-test.php
+++ b/tests/classes/presenters/pinterest-product-availability-presenter-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Pinterest_Product_Availability_Presenter;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
@@ -19,7 +20,7 @@ class Pinterest_Product_Availability_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/presenters/product-availability-presenter-test.php
+++ b/tests/classes/presenters/product-availability-presenter-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_Availability_Presenter;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
@@ -19,7 +20,7 @@ class Product_Availability_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/presenters/product-brand-presenter-test.php
+++ b/tests/classes/presenters/product-brand-presenter-test.php
@@ -4,9 +4,11 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_Brand_Presenter;
-use Yoast\WP\Woocommerce\Tests\TestCase;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class Product_Brand_Presenter_Test.
@@ -20,14 +22,14 @@ class Product_Brand_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 
 	/**
 	 * Holds the product.
 	 *
-	 * @var \Yoast\WP\SEO\Helpers\Options_Helper|\Mockery\MockInterface
+	 * @var Options_Helper|Mockery\MockInterface
 	 */
 	protected $options;
 

--- a/tests/classes/presenters/product-condition-presenter-test.php
+++ b/tests/classes/presenters/product-condition-presenter-test.php
@@ -4,9 +4,10 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Brain\Monkey\Filters;
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_Condition_Presenter;
-use Yoast\WP\Woocommerce\Tests\TestCase;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class Product_Condition_Presenter_Test.
@@ -20,7 +21,7 @@ class Product_Condition_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
+++ b/tests/classes/presenters/product-opengraph-deprecation-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Brain\Monkey\Actions;
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_OpenGraph_Deprecation_Presenter;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 
@@ -19,7 +20,7 @@ class Product_OpenGraph_Deprecation_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/presenters/product-price-amount-presenter-test.php
+++ b/tests/classes/presenters/product-price-amount-presenter-test.php
@@ -4,9 +4,10 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_Price_Amount_Presenter;
-use Yoast\WP\Woocommerce\Tests\TestCase;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class Product_Price_Amount_Presenter_Test.
@@ -20,7 +21,7 @@ class Product_Price_Amount_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/presenters/product-price-currency-presenter-test.php
+++ b/tests/classes/presenters/product-price-currency-presenter-test.php
@@ -4,9 +4,10 @@ namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_Price_Currency_Presenter;
-use Yoast\WP\Woocommerce\Tests\TestCase;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class Product_Price_Currency_Presenter_Test.
@@ -20,7 +21,7 @@ class Product_Price_Currency_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/presenters/product-retailer-item-id-presenter-test.php
+++ b/tests/classes/presenters/product-retailer-item-id-presenter-test.php
@@ -3,9 +3,10 @@
 namespace Yoast\WP\Woocommerce\Tests\Classes\Presenters;
 
 use Mockery;
+use WC_Product;
 use WPSEO_WooCommerce_Product_Retailer_Item_ID_Presenter;
-use Yoast\WP\Woocommerce\Tests\TestCase;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
+use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
  * Class Product_Retailer_Item_ID_Presenter_Test.
@@ -19,7 +20,7 @@ class Product_Retailer_Item_ID_Presenter_Test extends TestCase {
 	/**
 	 * Holds the product.
 	 *
-	 * @var \WC_Product|\Mockery\MockInterface
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 

--- a/tests/classes/seo-trait.php
+++ b/tests/classes/seo-trait.php
@@ -5,30 +5,35 @@ namespace Yoast\WP\Woocommerce\Tests\Classes;
 use Brain\Monkey\Functions;
 use Mockery;
 use stdClass;
+use Yoast\WP\SEO\Surfaces\Classes_Surface;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
 
 /**
  * Trait YoastSEO.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- False positive due to acronym.
  */
 trait YoastSEO {
 
 	/**
 	 * Holds the classes surface.
 	 *
-	 * @var \Yoast\WP\SEO\Surfaces\Classes_Surface|Mockery\MockInterface
+	 * @var Classes_Surface|Mockery\MockInterface
 	 */
 	public $classes;
 
 	/**
 	 * Holds the meta surface.
 	 *
-	 * @var \Yoast\WP\SEO\Surfaces\Meta_Surface|Mockery\MockInterface
+	 * @var Meta_Surface|Mockery\MockInterface
 	 */
 	public $meta;
 
 	/**
 	 * Holds the helpers surface.
 	 *
-	 * @var \Yoast\WP\SEO\Surfaces\Helpers_Surface|stdClass
+	 * @var Helpers_Surface|stdClass
 	 */
 	public $helpers;
 

--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -17,7 +17,7 @@ class Slack_Test extends TestCase {
 	/**
 	 * The Slack class under test.
 	 *
-	 * @var \WPSEO_WooCommerce_Slack
+	 * @var WPSEO_WooCommerce_Slack
 	 */
 	private $instance;
 

--- a/tests/classes/twitter-test.php
+++ b/tests/classes/twitter-test.php
@@ -17,7 +17,7 @@ class Twitter_Test extends TestCase {
 	/**
 	 * The Twitter class under test.
 	 *
-	 * @var \WPSEO_WooCommerce_Twitter
+	 * @var WPSEO_WooCommerce_Twitter
 	 */
 	private $instance;
 

--- a/tests/doubles/schema-double.php
+++ b/tests/doubles/schema-double.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\Woocommerce\Tests\Doubles;
 
+use WC_Product;
+use WP_Term;
 use WPSEO_WooCommerce_Schema;
 
 /**
@@ -29,7 +31,7 @@ class Schema_Double extends WPSEO_WooCommerce_Schema {
 	 * @param string $taxonomy_name Taxonomy name for the term.
 	 * @param int    $post_id       Post ID for the term.
 	 *
-	 * @return \WP_Term|null The primary term, the first term or null.
+	 * @return WP_Term|null The primary term, the first term or null.
 	 */
 	public function get_primary_term_or_first_term( $taxonomy_name, $post_id ) {
 		return parent::get_primary_term_or_first_term( $taxonomy_name, $post_id );
@@ -38,8 +40,8 @@ class Schema_Double extends WPSEO_WooCommerce_Schema {
 	/**
 	 * Filters the offers array to enrich it.
 	 *
-	 * @param array       $data    Schema Product data.
-	 * @param \WC_Product $product The product.
+	 * @param array      $data    Schema Product data.
+	 * @param WC_Product $product The product.
 	 *
 	 * @return array Schema Product data.
 	 */
@@ -61,8 +63,8 @@ class Schema_Double extends WPSEO_WooCommerce_Schema {
 	/**
 	 * Enhances the review data output by WooCommerce.
 	 *
-	 * @param array       $data    Review Schema data.
-	 * @param \WC_Product $product The WooCommerce product we're working with.
+	 * @param array      $data    Review Schema data.
+	 * @param WC_Product $product The WooCommerce product we're working with.
 	 *
 	 * @return array Review Schema data.
 	 */
@@ -73,7 +75,7 @@ class Schema_Double extends WPSEO_WooCommerce_Schema {
 	/**
 	 * Add a global identifier to our output if we have one.
 	 *
-	 * @param \WC_Product $product Product object.
+	 * @param WC_Product $product Product object.
 	 *
 	 * @return bool
 	 */
@@ -84,8 +86,8 @@ class Schema_Double extends WPSEO_WooCommerce_Schema {
 	/**
 	 * Enhances the SKU data output by WooCommerce.
 	 *
-	 * @param array       $data    SKU Schema data.
-	 * @param \WC_Product $product The WooCommerce product we're working with.
+	 * @param array      $data    SKU Schema data.
+	 * @param WC_Product $product The WooCommerce product we're working with.
 	 *
 	 * @return array SKU Schema data.
 	 */


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

Various minor tweaks:
* Alignment of `@param` tags.
* Add missing (default) type to `@param` tag.
* Import all `use`d classes/interfaces, including when only used in docblocks.
* Order `use` statements alphabetically.
* Ignore a (known) false positive from YoastCS.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ if the build passes we're good (and it won't, but that's not due to this change, the CS part passes)