### PR TITLE
Update woocommerce-schema.php

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -503,7 +503,7 @@ class WPSEO_WooCommerce_Schema {
 				],
 			];
 
-			$data[] = $offer;
+            		$data[] = apply_filters('wpseo_schema_offers', $offer, $variation);
 		}
 
 		return $data;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -503,7 +503,7 @@ class WPSEO_WooCommerce_Schema {
 				],
 			];
 
-            		$data[] = apply_filters('wpseo_schema_offers', $offer, $variation);
+            		$data[] = apply_filters( 'wpseo_schema_offer', $offer, $variation, $product );
 		}
 
 		return $data;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -502,6 +502,19 @@ class WPSEO_WooCommerce_Schema {
 					'valueAddedTaxIncluded' => $prices_include_tax,
 				],
 			];
+			
+			/**
+			 * Allow extending schema for each offer.
+			 *
+			 *
+			 * @param type  $var Description.
+			 * @param array $offer {
+			 *     The offer array.
+			 *
+			 * }
+			 * @param WC_Product_Variation  $variation The WooCommerce product variation we're working with.
+			 * @param WC_Product  		$product The WooCommerce product we're working with.
+			 */
 
             		$data[] = apply_filters( 'wpseo_schema_offer', $offer, $variation, $product );
 		}


### PR DESCRIPTION
Add a filter hook to allow for extending the offer schema in a simple way. I need to add SKU, GTIN13 and probably a lot of other stuff that are useful and can be found in the database by using the variation_id in the $variation array.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a new filter `wpseo_schema_offer` filter that can be used to change the output of the offers attribute of the product schema. Props to [Dekadinious](https://github.com/Dekadinious).

## Test instructions
* Have a product that has product variations.
* The schema output of that product should remain unchanged.
* Add the following to your `functions.php` in your theme:
```
add_filter( 'wpseo_schema_offer', function ( $schema ) {
  $schema['name'] = $schema['name'] . ' FILTERED';
  return $schema;
} );
```
* The schema output of that product should have `FILTERED` appended to the names of all offers.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
