### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,8 @@ script:
       travis_time_finish && travis_fold end "PHP.tests"
     elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer remove --dev yoast/wp-test-utils phpunit/phpunit --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev yoast/wp-test-utils phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       composer integration-test
       travis_time_finish && travis_fold end "PHP.tests"
     fi
@@ -179,8 +180,8 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      travis_retry composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction
-      travis_retry composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer remove --dev yoast/wp-test-utils phpunit/phpunit --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev yoast/wp-test-utils phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       composer test
       travis_time_finish && travis_fold end "PHP.tests"
     fi

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,10 @@
         },
         "preferred-install": {
             "yoast/wordpress-seo": "source"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true
         }
     },
     "repositories": {

--- a/composer.lock
+++ b/composer.lock
@@ -2603,7 +2603,7 @@
                     "Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
                 ],
                 "check-cs-thresholds": [
-                    "@putenv YOASTCS_THRESHOLD_ERRORS=251",
+                    "@putenv YOASTCS_THRESHOLD_ERRORS=252",
                     "@putenv YOASTCS_THRESHOLD_WARNINGS=220",
                     "Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
                 ],
@@ -2817,5 +2817,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION

## Context

* Composer 2.2 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Composer 2.2 compatibility

## Relevant technical choices:

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.
The `composer/installers` Composer plugin is used to install the plugin in the correct directory in a WordPress context.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution