### PR TITLE
Fix SKU and product identifier assessments not showing up on a new product without variants

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -102,8 +102,8 @@ function getProductVariants() {
 
 	/*
 	 * If no variation elements were found but the data-total attribute on the variations parent element is larger than 0,
-	 * it means that there are variations but they are not yet loaded on page load. If that's the case, get the variations
-	 * from the JavaScript object injected by the server.
+	 * it means that there are variations but they are not yet loaded on page load. 
+	 * If that's the case, get the variations from the JavaScript object injected by the server.
 	 */
 	if ( variationElements.length === 0 && variationsParentElement ) {
 		const numberOfVariations = variationsParentElement.getAttribute( "data-total" );

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -98,17 +98,18 @@ function getInitialProductVariant( id ) {
  */
 function getProductVariants() {
 	const variationElements = [ ...document.querySelectorAll( ".woocommerce_variation" ) ];
-
-	const variationsParentClass = document.querySelector( ".woocommerce_variations" );
-	const dataTotalAttribute = variationsParentClass.getAttribute( "data-total" );
+	const variationsParentElement = document.querySelector( ".woocommerce_variations" );
 
 	/*
-	 * If no variation elements were found but the data-total attribute of the woo-commerce variations is not 0,
+	 * If no variation elements were found but the data-total attribute on the variations parent element is larger than 0,
 	 * it means that there are variations but they are not yet loaded on page load. If that's the case, get the variations
 	 * from the JavaScript object injected by the server.
 	 */
-	if ( variationElements.length === 0 && dataTotalAttribute > 0 ) {
-		return Object.keys( wpseoWooIdentifiers.variations ).map( getInitialProductVariant );
+	if ( variationElements.length === 0 && variationsParentElement ) {
+		const numberOfVariations = variationsParentElement.getAttribute( "data-total" );
+		if ( numberOfVariations > 0 ) {
+			return Object.keys( wpseoWooIdentifiers.variations ).map( getInitialProductVariant );
+		}
 	}
 
 	return variationElements.map(

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -102,7 +102,7 @@ function getProductVariants() {
 
 	/*
 	 * If no variation elements were found but the data-total attribute on the variations parent element is larger than 0,
-	 * it means that there are variations but they are not yet loaded on page load. 
+	 * it means that there are variations but they are not yet loaded on page load.
 	 * If that's the case, get the variations from the JavaScript object injected by the server.
 	 */
 	if ( variationElements.length === 0 && variationsParentElement ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This [PR](https://github.com/Yoast/wpseo-woocommerce/pull/823) resulted in a console error and the assessments not showing up on a new product without variants. This is because it introduced code that always tries to get the attribute of the element with the `woocommerce_variations` class, even when that element doesn't exist. This PR fixes it so that we only get the attribute if the element exists.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the SKU and product identifier assessments did not show up on a new product without variants.

## Relevant technical choices:

* If the element with the `woocommerce_variations` class doesn't exist, it means the product doesn't have variants, so we don't need to try to get the initial variant data.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, WooCommerce, and Yoast SEO: WooCommerce
* Open a new product 
* For all the steps, pay extra attention that no console errors appear
* Confirm that the SKU and product identifier assessments return an orange bullet with the following feedback `SKU/Product identifier: Your product is missing a SKU/an identifier. Include this if you can, as it will help search engines to better understand your content.`
* Change the product to an external/affiliate product, and confirm that the result stays the same.
* Change the product to a grouped product and confirm that the assessments do not show up
* Change the product to a variable product, and confirm that the assessments return an orange bullet with the following feedback `SKU/Product identifier: Your product is missing a SKU/an identifier. Include this if you can, as it will help search engines to better understand your content.`
* Execute the testing steps from this PR to make sure that the fix from that PR still works: https://github.com/Yoast/wpseo-woocommerce/pull/823 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/PC-526
