### PR TITLE
QA: fix incorrect attribute escapes

### DIFF
--- a/classes/woocommerce-yoast-ids.php
+++ b/classes/woocommerce-yoast-ids.php
@@ -115,8 +115,8 @@ class WPSEO_WooCommerce_Yoast_Ids {
 		// Ignoring escaping because it would mangle the double quotes.
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<p ', $style, '>';
-		echo '<label for="yoast_variation_identifier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']" style="display: block;">', esc_html( $label ), '</label>';
-		echo '<input class="short" type="text" style="margin: 2px 0 0; line-height: 2.75; width: 100%;" id="yoast_variation_identifier[', esc_attr( $variation_id ), '][', esc_attr( $type ), ']" name="yoast_seo_variation[',esc_attr( $variation_id ), '][', esc_attr( $type ), ']" value="', esc_attr( $value ), '"/>';
+		echo '<label for="', esc_attr( 'yoast_variation_identifier[' . $variation_id . '][' . $type . ']' ), '" style="display: block;">', esc_html( $label ), '</label>';
+		echo '<input class="short" type="text" style="margin: 2px 0 0; line-height: 2.75; width: 100%;" id="', esc_attr( 'yoast_variation_identifier[' . $variation_id . '][' . $type . ']' ), '" name="', esc_attr( 'yoast_seo_variation[' . $variation_id . '][' . $type . ']' ), '" value="', esc_attr( $value ), '"/>';
 		echo '</p>';
 	}
 }

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -148,9 +148,9 @@ class WPSEO_WooCommerce_Yoast_Tab {
 	 */
 	protected function input_field_for_identifier( $type, $label, $value ) {
 		echo '<p class="form-field">';
-		echo '<label for="yoast_identifier_', esc_attr( $type ), '">', esc_html( $label ), ':</label>';
+		echo '<label for="', esc_attr( 'yoast_identifier_' . $type ), '">', esc_html( $label ), ':</label>';
 		echo '<span class="wrap">';
-		echo '<input class="input-text" type="text" id="yoast_identfier_', esc_attr( $type ), '" name="yoast_seo[', esc_attr( $type ), ']" value="', esc_attr( $value ), '"/>';
+		echo '<input class="input-text" type="text" id="', esc_attr( 'yoast_identifier_' . $type ), '" name="', esc_attr( 'yoast_seo[' . $type . ']' ), '" value="', esc_attr( $value ), '"/>';
 		echo '</span>';
 		echo '</p>';
 	}


### PR DESCRIPTION
## Context

* Minor security improvement

## Summary
This PR can be summarized in the following changelog entry:

* Minor security improvement


## Relevant technical choices:

`esc_attr*()` should be used for values in HTML attributes and attributes should be escaped in one go, not in bits and pieces.

Includes fixing a typo in the ID for one of these fields.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ Functionally, there should be no noticeable difference
