### PR TITLE
Load Yoast SEO Free product translations

### DIFF
--- a/config/webpack/webpack.config.default.js
+++ b/config/webpack/webpack.config.default.js
@@ -17,6 +17,7 @@ const externals = {
 const wordpressPackages = [
 	"@wordpress/hooks",
 	"@wordpress/data",
+	"@wordpress/i18n",
 ];
 
 // WordPress packages.

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -3,6 +3,7 @@
 import { getExcerpt, addExcerptEventHandlers, isTinyMCEAvailable } from "./yoastseo-woo-handle-excerpt-editors";
 import { addFilter } from "@wordpress/hooks";
 import { dispatch } from "@wordpress/data";
+import { setLocaleData } from "@wordpress/i18n";
 
 const PLUGIN_NAME = "YoastWooCommerce";
 
@@ -25,6 +26,8 @@ class YoastWooCommercePlugin {
 	 * @returns {void}
 	 */
 	constructor() {
+		setLocaleData( window.yoastseo.app.config.translations.locale_data[ "wordpress-seo" ], "wordpress-seo" );
+
 		this.loadWorkerScript();
 
 		YoastSEO.app.registerPlugin( "YoastWooCommercePlugin", { status: "ready" } );

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -26,8 +26,6 @@ class YoastWooCommercePlugin {
 	 * @returns {void}
 	 */
 	constructor() {
-		setLocaleData( window.yoastseo.app.config.translations.locale_data[ "wordpress-seo" ], "wordpress-seo" );
-
 		this.loadWorkerScript();
 
 		YoastSEO.app.registerPlugin( "YoastWooCommercePlugin", { status: "ready" } );

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@wordpress/dependency-extraction-webpack-plugin": "^3.1.0",
+    "@wordpress/i18n": "^4.2.4",
     "@yoast/feature-flag": "^0.5.2",
     "error-polyfill": "^0.1.2",
     "lodash-es": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,7 +64,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.13.10":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.16.0":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -327,6 +327,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/hooks@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.2.2.tgz#15062a10ca729569d02db8d45fc349b85ad1757e"
+  integrity sha512-MlFWyu2ttJhmzDFBVWPRwZwIMqQdHFZTjFWFWm50NlzUzIJ3gEtNA95mHNtav1Fone24N+I2YkaYMNb6PEPTyA==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+
 "@wordpress/i18n@^3.19.1":
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.20.0.tgz#dc9b04b9e8c359c1b0dbae78b99b32ef2c0b4729"
@@ -336,6 +343,19 @@
     "@wordpress/hooks" "^2.12.3"
     gettext-parser "^1.3.1"
     lodash "^4.17.19"
+    memize "^1.1.0"
+    sprintf-js "^1.1.1"
+    tannin "^1.2.0"
+
+"@wordpress/i18n@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.2.4.tgz#6dd8667551d0c0e43483fd187460c5e39e6cc218"
+  integrity sha512-36PnV7wTaLKCb+JZoapR3AtfrLTluhO5bIR6cUTG+QBBJ+g3gjRAdNFihnV8kz66FANu8PqDMI0T1jow/mrbYw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@wordpress/hooks" "^3.2.2"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.21"
     memize "^1.1.0"
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
@@ -4720,7 +4740,7 @@ lodash@^4.11.0, lodash@^4.14.2, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.19:
+lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WooCommerce SEO constructs its own list of assessments from the yoastseo package. When it does so, it doesn't use the correct translations anymore.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the content analysis was partially not translated for products.

## Relevant technical choices:

* I grab the translations from the window directly. Any functions that should help with that are in wordpress-seo/packages/js which we don't have access to from within the wpseo-woocommerce js.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Change the site language to something other than English.
* Edit or create a WooCommerce Product, add 400 words, check analysis - check that all elements in the content analysis are translated.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* (Javascript) translations in the product edit page.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes QA-2665
