### PR TITLE
Add support for ASIN product identifier.

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -525,6 +525,7 @@ class WPSEO_WooCommerce_Schema {
 				'gtin13',
 				'gtin14',
 				'mpn',
+				'asin',
 			];
 
 			foreach ( $global_identifier_types as $global_identifier_type ) {

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1025,6 +1025,13 @@ class Yoast_WooCommerce_SEO {
 			'basic',
 			'The product\'s MPN identifier.'
 		);
+
+		wpseo_register_var_replacement(
+			'wc_asin',
+			[ $this, 'get_product_var_asin' ],
+			'basic',
+			'The product\'s ASIN identifier.'
+		);
 	}
 
 	/**
@@ -1284,6 +1291,15 @@ class Yoast_WooCommerce_SEO {
 	 */
 	public function get_product_var_mpn() {
 		return $this->get_product_identifier( 'mpn' );
+	}
+
+	/**
+	 * Retrieves the product ASIN identifier.
+	 *
+	 * @return string The product ASIN identifier.
+	 */
+	public function get_product_var_asin() {
+		return $this->get_product_identifier( 'asin' );
 	}
 
 	/**

--- a/classes/woocommerce-yoast-ids.php
+++ b/classes/woocommerce-yoast-ids.php
@@ -21,6 +21,7 @@ class WPSEO_WooCommerce_Yoast_Ids {
 		'gtin13' => 'GTIN13 / EAN',
 		'gtin14' => 'GTIN14 / ITF-14',
 		'mpn'    => 'MPN',
+		'asin'   => 'ASIN',
 	];
 
 	/**

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -22,6 +22,7 @@ class WPSEO_WooCommerce_Yoast_Tab {
 		'gtin14' => 'GTIN14 / ITF-14',
 		'isbn'   => 'ISBN',
 		'mpn'    => 'MPN',
+		'asin'   => 'ASIN',
 	];
 
 	/**

--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -168,6 +168,7 @@ YoastReplaceVarPlugin.prototype.registerReplacements = function() {
 	this.addReplacement( new ReplaceVar( "%%wc_gtin14%%",    "wc_gtin14" ) );
 	this.addReplacement( new ReplaceVar( "%%wc_isbn%%",      "wc_isbn" ) );
 	this.addReplacement( new ReplaceVar( "%%wc_mpn%%",       "wc_mpn" ) );
+	this.addReplacement( new ReplaceVar( "%%wc_asin%%",       "wc_asin" ) );
 };
 
 /**
@@ -204,6 +205,7 @@ YoastReplaceVarPlugin.prototype.replaceVariables = function( data ) {
 		data = data.replace( /%%wc_gtin14%%/g, jQuery( "#yoast_identifier_gtin14" ).val() );
 		data = data.replace( /%%wc_isbn%%/g, jQuery( "#yoast_identifier_isbn" ).val() );
 		data = data.replace( /%%wc_mpn%%/g, jQuery( "#yoast_identifier_mpn" ).val() );
+		data = data.replace( /%%wc_asin%%/g, jQuery( "#yoast_identifier_asin" ).val() );
 
 		data = this.replacePlaceholders( data );
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -556,6 +556,7 @@ class Schema_Test extends TestCase {
 				'gtin14' => '',
 				'isbn'   => '',
 				'mpn'    => '',
+				'asin'   => '',
 			],
 			[
 				'gtin8'  => '',
@@ -564,6 +565,7 @@ class Schema_Test extends TestCase {
 				'gtin14' => '',
 				'isbn'   => '',
 				'mpn'    => '',
+				'asin'   => '',
 			],
 			[
 				'gtin8'  => '',
@@ -572,6 +574,7 @@ class Schema_Test extends TestCase {
 				'gtin14' => '0123456789101112',
 				'isbn'   => '',
 				'mpn'    => '',
+				'asin'   => '',
 			],
 		];
 
@@ -582,6 +585,7 @@ class Schema_Test extends TestCase {
 			'gtin14' => '',
 			'isbn'   => '',
 			'mpn'    => '',
+			'asin'   => '',
 		];
 
 		$expected_output = [
@@ -892,6 +896,32 @@ class Schema_Test extends TestCase {
 		$schema->add_global_identifier( $product );
 
 		$this->assertSame( [ 'gtin8' => '123' ], $schema->data );
+	}
+
+	/**
+	 * Test adding the ASIN identifier
+	 *
+	 * @covers ::add_global_identifier
+	 */
+	public function test_add_global_identifier_asin() {
+		$product = Mockery::mock( 'WC_Product' );
+		$product->expects( 'get_id' )->once()->andReturn( 123 );
+
+		$data = [
+			'asin'   => '123',
+			'gtin12' => '',
+		];
+
+		Functions\stubs(
+			[
+				'get_post_meta' => $data,
+			]
+		);
+
+		$schema = new Schema_Double();
+		$schema->add_global_identifier( $product );
+
+		$this->assertSame( [ 'asin' => '123' ], $schema->data );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Schema.org in the process of adding support for ASIN values (Amazon Standard Identification Number) on Product/Offer nodes.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the global identifiers feature for Products and variations to include the ASIN product ID and add it to the Schema output.

## Relevant technical choices:

* These are not included in the product identifier assessment by design.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the latest stable version of free and premium.
* Add a new product. And give it a name and a price.
* Add an ASIN in the Yoast SEO tab in the woocommerce meta box.
<img width="1308" alt="image" src="https://user-images.githubusercontent.com/6975345/185384966-4f75c90d-bfc9-4eb2-ac84-6cf88e670035.png">

* See that the product identifier assessment still says ` Your product is missing a product identifier (like a GTIN code).`
* Add a GTIN option in the same Yoast SEO tab as above and check if the assessment now says `Good job` with a green bullet.
* Save and go to the front-end.
* Check if the schema has an ASIN field with your value in the product type graph. (for me it was somewhere in the middle of the page)  Also make sure the GTIN field you put in is also there.
* add the `%wc_asin%%` replace var to the SEO title or meta description and see it's correctly replaced with the actual value in the frontend.
* Remove the GTIN and ASIN data and save. The keys should no longer show up in the schema.

* change the product to a variable product
* add 2 or more variations
* Give 1 of the variations a price and ASIN and save.
* Check if the ASIN shows in schema for the product
* Give the other product variation just a price and save.
* Check if the product variation shows up in the schema without a ASIN.
* Add an ASIN to the second product variation and check if both now show up.
* Check if the product identifier assessment is unafected by the ASIN numbers. It should still say `Not all your product variants have a product identifier. `

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes #
PC-397