### PR TITLE
GH Actions: minor updates

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           php-version: 5.6
         env:
           # Token is needed for the YoastSEO install via VCS.
-          COMPOSER_TOKEN: ${{ secrets.YOASTBOT_CI_GH_ACTIONS_TOKEN }}
+          COMPOSER_TOKEN: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
 
       # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -124,7 +124,7 @@ jobs:
       # Retention is normally 90 days, but this artifact is only for review
       # and use in the next step, so no need to keep it for more than a day.
       - name: Upload the artifact folder
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ success() }}
         with:
           name: deploy-artifact
@@ -167,7 +167,7 @@ jobs:
           fi
 
       - name: Checkout Yoast Dist repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.DIST_ORG }}/${{ github.event.repository.name }}
           ref: ${{ env.DIST_DEFAULT_BRANCH }}
@@ -196,7 +196,7 @@ jobs:
 
       # The artifact will be unpacked into the root directory of the repository.
       - name: Download and unpack the prepared artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: deploy-artifact
 

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # The ubuntu images come with Node, npm and yarn pre-installed.
       # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # This action checks the `composer.lock` file against known security vulnerabilities in the dependencies.
       # https://github.com/marketplace/actions/the-php-security-checker

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Context

* Improve CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

### GH Actions: version update for various predefined actions

A number of predefined actions have had major release, which warrant an update the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/upload-artifact/releases

### GH Actions: consistently use same secret token

... across all workflows in all repos.

This token has access to both the Yoast organisation as well as the Yoast-dist organisation.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
