### PR TITLE
Run integration tests with WP 5.9

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -49,7 +49,7 @@ jobs:
 
           # WP 5.9 is the earliest version which (sort of) supports PHP 8.1.
           - php_version: '8.1'
-            wp_version: '5.9-RC3'
+            wp_version: 'latest'
             multisite: true
 
     name: "Integration Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }}${{ matrix.multisite == true && ' (+ ms)' || '' }}"

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Determine the type of Composer install to use
         id: composer_toggle
         run: |
-          if [[ "${{ matrix.wp_version }}" =~ ^trunk|5\.9|[6789]\.[0-9]$ ]]; then
+          if [[ "${{ matrix.wp_version }}" =~ ^(trunk|latest|5\.9|[6789]\.[0-9])$ ]]; then
             echo '::set-output name=TYPE::1'
           elif [[ "${{ matrix.php_version }}" > "7.4" ]]; then
             echo '::set-output name=TYPE::2'


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We used to test against 5.9 RC3, now 5.9 is released, we can use "latest" again with PHP 8.1 tests

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Run automated tests with WordPress 5.9

## Relevant technical choices:

* The WP5.9+PHP8.1 test case matches [the description of type 1](https://github.com/Yoast/wpseo-woocommerce/blob/79711b252d4224d3de16fbca1b6f345c2beeab2b/.github/workflows/integrationtest.yml#L92). I now consider the "latest" version to be type 1, as all future latest versions will of course be > 5.9.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See integration tests pass with WP 5.9 and PHP 8.1


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

