### PR TITLE
Refactors code that sends over SKU and product identifier data to the analysis

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -40,7 +40,7 @@ function hasGlobalIdentifier( product ) {
 }
 
 /**
- * A function to calculate whether there are any variants.
+ * Checks whether there are any variants.
  *
  * @param {Object[]} productVariants The product variants.
  *
@@ -51,7 +51,7 @@ function hasVariants( productVariants ) {
 }
 
 /**
- * A function to calculate whether or not all variants have at least one identifier set.
+ * Checks whether or not all variants have at least one identifier set.
  *
  * @param {Object[]} productVariants The product variants.
  *
@@ -62,19 +62,19 @@ function doAllVariantsHaveIdentifier( productVariants ) {
 }
 
 /**
- * A function to calculate whether all variants have at least one identifier set.
+ * Checks whether or not all variants have SKU.
  *
  * @param {Object[]} productVariants The product variants.
  *
- * @returns {Boolean} Whether all variants have at least one identifier set.
+ * @returns {Boolean} Whether all variants have SKU.
  */
 function doAllVariantsHaveSkus( productVariants ) {
 	return productVariants.every( variant => variant.sku );
 }
 
 /**
- * Get the initial product data needed for the SKU and product identifier assessments
- * for the variant with the given id from the JavaScript object injected by the server.
+ * Gets the initial product data needed for the SKU and product identifier assessments
+ * for the variant with the given ID from the JavaScript object injected by the server.
  *
  * @param {string} id The product variant ID.
  *
@@ -126,7 +126,7 @@ function getProductVariants() {
 }
 
 /**
- * Get the initial product data needed for the SKU and product identifier assessments
+ * Gets the initial product data needed for the SKU and product identifier assessments
  * from the JavaScript object injected by the server.
  *
  * @returns {Object} The initial product data needed for the SKU and product identifier assessments.

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -299,7 +299,7 @@ function registerEventListeners() {
 		const newValue = event.target.value;
 
 		// Create a mock object to merge with the identifiersStore (to avoid referencing issues).
-		const newGlobalIdentifierValue = setWith( {}, `global_sku.${ SKUIdentifier }`, newValue );
+		const newGlobalIdentifierValue = setWith( {}, "global_sku", newValue );
 		skuStore = merge( {}, skuStore, newGlobalIdentifierValue );
 
 		// Refresh the app so the analysis runs.

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -192,7 +192,6 @@ function enrichDataWithIdentifiers( data ) {
 		hasGlobalIdentifier: hasGlobalIdentifier( product ),
 		hasVariants: hasVariants( variantsWithPrice ),
 		doAllVariantsHaveIdentifier: doAllVariantsHaveIdentifier( variantsWithPrice ),
-		variantIdentifierDataIsValid: true,
 		hasGlobalSKU: hasGlobalSKU( product ),
 		doAllVariantsHaveSKU: doAllVariantsHaveSkus( variantsWithPrice ),
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The existing code was fragile and did not cover many edge cases (e.g. updating the data on (bulk) removal of variations). This PR refactors it and solves some bugs related to these edge cases.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an empty SKU was not picked up in the SKU assessment.
* Fixes a bug where changes to the SKU and product identifiers were not picked up in the SKU and product identifier assessments when performing bulk actions, like bulk delete, bulk price increase and bulk price decrease.
* Fixes a bug where entering a price before entering an SKU lead to incorrect SKU assessment results.

## Relevant technical choices:

* Code has been refactored quite a bit:
  * SKU and product identifier data is gathered from the page when the analysis is run. This simplifies the code.
  * Addition and removal of product variations are now picked up using a `MutationObserver`. This observer observes whether new child elements (variations) are added to, or removed from, the list of variations. If so, the analysis is refreshed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Follow the test instructions as defined in https://github.com/Yoast/wordpress-seo/pull/18721. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/PC-139
