### PR TITLE
Check whether product identifiers can be retrieved

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -114,7 +114,7 @@ function getIdentifiers( identifierInputFieldElements ) {
 		}
 	} );
 
-	// Assign the identifiers to an object. Trim the values so that we don't recognize identifiers with only spaces as vald.
+	// Assign the identifiers to an object. Trim the values so that we don't recognize identifiers with only spaces as valid.
 	return {
 		gtin8: productIdentifiersArray[ 0 ].trim(),
 		gtin12: productIdentifiersArray[ 1 ].trim(),

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -259,20 +259,29 @@ function enrichDataWithIdentifiers( data ) {
 	const product = getProductData();
 	const productVariants = getProductVariants();
 
+	// Get product identifier data.
+	const productHasGlobalIdentifier = hasGlobalIdentifier( product );
+	const allVariantsHaveIdentifier = doAllVariantsHaveIdentifier( productVariants );
+	/*
+	 * Only set canRetrieveGlobalIdentifier and canRetrieveVariantIdentifiers to false if at least one identifier
+	 * could not be retrieved AND no identifier was found for the product/for all variants. If an identifier was
+	 * found, it doesn't matter if potentially other of the identifier fields cannot be retrieved.
+	*/
+	const canRetrieveGlobalIdentifier = productHasGlobalIdentifier ||
+		! productHasGlobalIdentifier && product.canRetrieveAllIdentifiers === true;
+
+	const canRetrieveVariantIdentifiers = allVariantsHaveIdentifier ||
+		! allVariantsHaveIdentifier && canRetrieveAllVariantIdentifiers === true;
+
 	newData.customData = Object.assign( newData.customData, {
-		/*
-		 * Only set canRetrieveGlobalIdentifier and canRetrieveVariantIdentifiers to false if at least one identifier
-		 * could not be retrieved AND no identifier was found for the product/for all variants. If an identifier was
-		 * found, it doesn't matter if potentially other of the identifier fields cannot be retrieved.
-		*/
-		canRetrieveGlobalIdentifier: product.canRetrieveAllIdentifiers && ! hasGlobalIdentifier( product ),
-		canRetrieveVariantIdentifiers: canRetrieveAllVariantIdentifiers && ! doAllVariantsHaveIdentifier( productVariants ),
+		canRetrieveGlobalIdentifier: canRetrieveGlobalIdentifier,
+		canRetrieveVariantIdentifiers: canRetrieveVariantIdentifiers,
 		canRetrieveGlobalSku: product.canRetrieveGlobalSku,
 		canRetrieveVariantSkus: canRetrieveVariantSkus,
 		productType: product.productType,
-		hasGlobalIdentifier: hasGlobalIdentifier( product ),
+		hasGlobalIdentifier: productHasGlobalIdentifier,
 		hasVariants: hasVariants( productVariants ),
-		doAllVariantsHaveIdentifier: doAllVariantsHaveIdentifier( productVariants ),
+		doAllVariantsHaveIdentifier: allVariantsHaveIdentifier,
 		hasGlobalSKU: hasGlobalSKU( product ),
 		doAllVariantsHaveSKU: doAllVariantsHaveSkus( productVariants ),
 	} );

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -165,9 +165,9 @@ function getProductVariants() {
 				`#yoast_variation_identifier\\[${id}\\]\\[gtin8\\]`,
 				`#yoast_variation_identifier\\[${id}\\]\\[gtin12\\]`,
 				`#yoast_variation_identifier\\[${id}\\]\\[gtin13\\]`,
-				`#yoast_variation_identifier\\\\[${id}\\\\]\\\\[gtin14\\\\]`,
-				`#yoast_variation_identifier\\\\[${id}\\\\]\\\\[gtin14\\\\]`,
-				`#yoast_variation_identifier\\\\[${id}\\\\]\\\\[mpn\\\\]`,
+				`#yoast_variation_identifier\\[${id}\\]\\[gtin14\\]`,
+				`#yoast_variation_identifier\\[${id}\\]\\[gtin14\\]`,
+				`#yoast_variation_identifier\\[${id}\\]\\[mpn\\]`,
 			];
 			const identifierInputFieldElements = identifierElementIds.map( elementId => element.querySelector( elementId ) );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds information about whether the product identifiers can be retrieved to the custom data. Sets the identifier to an empty string if it cannot be retrieved.

## Relevant technical choices:

* When retrieving the identifiers, if at least one of the identifier input fields cannot be retrieved, the `canRetrieveAllVariantIdentifiers` / `canRetrieveAllIdentifiers` variable is set to false. However, in the data that is sent to the paper, `canRetrieveGlobalIdentifier ` and `canRetrieveVariantIdentifiers` are only set to false when at least one identifier cannot be retrieved AND no other identifier field is filled in. This is because you only need to fill in one identifier to get a green bullet, so as long as one is filled in it doesn't matter if some other input fields cannot be retrieved.
* The function to get the identifiers is abstracted and used for both global identifiers and variant identifier.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions in the accompanying Free PR https://github.com/Yoast/wordpress-seo/pull/18941


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
