### PR TITLE
GH Actions: minor tweaks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
           coverage: none
         env:
           # Token is needed for the YoastSEO install via VCS.
-          COMPOSER_TOKEN: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
+          GITHUB_TOKEN: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
 
       # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 5.6
+          coverage: none
         env:
           # Token is needed for the YoastSEO install via VCS.
           COMPOSER_TOKEN: ${{ secrets.YOASTBOT_CI_PAT_DIST }}


### PR DESCRIPTION
## Context

* CI maintenance

## Summary
This PR can be summarized in the following changelog entry:

* CI maintenance


## Relevant technical choices:

### GH Actions: minor tweak

Ensure that `coverage: none` is always used (except for when running Coverage) as it prevents problems with undesired extensions being installed/incorrectly configured.

### GH Actions: update name of environment variable

`setup-php` has deprecated and replaced an environment variable in a recent release:

> Deprecated COMPOSER_TOKEN in favor of GITHUB_TOKEN

This updates the workflow for that change.

Refs:
* https://github.com/shivammathur/setup-php/releases/tag/2.21.0
* https://github.com/shivammathur/setup-php#github-composer-authentication

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.
