### PR TITLE
Composer: clean up CS command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
             "Yoast\\WP\\Woocommerce\\Composer\\Actions::check_coding_standards"
         ],
         "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=*/vendor/*"
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
         ],
         "check-staged-cs": [
             "@check-cs --filter=GitStaged"


### PR DESCRIPTION
## Context

*

## Summary
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

The `vendor` directory is already ignored via the YoastCS ruleset, so no need to explicitly ignore it.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the (CS part of the) build passes, we're good.