### PR TITLE
DUPP-401 - DUPP-401-add-variations-sku-and-url-to-schema

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -505,11 +505,16 @@ class WPSEO_WooCommerce_Schema {
 				'name'               => $product_name . ' - ' . $variation_name,
 				'price'              => wc_format_decimal( $variation['display_price'], $decimals ),
 				'priceCurrency'      => $currency,
+				'url'                => get_permalink( $variation['variation_id'] ),
 				'priceSpecification' => [
 					'@type'                 => 'PriceSpecification',
 					'valueAddedTaxIncluded' => $prices_include_tax,
 				],
 			];
+
+			if ( ! empty( $variation['sku'] ) ) {
+				$offer['sku'] = $variation['sku'];
+			}
 
 			// Adds variation's global identifiers to the $offer array.
 			$variation_global_ids    = get_post_meta( $variation['variation_id'], 'wpseo_variation_global_identifiers_values', true );

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "require-dev": {
         "yoast/yoastcs": "^2.2.1",
         "yoast/wp-test-utils": "^1.0.0",
-        "yoast/wordpress-seo": "dev-release/19.1@dev"
+        "yoast/wordpress-seo": "dev-trunk@dev"
     },
     "extra": {
         "installer-paths": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97c9357f880408fc01d01d702581f291",
+    "content-hash": "b156317f6f5eda2aefe46790a3ad88ca",
     "packages": [
         {
             "name": "composer/installers",
@@ -2538,7 +2538,7 @@
         },
         {
             "name": "yoast/wordpress-seo",
-            "version": "dev-release/19.1",
+            "version": "dev-trunk",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wordpress-seo.git",
@@ -2573,6 +2573,7 @@
                 "yoast/wp-test-utils": "^1.0.0",
                 "yoast/yoastcs": "^2.2.1"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "classmap": [
@@ -2830,5 +2831,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -392,7 +392,7 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$variants        = [
+		$variants = [
 			[
 				'attributes'            => [
 					'attribute_pa_size' => 'l',
@@ -487,7 +487,7 @@ class Schema_Test extends TestCase {
 				'max_qty'               => '',
 				'min_qty'               => 1,
 				'price_html'            => '<span class=\'price\'><span class=\'woocommerce-Price-amount amount\'><span class=\'woocommerce-Price-currencySymbol\'>&pound;</span>8.00</span></span>',
-				'sku'                   => '209643',
+				'sku'                   => '209644',
 				'variation_description' => '',
 				'variation_id'          => 331,
 				'variation_is_active'   => true,
@@ -538,7 +538,7 @@ class Schema_Test extends TestCase {
 				'max_qty'               => '',
 				'min_qty'               => 1,
 				'price_html'            => '<span class=\'price\'><span class=\'woocommerce-Price-amount amount\'><span class=\'woocommerce-Price-currencySymbol\'>&pound;</span>12.00</span></span>',
-				'sku'                   => '209643',
+				'sku'                   => '209645',
 				'variation_description' => '',
 				'variation_id'          => 332,
 				'variation_is_active'   => true,
@@ -547,6 +547,43 @@ class Schema_Test extends TestCase {
 				'weight_html'           => 'N/A',
 			],
 		];
+
+		$variations_global_ids = [
+			[
+				'gtin8'  => '01234567',
+				'gtin12' => '',
+				'gtin13' => '',
+				'gtin14' => '',
+				'isbn'   => '',
+				'mpn'    => '',
+			],
+			[
+				'gtin8'  => '',
+				'gtin12' => '012345678910',
+				'gtin13' => '',
+				'gtin14' => '',
+				'isbn'   => '',
+				'mpn'    => '',
+			],
+			[
+				'gtin8'  => '',
+				'gtin12' => '',
+				'gtin13' => '',
+				'gtin14' => '0123456789101112',
+				'isbn'   => '',
+				'mpn'    => '',
+			],
+		];
+
+		$product_global_ids = [
+			'gtin8'  => '11112222',
+			'gtin12' => '',
+			'gtin13' => '',
+			'gtin14' => '',
+			'isbn'   => '',
+			'mpn'    => '',
+		];
+
 		$expected_output = [
 			'@type'         => 'AggregateOffer',
 			'lowPrice'      => '8.00',
@@ -568,10 +605,13 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - l',
 					'price'              => 10,
 					'priceCurrency'      => 'GBP',
+					'url'                => 'https://example.com/product/customizable-responsive-toolset/?attribute_pa_size=l',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
 					],
+					'sku'                => '209643',
+					'gtin8'              => '01234567',
 				],
 				[
 					'@type'              => 'Offer',
@@ -579,10 +619,14 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - m',
 					'price'              => 8,
 					'priceCurrency'      => 'GBP',
+					'url'                => 'https://example.com/product/customizable-responsive-toolset/?attribute_pa_size=m',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
 					],
+					'sku'                => '209644',
+					'gtin8'              => '11112222',
+					'gtin12'             => '012345678910',
 				],
 				[
 					'@type'              => 'Offer',
@@ -590,10 +634,14 @@ class Schema_Test extends TestCase {
 					'name'               => 'Customizable responsive toolset - xl',
 					'price'              => 12,
 					'priceCurrency'      => 'GBP',
+					'url'                => 'https://example.com/product/customizable-responsive-toolset/?attribute_pa_size=xl',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
 					],
+					'sku'                => '209645',
+					'gtin8'              => '11112222',
+					'gtin14'             => '0123456789101112',
 				],
 			],
 		];
@@ -606,7 +654,6 @@ class Schema_Test extends TestCase {
 				'wc_get_price_decimals'    => 2,
 				'wc_format_decimal'        => null,
 				'wc_tax_enabled'           => false,
-				'get_post_meta'            => null,
 			]
 		);
 
@@ -616,6 +663,21 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_name' )->once()->andReturn( 'Customizable responsive toolset' );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
+
+		Functions\expect( 'get_permalink' )
+			->andReturn(
+				$input['url'] . '?attribute_pa_size=' . $variants[0]['attributes']['attribute_pa_size'],
+				$input['url'] . '?attribute_pa_size=' . $variants[1]['attributes']['attribute_pa_size'],
+				$input['url'] . '?attribute_pa_size=' . $variants[2]['attributes']['attribute_pa_size']
+			);
+
+		Functions\expect( 'get_post_meta' )
+			->andReturn(
+				$product_global_ids,
+				$variations_global_ids[0],
+				$variations_global_ids[1],
+				$variations_global_ids[2]
+			);
 
 		$this->meta
 			->expects( 'for_current_page' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to enrich generated products' schemata by adding more information  related to products' variations

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds variations' SKU and URL to a product's schema. Props to @jaredforth.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create some variations of a product and specify the price for each variation. **Note:** At least one variation needs to have a different price than the others for the proper `AggregateOffer` schema piece to be generated
* For some of the variations, fill the SKU input field too
* Check the frontend of the product you created and find the schema having `Product` as `@type` 
* Validate the schema through a schema validator tool (e.g. [this](https://classyschema.org/Visualisation))
* For each `"@type": "Offer"` object, verify:
  *  The SKU value is present iff it was specified for that variation
  * the `url` attribute is present 
* Copy a variation `url` attribute and paste it in a browser's tab
* Verify the url opens the product's page with that variation already selected


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes [DUPP-401](https://yoast.atlassian.net/browse/DUPP-401)
