### PR TITLE
Schema output for Product is not correct and contains Unspecified Type

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -407,9 +407,13 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		if ( has_post_thumbnail() ) {
-			$thumbnail_id        = get_post_thumbnail_id();
-			$image_schema_id     = YoastSEO()->meta->for_current_page()->canonical . Schema_IDs::PRIMARY_IMAGE_HASH;
-			$this->data['image'] = YoastSEO()->helpers->schema->image->generate_from_attachment_id( $image_schema_id, $thumbnail_id );
+			$thumbnail_id    = get_post_thumbnail_id();
+			$image_schema_id = YoastSEO()->meta->for_current_page()->canonical . Schema_IDs::PRIMARY_IMAGE_HASH;
+			$image_schema    = YoastSEO()->helpers->schema->image->generate_from_attachment_id( $image_schema_id, $thumbnail_id );
+
+			$this->data['image'] = [
+				'@id' => $image_schema['@id'],
+			];
 
 			return;
 		}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -407,9 +407,9 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		if ( has_post_thumbnail() ) {
-			$this->data['image'] = [
-				'@id' => YoastSEO()->meta->for_current_page()->canonical . Schema_IDs::PRIMARY_IMAGE_HASH,
-			];
+			$thumbnail_id        = get_post_thumbnail_id();
+			$image_schema_id     = YoastSEO()->meta->for_current_page()->canonical . Schema_IDs::PRIMARY_IMAGE_HASH;
+			$this->data['image'] = YoastSEO()->helpers->schema->image->generate_from_attachment_id( $image_schema_id, $thumbnail_id );
 
 			return;
 		}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -993,6 +993,7 @@ class Schema_Test extends TestCase {
 		Functions\stubs(
 			[
 				'has_post_thumbnail'       => true,
+				'get_post_thumbnail_id'    => 123,
 				'home_url'                 => $base_url,
 				'get_site_url'             => $base_url,
 				'get_post_meta'            => false,
@@ -1014,19 +1015,13 @@ class Schema_Test extends TestCase {
 			->with( 'product_cat', 1 )
 			->andReturn( (object) [ 'name' => $product_name ] );
 
-		$image_data   = [
-			'url'    => $base_url . '/example_image.jpg',
-			'width'  => 50,
-			'height' => 50,
+		$image_data = [
+			'@id'    => $canonical . '#primaryimage',
 		];
-		$schema_image = Mockery::mock( 'overload:WPSEO_Schema_Image' );
-		$schema_image->expects( '__construct' )
-			->once()
-			->with( $canonical . '#woocommerceimageplaceholder' )
-			->andReturnSelf();
-		$schema_image->expects( 'generate_from_url' )
-			->once()
-			->with( $base_url . '/example_image.jpg' )
+
+		$this->helpers->schema->image
+			->expects( 'generate_from_attachment_id' )
+			->with( $canonical . '#primaryimage', 123 )
 			->andReturn( $image_data );
 
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
@@ -1361,6 +1356,7 @@ class Schema_Test extends TestCase {
 		Functions\stubs(
 			[
 				'has_post_thumbnail'       => true,
+				'get_post_thumbnail_id'    => 123,
 				'get_post_meta'            => false,
 				'get_the_terms'            => [
 					(object) [ 'name' => 'green' ],
@@ -1393,9 +1389,14 @@ class Schema_Test extends TestCase {
 				]
 			);
 
+		$image_data = [
+			'@id'    => $canonical . '#primaryimage',
+		];
+
 		$this->helpers->schema->image
-			->expects( 'generate_from_url' )
-			->never();
+			->expects( 'generate_from_attachment_id' )
+			->with( $canonical . '#primaryimage', 123 )
+			->andReturn( $image_data );
 
 		$data = [
 			'@type'       => 'Product',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes WooCommerce SEO compatible with the schema changes introduced in Yoast SEO 18.5.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Free 18.5
* Publish a product with a Product Image
* Visit the product's frontend and copy all of the source code and run it in the https://validator.schema.org/ validator
Without this PR:
* Visit the product's frontend and copy all of the source code and run it in the https://validator.schema.org/ validator
* You'll get an `Unspecified Type` as a result:
![image](https://user-images.githubusercontent.com/12400734/160844989-a20aab0a-c3f9-4395-b0e1-e721ef99d281.png)

With this PR:
* Visit the product's frontend and copy all of the source code and run it in the https://validator.schema.org/ validator
* You are NOT going to get an `Unspecified Type` as a result:
![image](https://user-images.githubusercontent.com/12400734/160847288-0194aeab-eb2b-4cc5-aca9-eace0219f0b6.png)



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Product schema

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
