### PR TITLE
Fix the assessment results for SKU and product identifier not always updating for variable products

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -10,13 +10,6 @@ const identifierKeys = [
 	"mpn",
 ];
 
-/*
- Whether the variant data is valid or not. We are not currently able to detect a change to the data resulting from
- certain actions. When this happens, we set this variable to 'false' and return a grey bullet for the assessment
- asking the user to refresh the page.
-*/
-let variantDataIsValid = true;
-
 /**
  * Checks whether the product has a global identifier.
  *
@@ -77,15 +70,6 @@ function doAllVariantsHaveIdentifier( productVariants ) {
  */
 function doAllVariantsHaveSkus( productVariants ) {
 	return productVariants.every( variant => variant.sku );
-}
-
-/**
- * Checks whether the identifier data is valid.
- **
- * @returns {Boolean} Whether the identifier data is valid.
- */
-function isVariantDataValid() {
-	return variantDataIsValid;
 }
 
 /**
@@ -218,7 +202,6 @@ function enrichDataWithIdentifiers( data ) {
 		doAllVariantsHaveIdentifier: doAllVariantsHaveIdentifier( variantsWithPrice ),
 		hasGlobalSKU: hasGlobalSKU( product ),
 		doAllVariantsHaveSKU: doAllVariantsHaveSkus( variantsWithPrice ),
-		isVariantDataValid: isVariantDataValid(),
 	} );
 
 	return newData;
@@ -288,30 +271,6 @@ function registerEventListeners() {
 		"change", "#variable_product_options .woocommerce_variations :input[id^=variable_sku]",
 		YoastSEO.app.refresh
 	);
-
-	/*
-	 The above listeners don't currently detect changes as a result of performing bulk actions for product variants.
-	 Therefore, when a user performs a bulk action we don't have valid variant data until the page is refreshed.
-	 */
-	jQuery( ".wc-metaboxes-wrapper" ).on( "click", "a.do_variation_action", () => {
-		// User is trying to "go" for the following bulk action:
-		const attemptedBulkACtion = jQuery( ".variation_actions" )[ 0 ].value;
-		if ( [
-			"variable_regular_price",
-			"variable_regular_price_increase",
-			"variable_regular_price_decrease",
-			"delete_all",
-		].includes( attemptedBulkACtion ) ) {
-			variantDataIsValid = false;
-			YoastSEO.app.refresh();
-		}
-	} );
-
-	// The above listeners also don't detect when individual variants are removed.
-	jQuery( "#variable_product_options" ).on( "click", ".remove_variation", () => {
-		variantDataIsValid = false;
-		YoastSEO.app.refresh();
-	} );
 }
 
 /**

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -10,7 +10,11 @@ const identifierKeys = [
 	"mpn",
 ];
 
-// Store to keep track of whether identifiersStore can be trusted or should be reloaded.
+/*
+ Whether the variant data is valid or not. We are not currently able to detect a change to the data resulting from
+ certain actions. When this happens, we set this variable to 'false' and return a grey bullet for the assessment
+ asking the user to refresh the page.
+*/
 let variantDataIsValid = true;
 
 /**
@@ -286,8 +290,8 @@ function registerEventListeners() {
 	);
 
 	/*
-	 Store bulk action in order to know what has happened when the variations block gets loaded again.
-	 We don't know what value the customer put in, and we don't know whether they've cancelled or not.
+	 The above listeners don't currently detect changes as a result of performing bulk actions for product variants.
+	 Therefore, when a user performs a bulk action we don't have valid variant data until the page is refreshed.
 	 */
 	jQuery( ".wc-metaboxes-wrapper" ).on( "click", "a.do_variation_action", () => {
 		// User is trying to "go" for the following bulk action:
@@ -303,7 +307,8 @@ function registerEventListeners() {
 		}
 	} );
 
