### PR TITLE
Listen for changes to the product variations tab before adding the va…

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -204,6 +204,23 @@ function enrichDataWithIdentifiers( data ) {
 }
 
 /**
+ * Registers a mutation observer that observes
+ * whether new product variatons are added or removed from the page.
+ *
+ * @param {MutationRecord[]} _ mutation records (unused).
+ * @param {MutationObserver} observer The mutation observer triggering this function.
+ *
+ * @returns {void}
+ */
+function registerVariationsObserver( _, observer ) {
+	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
+	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
+	variationsObserver.observe( document.querySelector( ".woocommerce_variations" ), { childList: true } );
+	// Remove the observer again, now the variations observer is working.
+	observer.disconnect();
+}
+
+/**
  * A function that registers event listeners.
  *
  * @returns {void}.
@@ -223,9 +240,9 @@ function registerEventListeners() {
 	const globalPriceInput = document.getElementById( "_regular_price" );
 	globalPriceInput.addEventListener( "change", YoastSEO.app.refresh );
 
-	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
-	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
-	variationsObserver.observe( document.querySelector( ".woocommerce_variations" ), { childList: true } );
+	// Since new products do not have a variations element yet, observe the variations tab until it has one.
+	const observer = new MutationObserver( registerVariationsObserver );
+	observer.observe( document.getElementById( "variable_product_options_inner" ), { childList: true } );
 
 	// Detect changes in the price inputs and handle them.
 	jQuery( document.body ).on(


### PR DESCRIPTION
…riations mutation observer.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the synonyms input in Yoast SEO Premium was not shown on new WooCommerce products.
* Fixes a bug where variations are not recognized when creating a new WooCommerce product.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Premium. (Needed to check if the synonyms field shows up).
* Create a new WooCommerce product.
* Navigate to the Yoast SEO Premium metabox
   * Navigate to the Premium SEO analysis and confirm that the Keyphrase synonyms input field is available.
   * Confirm that the Add related keyphrase collapsible is available.
* In the Product data metabox, switch the product to be a variable product. (You can do this in the dropdown box at the top of the metabox).
* In the Product data metabox, add variations to the product.
   * In the attributes tab, add an attribute with multiple values. (E.g. color with value `red|green|blue`). Make sure that the 'variations' checkbox is checked.
   * In the variations tab, add one or more variations, based on the attribute you added earlier.
 * Add a price to one of the variations. 
 * In the SEO analysis results, confirm that you see these two assessment results:
   * > Product identifier: Not all your product variants have an identifier. Include this if you can, as it will help search engines to better understand your content.
   * > SKU: Not all your product variants have a SKU. Include this if you can, as it will help search engines to better understand your content.  

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* SKU and Product identifier assessments in general.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unit tests to verify the code works as intended

Fixes #
