### PR TITLE
Fix SKU assessment not updating when variants are deleted after opening a saved product

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -97,8 +97,15 @@ function getInitialProductVariant( id ) {
 function getProductVariants() {
 	const variationElements = [ ...document.querySelectorAll( ".woocommerce_variation" ) ];
 
-	if ( variationElements.length === 0 ) {
-		// WooCommerce variations are not loaded yet, so try to use the initial data.
+	const variationsParentClass = document.querySelector( ".woocommerce_variations" );
+	const dataTotalAttribute = variationsParentClass.getAttribute( "data-total" );
+
+	/*
+	 * If no variation elements were found but the data-total attribute of the woo-commerce variations is not 0,
+	 * it means that there are variations but they are not yet loaded on page load. If that's the case, get the variations
+	 * from the JavaScript object injected by the server.
+	 */
+	if ( variationElements.length === 0 && dataTotalAttribute > 0 ) {
 		return Object.keys( wpseoWooIdentifiers.variations ).map( getInitialProductVariant );
 	}
 

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -231,7 +231,11 @@ function registerEventListeners() {
 
 	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
 	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
-	variationsObserver.observe( document.getElementById( "variable_product_options" ),  { childList: true, subtree: true, attributes: true } );
+	variationsObserver.observe( document.getElementsByClassName( "woocommerce_variations wc-metaboxes ui-sortable" ),  { childList: true, subtree: true, attributes: true } );
+
+	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
+	const variableProductOptions = document.getElementsByClassName( "woocommerce_variations wc-metaboxes ui-sortable" );
+	variableProductOptions.addEventListener( "change", YoastSEO.app.refresh );
 
 	// Detect changes in the variation product identifiers and handle them.
 	jQuery( document.body ).on(

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -231,11 +231,7 @@ function registerEventListeners() {
 
 	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
 	const variationsObserver = new MutationObserver( YoastSEO.app.refresh );
-	variationsObserver.observe( document.getElementsByClassName( "woocommerce_variations wc-metaboxes ui-sortable" ),  { childList: true, subtree: true, attributes: true } );
-
-	// Listen for changes in the WooCommerce variations (e.g. adding or removing variations).
-	const variableProductOptions = document.getElementsByClassName( "woocommerce_variations wc-metaboxes ui-sortable" );
-	variableProductOptions.addEventListener( "change", YoastSEO.app.refresh );
+	variationsObserver.observe( document.getElementById( "variable_product_options" ),  { childList: true, subtree: true, attributes: true } );
 
 	// Detect changes in the variation product identifiers and handle them.
 	jQuery( document.body ).on(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the SKU and product identifiers assessment results would not update when opening a saved product with variants and deleting the variants.

## Relevant technical choices:

* The bug was caused by the fact that if no variation elements are found, we get the variant data from the JavaScript object injected by the server. Since the variation elements are not immediately available on page load, this ensures that we still can retrieve the variants on page load. However, when we remove the variants after opening the page, the variation elements are also not found (because they were removed), but the data from the JS objected injected by the server is not updated without refreshing the page. So in that situation, we falsely think that the product still has variants and the assessment doesn't update. This is fixed by adding an additional check: we only get the initial data from the JS object injected by the server if the `data-total` attribute of the parent element of the variations is larger than 0. This means that there are variations, but the variation elements are not yet loaded. On the other hand, if there are no variation elements and the `data-total` attribute is 0, it means there are no variations, and an empty array is returned.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, WooCommerce, and Yoast SEO: WooCommerce

#### Test the fix on saved products
* Create a new product with variants ([see documentation on how to add variants](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2564686155/How+to+add+variants+to+a+product)). Do not save the product.
* Confirm that the SKU and product identifier assessments return orange bullets with the following feedback: `Product identifier/SKU: Not all your product variants have an identifier/a SKU. Include this if you can, as it will help search engines to better understand your content.`
* Add some text and a title, and save the product.
* Confirm that the assessment result stays the same.
* Delete each variant from the product individually.
* Confirm that the assessment results change to `SKU/Product identifier: Your product is missing a SKU/an identifier. Include this if you can, as it will help search engines to better understand your content.`
* Save the product and confirm that the assessment result stays the same.
* Add back the variants and confirm that the assessments return orange bullets with the following feedback: `Product identifier/SKU: Not all your product variants have an identifier/a SKU. Include this if you can, as it will help search engines to better understand your content.`
* Save the product again and confirm the feedback doesn't change.
* Delete the variants by using the `Delete all variations` option from the bulk action menu.
* Confirm that the assessment results change to `SKU/Product identifier: Your product is missing a SKU/an identifier. Include this if you can, as it will help search engines to better understand your content.`

#### Test with SKU and product identifier filled in
* Repeat the steps from the previous section, but this time fill in the SKU and product identifier of the variants when you add them.

#### Check whether updating still works on unsaved products
* Create a new product with variants and don't save it
* Confirm that the SKU and product identifier assessments return orange bullets with the following feedback: `Product identifier/SKU: Not all your product variants have an identifier/a SKU. Include this if you can, as it will help search engines to better understand your content.`
* Delete variants (either individually or by using the bulk action menu)
* Confirm that the assessment results change to `SKU/Product identifier: Your product is missing a SKU/an identifier. Include this if you can, as it will help search engines to better understand your content.`
* Repeat the above steps but this time fill in the SKU and product identifier of the variants.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* In addition to the acceptance test steps, re-test the feature using the steps from this issue https://yoast.atlassian.net/browse/PC-369 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/PC-509 
