### PR TITLE
Made configuration for product description length adaptable

### DIFF
--- a/js/src/assessments/ProductDescriptionAssessment.js
+++ b/js/src/assessments/ProductDescriptionAssessment.js
@@ -50,7 +50,7 @@ export default class ProductDescriptionAssessment extends Assessment {
 	 *
 	 * @param {Researcher}  researcher  The researcher used for calling research.
 	 *
-	 * @returns {object} The config to use.
+	 * @returns {Object} The config to use.
 	 */
 	getConfig( researcher ) {
 		let config = this._config;
@@ -96,7 +96,7 @@ export default class ProductDescriptionAssessment extends Assessment {
 	 * Returns the score based on the length of the product description.
 	 *
 	 * @param {number} length   The length of the product description.
-	 * @param {object} config   The configuration to use.
+	 * @param {Object} config   The configuration to use.
 	 *
 	 * @returns {{score: number, text: *}} The result object with score and text.
 	 */

--- a/js/tests/assessments/ProductDescriptionAssessment.test.js
+++ b/js/tests/assessments/ProductDescriptionAssessment.test.js
@@ -1,18 +1,25 @@
+import { Paper } from "yoastseo";
+import EnglishResearcher from "yoastseo/src/languageProcessing/languages/en/Researcher.js";
+import JapaneseResearcher from "yoastseo/src/languageProcessing/languages/ja/Researcher.js";
 import ProductDescriptionAssessment from "../../src/assessments/ProductDescriptionAssessment";
+
 const mockL10n = {};
+const mockPaper = new Paper( "" );
+const englishResearcher = new EnglishResearcher( mockPaper );
+const japaneseResearcher = new JapaneseResearcher( mockPaper );
 
 describe( "a test for product description length.", function() {
-	it( "returns score 1 when the product description is empty", function() {
+	it( "should return score 1 when the product description is empty", function() {
 		const productDescription = "";
-		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult();
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, englishResearcher );
 		expect( result.getScore() ).toBe( 1 );
 	} );
-	it( "returns score 5 when the product description contains less than 20 words", function() {
+	it( "should return score 5 when the product description contains less than 20 words", function() {
 		const productDescription = "The cat (Felis catus) is a domestic species of small carnivorous mammal.";
-		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult();
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, englishResearcher );
 		expect( result.getScore() ).toBe( 5 );
 	} );
-	it( "returns score 5 when the product description contains more than 50 words", function() {
+	it( "should return score 5 when the product description contains more than 50 words", function() {
 		const productDescription = "The cat (Felis catus) is a domestic species of small carnivorous mammal." +
 			"It is the only domesticated species in the family Felidae and is often referred to as the domestic cat to distinguish it " +
 			"from the wild members of the family. A cat can either be a house cat, a farm cat or a feral cat; the latter ranges freely " +
@@ -21,14 +28,37 @@ describe( "a test for product description length.", function() {
 			"it has a strong flexible body, quick reflexes, sharp teeth and retractable claws adapted to killing small prey. Its night vision " +
 			"and sense of smell are well developed. Cat communication includes vocalizations like meowing, " +
 			"purring, trilling, hissing, growling and grunting as well as cat-specific body language.";
-		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult();
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, englishResearcher );
 		expect( result.getScore() ).toBe( 5 );
 	} );
-	it( "returns score 9 when the product description contains between 20 to 50 words", function() {
+	it( "should return score 9 when the product description contains between 20 to 50 words", function() {
 		const productDescription = "The cat (Felis catus) is a domestic species of small carnivorous mammal." +
 			"It is the only domesticated species in the family Felidae and is often referred to as the domestic cat to distinguish it " +
 			"from the wild members of the family.";
-		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult();
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, englishResearcher );
+		expect( result.getScore() ).toBe( 9 );
+	} );
+} );
+
+describe( "a test for product description length for Japanese.", function() {
+	it( "should return score 1 when the product description is empty", function() {
+		const productDescription = "";
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
+		expect( result.getScore() ).toBe( 1 );
+	} );
+	it( "should return score 5 when the product description contains less than 10 characters", function() {
+		const productDescription = "猫".repeat( 9 );
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
+		expect( result.getScore() ).toBe( 5 );
+	} );
+	it( "should return score 5 when the product description contains more than 25 characters", function() {
+		const productDescription = "猫".repeat( 26 );
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
+		expect( result.getScore() ).toBe( 5 );
+	} );
+	it( "should return score 9 when the product description contains between 10 to 25 characters", function() {
+		const productDescription = "猫".repeat( 17 );
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
 		expect( result.getScore() ).toBe( 9 );
 	} );
 } );

--- a/js/tests/assessments/ProductDescriptionAssessment.test.js
+++ b/js/tests/assessments/ProductDescriptionAssessment.test.js
@@ -1,17 +1,24 @@
 import { Paper } from "yoastseo";
 import EnglishResearcher from "yoastseo/src/languageProcessing/languages/en/Researcher.js";
 import JapaneseResearcher from "yoastseo/src/languageProcessing/languages/ja/Researcher.js";
+import DefaultResearcher from "yoastseo/src/languageProcessing/languages/_default/Researcher";
 import ProductDescriptionAssessment from "../../src/assessments/ProductDescriptionAssessment";
 
 const mockL10n = {};
 const mockPaper = new Paper( "" );
 const englishResearcher = new EnglishResearcher( mockPaper );
 const japaneseResearcher = new JapaneseResearcher( mockPaper );
+const defaultResearcher = new DefaultResearcher( mockPaper );
 
 describe( "a test for product description length.", function() {
 	it( "should return score 1 when the product description is empty", function() {
 		const productDescription = "";
 		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, englishResearcher );
+		expect( result.getScore() ).toBe( 1 );
+	} );
+	it( "should still return score 1 when the product description is empty and the default Researcher is used", function() {
+		const productDescription = "";
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, defaultResearcher );
 		expect( result.getScore() ).toBe( 1 );
 	} );
 	it( "should return score 5 when the product description contains less than 20 words", function() {
@@ -36,6 +43,13 @@ describe( "a test for product description length.", function() {
 			"It is the only domesticated species in the family Felidae and is often referred to as the domestic cat to distinguish it " +
 			"from the wild members of the family.";
 		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, englishResearcher );
+		expect( result.getScore() ).toBe( 9 );
+	} );
+	it( "should still return score 9 when the product description contains between 20 to 50 words and the default Researcher is used", function() {
+		const productDescription = "The cat (Felis catus) is a domestic species of small carnivorous mammal." +
+			"It is the only domesticated species in the family Felidae and is often referred to as the domestic cat to distinguish it " +
+			"from the wild members of the family.";
+		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, defaultResearcher );
 		expect( result.getScore() ).toBe( 9 );
 	} );
 } );

--- a/js/tests/assessments/ProductDescriptionAssessment.test.js
+++ b/js/tests/assessments/ProductDescriptionAssessment.test.js
@@ -46,18 +46,18 @@ describe( "a test for product description length for Japanese.", function() {
 		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
 		expect( result.getScore() ).toBe( 1 );
 	} );
-	it( "should return score 5 when the product description contains less than 10 characters", function() {
-		const productDescription = "猫".repeat( 9 );
+	it( "should return score 5 when the product description contains less than 40 characters", function() {
+		const productDescription = "猫".repeat( 39 );
 		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
 		expect( result.getScore() ).toBe( 5 );
 	} );
-	it( "should return score 5 when the product description contains more than 25 characters", function() {
-		const productDescription = "猫".repeat( 26 );
+	it( "should return score 5 when the product description contains more than 100 characters", function() {
+		const productDescription = "猫".repeat( 102 );
 		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
 		expect( result.getScore() ).toBe( 5 );
 	} );
-	it( "should return score 9 when the product description contains between 10 to 25 characters", function() {
-		const productDescription = "猫".repeat( 17 );
+	it( "should return score 9 when the product description contains between 40 to 100 characters", function() {
+		const productDescription = "猫".repeat( 50 );
 		const result = new ProductDescriptionAssessment( productDescription, mockL10n ).getResult( mockPaper, japaneseResearcher );
 		expect( result.getScore() ).toBe( 9 );
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We were unable to adapt the configuration for product description length. This PR allows to pass a custom configuration. 
* Also, the production description length is now counted in characters for languages that have a `customCountLength` helper defined. 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adapts Product description assessment for Japanese.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirements:
* Install and activate WooCommerce plugin
* Build the Yoast SEO WooCommerce plugin

**Test in English** (to make sure that the assessment is still working as expected after the changes are introduced)
* Set the site language to English
* Create a Product (don't add a short description yet)
* Confirm that the feedback below is shown under SEO analysis tab:
   * `You should write a short description for this product.`
* Add a short description with a text containing less than 20 words
* Confirm that the feedback below is shown under SEO analysis tab:
   * `The short description for this product is too short.`
* Add a short description with a text containing 20-50 words
* Confirm that the feedback below is shown under SEO analysis tab:
   * `Your short description has a good length.`
* Add a short description with a text containing more than 50 words
* Confirm that the feedback below is shown under SEO analysis tab:
   * `The short description for this product is too long.`
   
**Test in Japanese**
* Set the site language to Japanese
* Create a Product (don't add a short description yet)
* Confirm that the feedback below is shown under SEO analysis tab:
   * `この商品に関する短い説明文を記入するのをおすすめします。`
* Add a short description with a text containing less than 40 characters (you can use[ this generator](https://generator.lorem-ipsum.info/_japanese) in combination with [this character counter](https://wordcounter.net/character-count))
* Confirm that the feedback below is shown under SEO analysis tab:
   * `商品の短い説明文が短すぎます。`
* Add a short description with a text containing 40-100 characters
* Confirm that the feedback below is shown under SEO analysis tab:
   * `短い説明文の長さはちょうどよいです。`
* Add a short description with a text containing more than 100 characters
* Confirm that the feedback below is shown under SEO analysis tab:
   * `商品の短い説明文が長すぎます。`
   
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-1196
