### PR TITLE
Sets minimum WordPress version to 5.9 and tested up to 6.0.

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - php_version: '5.6'
-            wp_version: '5.8'
+            wp_version: '5.9'
             multisite: true
 
           - php_version: '7.0'
@@ -39,12 +39,12 @@ jobs:
             multisite: true
 
           - php_version: '7.4'
-            wp_version: '5.8'
+            wp_version: '5.9'
             multisite: false
 
           # WP 5.6 is the earliest version which (sort of) supports PHP 8.0.
           - php_version: '8.0'
-            wp_version: '5.8'
+            wp_version: '5.9'
             multisite: false
 
           # WP 5.9 is the earliest version which (sort of) supports PHP 8.1.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WooCommerce Yoast SEO
 =====================
-Requires at least: 5.8
-Tested up to: 5.9
+Requires at least: 5.9
+Tested up to: 6.0
 Stable tag: 14.8
 Requires PHP: 5.6.20
 Depends: Yoast SEO, WooCommerce

--- a/classes/woocommerce-dependencies.php
+++ b/classes/woocommerce-dependencies.php
@@ -18,7 +18,7 @@ class Yoast_WooCommerce_Dependencies {
 	 * @return bool True when the dependencies are okay.
 	 */
 	public function check_dependencies( $wp_version ) {
-		if ( ! version_compare( $wp_version, '5.8', '>=' ) ) {
+		if ( ! version_compare( $wp_version, '5.9', '>=' ) ) {
 			add_action( 'all_admin_notices', [ $this, 'wordpress_upgrade_error' ] );
 
 			return false;

--- a/tests/classes/woocommerce-dependencies-test.php
+++ b/tests/classes/woocommerce-dependencies-test.php
@@ -20,13 +20,13 @@ class Yoast_WooCommerce_Dependencies_Test extends TestCase {
 	 * @covers Yoast_WooCommerce_Dependencies::check_woocommerce_exists
 	 */
 	public function test_check_dependencies() {
-		$valid_wp_version        = '5.8';
+		$valid_wp_version        = '5.9';
 		$valid_yoast_seo_version = '18.8';
 
 		$class = Mockery::mock( Yoast_WooCommerce_Dependencies_Double::class )->makePartial();
 
 		// Invalid WordPress version.
-		$actual = $class->check_dependencies( '5.6' );
+		$actual = $class->check_dependencies( '5.8' );
 		$this->assertFalse( $actual );
 
 		// Valid WordPress version.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Sets minimum WordPress version to 5.9 and tested up to 6.0.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets minimum WordPress version to 5.9 and tested up to 6.0.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