-	jQuery( "#variable_product_options" ).on( "click", ".remove_variation", ( ) => {
+	// The above listeners also don't detect when individual variants are removed.
+	jQuery( "#variable_product_options" ).on( "click", ".remove_variation", () => {
 		variantDataIsValid = false;
 		YoastSEO.app.refresh();
 	} );

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -208,23 +208,6 @@ function enrichDataWithIdentifiers( data ) {
 }
 
 /**
- * Registers a mutation observer that observes
- * whether new product variatons are added or removed from the page.
- *
- * @param {MutationRecord[]} _ mutation records (unused).
- * @param {MutationObserver} observer The mutation observer triggering this function.
- *
- * @returns {void}
- */
-function registerVariationsObserver( _, observer ) {
-	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
-	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
-	variationsObserver.observe( document.querySelector( ".woocommerce_variations" ), { childList: true } );
-	// Remove the observer again, now the variations observer is working.
-	observer.disconnect();
-}
-
-/**
  * A function that registers event listeners.
  *
  * @returns {void}.
@@ -249,9 +232,9 @@ function registerEventListeners() {
 	// ProductType.addEventListener( "change", YoastSEO.app.refresh );
 	productTypeInput.addEventListener( "change", YoastSEO.app.refresh );
 
-	// Since new products do not have a variations element yet, observe the variations tab until it has one.
-	const observer = new MutationObserver( registerVariationsObserver );
-	observer.observe( document.getElementById( "variable_product_options_inner" ), { childList: true } );
+	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
+	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
+	variationsObserver.observe( document.getElementById( "variable_product_options" ),  { childList: true, subtree: true, attributes: true } );
 
 	// Detect changes in the price inputs and handle them.
 	jQuery( document.body ).on(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The SKU and product identifiers assessment result wasn't updating without refreshing the page when performing a bulk action on variants, or when deleting a variant.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the SKU and product identifier assessment results weren't updating without refreshing the page when performing a bulk action on product variants, or when deleting a variant.

## Relevant technical choices:

* Observing the whole variations tab, with the `subtree`, `attributes`, and `childList` options, ensures that all the changes to variant data are detected.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, WooCommerce, and Yoast SEO: WooCommerce plugins
* (for acceptance tester) Make sure to run `composer require yoast/wordpress-seo:dev-trunk@dev --dev` in woocommerce-seo before building the branch
* Create a new product (make sure to _not_ save it or fill in any fields like text, title etc.

#### Test whether the bugfix works:
* Change the product to a variable product
* Create 3 variants for the product (go to the Attributes tab and add some attributes (make sure to check `Used for variations` checkbox). Then go to the Variants tab that appears and create variants from the attributes)
* Confirm that the SKU and product identifiers assessments do not appear under SEO analysis
* Click on the dropdown menu above the variants, and select the 'Set regular prices' option. Enter a price in the pop up that appears.
* Confirm that the SKU and product identifiers assessments return an orange bullet with the following feedback: `SKU/Product identifier: Not all your product variants have a SKU/identifier. Include this if you can, as it will help search engines to better understand your content.`
* Add a SKU and a product identifier to 2 of the variants. Confirm the assessment result stays the same.
* Delete the variant that doesn't have the SKU and identifier.
* Confirm that the SKU and product identifiers assessments return a green bullet with the following feedback: `SKU/Product identifier: All your product variants have a SKU/identifier. Good job!`
* From the bulk action menu, select the option 'Delete all variations'
* Confirm that the SKU and product identifiers assessment do not appear in the SEO analysis results.

#### Regression testing
* Check that the changes didn't break any existing SKU/product identifier assessments functionality: follow the steps from this [document](https://docs.google.com/document/d/1m7n_9mXCd3N1ugqz6geu37taxmf0gT2fOwjx3rbMtkc/edit?usp=sharing), with the exception of checking the schema, checking in cornerstone/Premium/Classic editor/other language, and checking the steps already mentioned in the previous section.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
