### PR TITLE
Add global identifiers for product variations

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -75,6 +75,7 @@ class Yoast_WooCommerce_SEO {
 			add_action( 'admin_footer', [ $this, 'footer_js' ] );
 
 			new WPSEO_WooCommerce_Yoast_Tab();
+			new WPSEO_WooCommerce_Yoast_Ids();
 		}
 		else {
 			// Initialize schema & OpenGraph.

--- a/classes/woocommerce-yoast-ids.php
+++ b/classes/woocommerce-yoast-ids.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * WooCommerce Yoast SEO plugin file.
+ *
+ * @package WPSEO/WooCommerce
+ */
+
+/**
+ * Class WPSEO_WooCommerce_Yoast_Ids
+ */
+class WPSEO_WooCommerce_Yoast_Ids {
+
+	/**
+	 * The array of allowed identifier types.
+	 *
+	 * @var string[]
+	 */
+	protected $global_identifier_types = [
+		'gtin8'  => 'GTIN8',
+		'gtin12' => 'GTIN12 / UPC',
+		'gtin13' => 'GTIN13 / EAN',
+		'gtin14' => 'GTIN14 / ITF-14',
+		'isbn'   => 'ISBN',
+		'mpn'    => 'MPN',
+	];
+
+	/**
+	 * WPSEO_WooCommerce_Yoast_Ids constructor.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_product_after_variable_attributes', [ $this, 'add_variations_global_ids' ], 10, 3 );
+		add_action( 'woocommerce_save_product_variation', [ $this, 'save_data' ], 10, 1 );
+	}
+
+	/**
+	 * Add global identifiers text fields to a variation description.
+	 *
+	 * @param int     $loop The iteration number.
+	 * @param array   $variation_data Data related to the variation.
+	 * @param WP_Post $variation The variation object.
+	 *
+	 * @return void
+	 */
+	public function add_variations_global_ids( $loop, $variation_data, $variation ) {
+		echo '<div id="yoast_seo_variation" class="panel woocommerce_options_panel">';
+		echo '<div class="options_group">';
+		echo '<h1>' . esc_html__( 'Yoast SEO options', 'yoast-woo-seo' ) . '</h1>';
+		echo '<p>' . esc_html__( 'If this product variation has unique identifiers, you can enter them here', 'yoast-woo-seo' ) . '</p>';
+
+		wp_nonce_field( 'yoast_woo_seo_variation_identifiers', '_wpnonce_yoast_seo_woo' );
+
+		$variation_values = get_post_meta( $variation->ID, 'wpseo_variation_global_identifiers_values', true );
+
+		foreach ( $this->global_identifier_types as $type => $label ) {
+			$value = isset( $variation_values[ $type ] ) ? $variation_values[ $type ] : '';
+			$this->input_field_for_identifier( $variation->ID, $type, $label, $value );
+		}
+		echo '</div>';
+		echo '</div>';
+	}
+
+	/**
+	 * Grab the values from the $_POST data and validate them.
+	 *
+	 * @param int $variation_id The id of the variation to be saved.
+	 *
+	 * @return array Valid save data.
+	 */
+	protected function save_variation_data( $variation_id ) {
+		$values = [];
+		foreach ( $this->global_identifier_types as $key => $label ) {
+			// Ignoring nonce verification as we do that elsewhere, sanitization as we do that below.
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$value = isset( $_POST['yoast_seo_variation'][ $variation_id ][ $key ] ) ? wp_unslash( $_POST['yoast_seo_variation'][ $variation_id ][ $key ] ) : '';
+			if ( $this->validate_data( $value ) ) {
+				$values[ $key ] = $value;
+			}
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Save the $_POST values from the variation's ids div.
+	 *
+	 * @param int $variation_id The variation ID.
+	 *
+	 * @return bool Whether or not we saved data.
+	 */
+	public function save_data( $variation_id ) {
+		$nonce = filter_input( INPUT_POST, '_wpnonce_yoast_seo_woo' );
+		if ( ! wp_verify_nonce( $nonce, 'yoast_woo_seo_variation_identifiers' ) ) {
+			return false;
+		}
+
+		$values = $this->save_variation_data( $variation_id );
+
+		if ( $values !== [] ) {
+			return update_post_meta( $variation_id, 'wpseo_variation_global_identifiers_values', $values );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Make sure the data is safe to save.
+	 *
+	 * @param string $value The value we're testing.
+	 *
+	 * @return bool True when safe and not empty, false when it's not.
+	 */
+	protected function validate_data( $value ) {
+		if ( wp_strip_all_tags( $value ) !== $value ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Displays an input field for an identifier.
+	 *
+	 * @param string $variation_id  The id of the variation.
+	 * @param string $type          Type of identifier, used for input name.
+	 * @param string $label         Label for the identifier input.
+	 * @param string $value         Current value of the identifier.
+	 *
+	 * @return void
+	 */
+	protected function input_field_for_identifier( $variation_id, $type, $label, $value ) {
+		echo '<p class="form-field">';
+		echo '<label for="yoast_variation_identifier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']">', esc_html( $label ), ':</label>';
+		echo '<span class="wrap">';
+		echo '<input class="input-text" type="text" id="yoast_variation_identfier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']" name="yoast_seo_variation[',esc_attr( $variation_id ), '][', esc_attr( $type ), ']" value="', esc_attr( $value ), '"/>';
+		echo '</span>';
+		echo '</p>';
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*WooCommerce doesn't allows to spoecify global identifiers (e.g., GTIN12, ISBN, etc.) only for products. We want to add this functionality to products variations.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds global identifiers to products variations

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

<img width="1027" alt="Screenshot 2022-04-01 at 15 01 40" src="https://user-images.githubusercontent.com/68744851/161268726-24a6b484-2179-454e-8f53-6d3d20554b2e.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
