### PR TITLE
Update woocommerce-seo.php

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -74,8 +74,8 @@ class Yoast_WooCommerce_SEO {
 			// Move Woo box above SEO box.
 			add_action( 'admin_footer', [ $this, 'footer_js' ] );
 
-			new WPSEO_WooCommerce_Yoast_Tab();
-			new WPSEO_WooCommerce_Yoast_Ids();
+			$wpseo_woocommerce_yoast_tab = new WPSEO_WooCommerce_Yoast_Tab();
+			$wpseo_woocommerce_yoast_ids = new WPSEO_WooCommerce_Yoast_Ids();
 		}
 		else {
 			// Initialize schema & OpenGraph.


### PR DESCRIPTION
Assign class instances to objects to enable removing of actions from other parts of the total codebase as per best practice.

## Context
* Using remove_action is not possible if there is no reference to a specific class.

## Summary

* Assign class instances to objects to enable removing actions
