### PR TITLE
edit typo in variants identifier name

### DIFF
--- a/classes/woocommerce-yoast-ids.php
+++ b/classes/woocommerce-yoast-ids.php
@@ -116,7 +116,7 @@ class WPSEO_WooCommerce_Yoast_Ids {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<p ', $style, '>';
 		echo '<label for="yoast_variation_identifier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']" style="display: block;">', esc_html( $label ), '</label>';
-		echo '<input class="short" type="text" style="margin: 2px 0 0; line-height: 2.75; width: 100%;" id="yoast_variation_identfier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']" name="yoast_seo_variation[',esc_attr( $variation_id ), '][', esc_attr( $type ), ']" value="', esc_attr( $value ), '"/>';
+		echo '<input class="short" type="text" style="margin: 2px 0 0; line-height: 2.75; width: 100%;" id="yoast_variation_identifier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']" name="yoast_seo_variation[',esc_attr( $variation_id ), '][', esc_attr( $type ), ']" value="', esc_attr( $value ), '"/>';
 		echo '</p>';
 	}
 }

--- a/tests/classes/woocommerce-yoast-ids-test.php
+++ b/tests/classes/woocommerce-yoast-ids-test.php
@@ -151,7 +151,7 @@ class WooCommerce_Yoast_Ids_Test extends TestCase {
 			[ 'gtin8' ],
 			[ 'GTIN 8' ],
 			[ '12345678' ],
-			[ 'yoast_variation_identfier[123][gtin8]' ],
+			[ 'yoast_variation_identifier[123][gtin8]' ],
 		];
 	}
 
@@ -206,7 +206,7 @@ class WooCommerce_Yoast_Ids_Test extends TestCase {
 					'gtin14'  => '4',
 					'mpn'     => '12',
 				],
-				'id="yoast_variation_identfier[1][gtin12]" name="yoast_seo_variation[1][gtin12]" value="2"',
+				'id="yoast_variation_identifier[1][gtin12]" name="yoast_seo_variation[1][gtin12]" value="2"',
 			],
 			[
 				1337,
@@ -218,7 +218,7 @@ class WooCommerce_Yoast_Ids_Test extends TestCase {
 					'gtin14'  => '4',
 					'mpn'     => '12',
 				],
-				'id="yoast_variation_identfier[2][mpn]" name="yoast_seo_variation[2][mpn]" value="12"',
+				'id="yoast_variation_identifier[2][mpn]" name="yoast_seo_variation[2][mpn]" value="12"',
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [this PR](https://github.com/Yoast/wpseo-woocommerce/pull/761/commits/c6d1beee0d50bd543629741f695f5345098680c6) the id name for product variants identifiers was accidentally misspelled. 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Edits typo in id name for product variants identifiers.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a product and make some variations for it
* Open the variations and confirm that the fields related to global identifiers are showing
* Right click on of the identifier fields and choose `Inspect` from the drop-down menu
* An `Element` console will open to the right of the screen
* In that `Element` console, confirm that the name you see in the id field is `yoast_variation_identifier` (and not `yoast_variation_identfier`)
<img width="512" alt="Screenshot 2022-06-27 at 11 11 22" src="https://user-images.githubusercontent.com/56546633/175904316-ba10ffa5-44f6-4fbb-aa40-feacee4909da.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
