### PR TITLE
Fix the product identifiers assessment result not updating automatically for simple products

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -205,6 +205,16 @@ function enrichDataWithIdentifiers( data ) {
  * @returns {void}.
  */
 function registerEventListeners() {
+	// Register event listeners for the global identifier inputs (non-variation);
+	identifierKeys.forEach( key => {
+		const globalIdentifierInput = document.getElementById( `yoast_identifier_${ key }` );
+		globalIdentifierInput.addEventListener( "change", YoastSEO.app.refresh );
+	} );
+
+	// Register event listeners for the global sku input from Woocommerce (non-variation);
+	const globalSkuInput = document.getElementById( "_sku" );
+	globalSkuInput.addEventListener( "change", YoastSEO.app.refresh );
+
 	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
 	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
 	variationsObserver.observe( document.querySelector( ".woocommerce_variations" ), { childList: true } );
@@ -227,16 +237,6 @@ function registerEventListeners() {
 		"change", "#variable_product_options .woocommerce_variations :input[id^=variable_sku]",
 		YoastSEO.app.refresh
 	);
-
-	// Register event listeners for the global identifier inputs (non-variation);
-	identifierKeys.forEach( key => {
-		const globalIdentifierInput = document.getElementById( `yoast_identifier_${ key }` );
-		globalIdentifierInput.addEventListener( "change", YoastSEO.app.refresh );
-	} );
-
-	// Register event listeners for the global sku input from Woocommerce (non-variation);
-	const globalSkuInput = document.getElementById( "_sku" );
-	globalSkuInput.addEventListener( "change", YoastSEO.app.refresh );
 }
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the page needed to be refreshed in order for the Product identifiers assessment result to update when adding or removing a global identifier.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, WooCommerce, and Yoast SEO: WooCommerce
* Create a new product. Don't make any edits such as adding text or a title. 
* Confirm that the Product identifiers assessment appears with an orange bullet and the following feedback: `Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content.` 
* Go to the Yoast SEO tab in the product metabox and add an identifier. Click away from the input field.
* Confirm that the Product identifiers assessment returns a green bullet and the following feedback: `Product identifier: Your product has an identifier. Good job!`
* Remove the identifier, click away from the input field, and confirm that the Product identifiers assessment appears with an orange bullet and the following feedback: `Product identifier: Your product is missing an identifier (like a GTIN code). Include this if you can, as it will help search engines to better understand your content.` 
* Repeat the same steps for the SKU assessment (the SKU can be added in the Inventory tab of the product metabox, and the feedback strings will mention SKU instead of Product identifier).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
