### PR TITLE
Improve Offers / priceSpecification output

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -62,6 +62,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			'woo_schema_brand'        => '',
 			'woo_schema_manufacturer' => '',
 			'woo_schema_color'        => '',
+			'woo_schema_pattern'      => '',
 			'woo_breadcrumbs'         => true,
 			'woo_metabox_top'         => true,
 		];
@@ -123,6 +124,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 					case 'woo_schema_brand':
 					case 'woo_schema_manufacturer':
 					case 'woo_schema_color':
+					case 'woo_schema_pattern':
 						if ( isset( $dirty[ $key ] ) ) {
 							if ( in_array( $dirty[ $key ], $valid_taxonomies, true ) ) {
 								$clean[ $key ] = $dirty[ $key ];

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -213,7 +213,7 @@ class WPSEO_WooCommerce_Schema {
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {
-				$data['offers'][ $key ]['@id']   = YoastSEO()->meta->for_current_page()->site_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
+				$data['offers'][ $key ]['@id'] = YoastSEO()->meta->for_current_page()->site_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
 
 				$data['offers'][ $key ]['priceSpecification']['@type'] = 'PriceSpecification';
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -351,14 +351,13 @@ class WPSEO_WooCommerce_Schema {
 
 		if ( ! empty( $data['offers'] ) ) {
 			foreach ( $data['offers'] as $key => $offer ) {
-				$data[ $key ]['seller'] = [
+				$data['offers'][ $key ]['seller'] = [
 					'@id' => trailingslashit( YoastSEO()->meta->for_current_page()->site_url ) . Schema_IDs::ORGANIZATION_HASH,
 				];
 			}
 		}
 
-		// We don't want an array with keys, we just need the offers.
-		return array_values( $data );
+		return $data;
 	}
 
 	/**
@@ -459,7 +458,7 @@ class WPSEO_WooCommerce_Schema {
 	}
 
 	/**
-	 * Adds the product color property to the Schema output.
+	 * Adds the product pattern property to the Schema output.
 	 *
 	 * @param WC_Product $product The product object.
 	 *

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -181,6 +181,7 @@ class WPSEO_WooCommerce_Schema {
 		$this->add_brand( $product );
 		$this->add_manufacturer( $product );
 		$this->add_color( $product );
+		$this->add_pattern( $product );
 		$this->add_global_identifier( $product );
 
 		/**
@@ -238,6 +239,7 @@ class WPSEO_WooCommerce_Schema {
 			}
 		}
 
+		// We don't want an array with keys, we just need the offers.
 		$data['offers'] = array_values( $data['offers'] );
 
 		return $data;
@@ -348,14 +350,15 @@ class WPSEO_WooCommerce_Schema {
 		}
 
 		if ( ! empty( $data['offers'] ) ) {
-			foreach ( $data['offers'] as $offer ) {
-				$offer['seller'] = [
+			foreach ( $data['offers'] as $key => $offer ) {
+				$data[ $key ]['seller'] = [
 					'@id' => trailingslashit( YoastSEO()->meta->for_current_page()->site_url ) . Schema_IDs::ORGANIZATION_HASH,
 				];
 			}
 		}
 
-		return $data;
+		// We don't want an array with keys, we just need the offers.
+		return array_values( $data );
 	}
 
 	/**
@@ -451,6 +454,30 @@ class WPSEO_WooCommerce_Schema {
 				}
 
 				$this->data['color'] = $colors;
+			}
+		}
+	}
+
+	/**
+	 * Adds the product color property to the Schema output.
+	 *
+	 * @param WC_Product $product The product object.
+	 *
+	 * @return void
+	 */
+	private function add_pattern( $product ) {
+		$schema_pattern = WPSEO_Options::get( 'woo_schema_pattern' );
+
+		if ( ! empty( $schema_pattern ) ) {
+			$terms = get_the_terms( $product->get_id(), $schema_pattern );
+
+			if ( is_array( $terms ) ) {
+				$patterns = [];
+				foreach ( $terms as $term ) {
+					$patterns[] = strtolower( $term->name );
+				}
+
+				$this->data['pattern'] = $patterns;
 			}
 		}
 	}

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -478,6 +478,7 @@ class Yoast_WooCommerce_SEO {
 		Yoast_Form::get_instance()->select( 'woo_schema_manufacturer', esc_html__( 'Manufacturer', 'yoast-woo-seo' ), $taxonomies );
 		Yoast_Form::get_instance()->select( 'woo_schema_brand', esc_html__( 'Brand', 'yoast-woo-seo' ), $taxonomies );
 		Yoast_Form::get_instance()->select( 'woo_schema_color', esc_html__( 'Color', 'yoast-woo-seo' ), $taxonomies );
+		Yoast_Form::get_instance()->select( 'woo_schema_pattern', esc_html__( 'Pattern', 'yoast-woo-seo' ), $taxonomies );
 
 		if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
 			echo '<h2>' . esc_html__( 'Breadcrumbs', 'yoast-woo-seo' ) . '</h2>';

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -41,12 +41,12 @@ class Schema_Test extends TestCase {
 
 		Monkey\Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
-			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->with( Mockery::anyOf( [ 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ] ) )
 			->andReturn( [] );
 
 		Monkey\Functions\expect( 'get_site_option' )
 			->zeroOrMoreTimes()
-			->with( Mockery::anyOf( 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ) )
+			->with( Mockery::anyOf( [ 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ] ) )
 			->andReturn( [] );
 
 		Mockery::mock( 'overload:Yoast\WP\SEO\Config\Schema_IDs', new Schema_IDs() );
@@ -1057,11 +1057,9 @@ class Schema_Test extends TestCase {
 		$canonical    = $base_url . 'product/test/';
 
 		$product = Mockery::mock( 'WC_Product' );
-		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
+		$product->expects( 'get_id' )->times( 7 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
-		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
@@ -1167,7 +1165,6 @@ class Schema_Test extends TestCase {
 			'offers'           => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '1.00',
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $base_url . '#organization',
@@ -1177,7 +1174,6 @@ class Schema_Test extends TestCase {
 						'valueAddedTaxIncluded' => false,
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
-					'priceCurrency'      => 'GBP',
 				],
 			],
 			'review'           => [
@@ -1200,7 +1196,7 @@ class Schema_Test extends TestCase {
 			'mainEntityOfPage' => [ '@id' => $canonical ],
 			'image'            => [ '@id' => $canonical . '#primaryimage' ],
 			'brand'            => [
-				'@type' => 'Organization',
+				'@type' => 'Brand',
 				'name'  => $product_name,
 			],
 			'manufacturer'     => [
@@ -1211,7 +1207,7 @@ class Schema_Test extends TestCase {
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->times( 5 )
+			->times( 6 )
 			->andReturn(
 				(object) [
 					'site_url'       => $base_url,
@@ -1242,11 +1238,9 @@ class Schema_Test extends TestCase {
 		$canonical    = $base_url . 'product/test/';
 
 		$product = Mockery::mock( 'WC_Product' );
-		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
+		$product->expects( 'get_id' )->times( 7 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
-		$product->expects( 'get_price' )->once()->andReturn( 1 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
@@ -1290,7 +1284,7 @@ class Schema_Test extends TestCase {
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->times( 5 )
+			->times( 6 )
 			->andReturn(
 				(object) [
 					'site_url'       => $base_url,
@@ -1357,7 +1351,6 @@ class Schema_Test extends TestCase {
 			'offers'           => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '1.00',
 					'url'                => $canonical,
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
@@ -1367,7 +1360,6 @@ class Schema_Test extends TestCase {
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
-					'priceCurrency'      => 'GBP',
 				],
 			],
 			'review'           => [
@@ -1396,7 +1388,7 @@ class Schema_Test extends TestCase {
 				'height' => 50,
 			],
 			'brand'            => [
-				'@type' => 'Organization',
+				'@type' => 'Brand',
 				'name'  => $product_name,
 			],
 			'manufacturer'     => [
@@ -1432,8 +1424,6 @@ class Schema_Test extends TestCase {
 		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
-		$product->expects( 'get_price' )->once()->with()->andReturn( 1 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->with()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
@@ -1441,7 +1431,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
-		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturn( 'product_cat' );
+		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturnNull();
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 
@@ -1472,7 +1462,7 @@ class Schema_Test extends TestCase {
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->times( 5 )
+			->times( 6 )
 			->andReturn(
 				(object) [
 					'site_url'       => $base_url,
@@ -1532,16 +1522,13 @@ class Schema_Test extends TestCase {
 			'offers'           => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '1.00',
 					'url'                => $canonical,
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
-					'priceCurrency'      => 'GBP',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
-						'valueAddedTaxIncluded' => false,
 					],
 				],
 			],
@@ -1565,7 +1552,7 @@ class Schema_Test extends TestCase {
 			'mainEntityOfPage' => [ '@id' => $canonical ],
 			'image'            => [ '@id' => $canonical . '#primaryimage' ],
 			'brand'            => [
-				'@type' => 'Organization',
+				'@type' => 'Brand',
 				'name'  => $product_name,
 			],
 			'manufacturer'     => [
@@ -1679,13 +1666,13 @@ class Schema_Test extends TestCase {
 			'offers'      => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '49.00',
 					'priceValidUntil'    => '2020-03-24',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
+						'price'                 => '49.00',
 					],
-					'priceCurrency'      => 'GBP',
 					'availability'       => 'https://schema.org/InStock',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
@@ -1697,8 +1684,9 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$expected_output                     = $input;
-		$expected_output['offers'][0]['@id'] = 'http://example.com/#/schema/offer/209643-0';
+		$expected_output                        = $input;
+		$expected_output['offers'][0]['@id']    = 'http://example.com/#/schema/offer/209643-0';
+		$expected_output['offers'][0]['seller'] = [ '@id' => 'http://example.com/#organization' ];
 
 		Functions\stubs(
 			[
@@ -1713,15 +1701,13 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
-		$product->expects( 'get_price' )->once()->andReturn( 49 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( true );
 		$product->expects( 'get_date_on_sale_to' )->once()->andReturn( 'not-a-null-value' );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->once()
+			->twice()
 			->andReturn( (object) [ 'site_url' => 'http://example.com/' ] );
 
 		$output = $schema->filter_offers( $input, $product );
@@ -1789,12 +1775,12 @@ class Schema_Test extends TestCase {
 			'offers'      => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '49.00',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
-						'valueAddedTaxIncluded' => false,
+						'valueAddedTaxIncluded' => true,
+						'price'                 => '49.00',
+						'priceCurrency'         => 'GBP',
 					],
-					'priceCurrency'      => 'GBP',
 					'availability'       => 'https://schema.org/InStock',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
@@ -1806,12 +1792,12 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$expected_output                     = $input;
-		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
-		$expected_output['offers'][0]['priceSpecification']['@type']                 = 'PriceSpecification';
-		$expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] = true;
+		$expected_output                        = $input;
+		$expected_output['offers'][0]['@id']    = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output['offers'][0]['seller'] = [ '@id' => 'https://example.com/#organization' ];
+		$expected_output['offers'][0]['priceSpecification']['@type'] = 'PriceSpecification';
 
-		$base_url = 'http://example.com';
+		$base_url = 'https://example.com';
 		Functions\stubs(
 			[
 				'get_site_url'             => $base_url,
@@ -1831,14 +1817,12 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
-		$product->expects( 'get_price' )->once()->andReturn( 49 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->once()
+			->twice()
 			->andReturn( (object) [ 'site_url' => 'https://example.com/' ] );
 
 		$output = $schema->filter_offers( $input, $product );

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1069,6 +1069,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
+		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 
@@ -1253,6 +1254,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
+		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 
@@ -1439,6 +1441,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_brand' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
+		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -94,10 +94,16 @@ class Schema_Test extends TestCase {
 	 */
 	public function test_construct_old_wc() {
 		$schema = new WPSEO_WooCommerce_Schema( '3.8' );
-		$this->assertSame( 10, \has_filter( 'woocommerce_structured_data_review', [
-			$schema,
-			'change_reviewed_entity'
-		] ) );
+		$this->assertSame(
+			10,
+			\has_filter(
+				'woocommerce_structured_data_review',
+				[
+					$schema,
+					'change_reviewed_entity',
+				]
+			)
+		);
 	}
 
 	/**
@@ -119,12 +125,12 @@ class Schema_Test extends TestCase {
 
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
-			  ->andReturnUsing(
-				  static function( $data ) {
-					  // phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
-					  return \json_encode( $data );
-				  }
-			  );
+			->andReturnUsing(
+				static function( $data ) {
+					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
+					return \json_encode( $data );
+				}
+			);
 
 		$schema->data = $data;
 		$schema->output_schema_footer();
@@ -1086,9 +1092,9 @@ class Schema_Test extends TestCase {
 
 		$instance = Mockery::mock( Schema_Double::class )->makePartial();
 		$instance->expects( 'get_primary_term_or_first_term' )
-				 ->twice()
-				 ->with( 'product_cat', 1 )
-				 ->andReturn( (object) [ 'name' => $product_name ] );
+				->twice()
+				->with( 'product_cat', 1 )
+				->andReturn( (object) [ 'name' => $product_name ] );
 
 		$image_data   = [
 			'url'    => $base_url . '/example_image.jpg',
@@ -1097,13 +1103,13 @@ class Schema_Test extends TestCase {
 		];
 		$schema_image = Mockery::mock( 'overload:WPSEO_Schema_Image' );
 		$schema_image->expects( '__construct' )
-					 ->once()
-					 ->with( $canonical . '#woocommerceimageplaceholder' )
-					 ->andReturnSelf();
+				->once()
+					->with( $canonical . '#woocommerceimageplaceholder' )
+					->andReturnSelf();
 		$schema_image->expects( 'generate_from_url' )
-					 ->once()
-					 ->with( $base_url . '/example_image.jpg' )
-					 ->andReturn( $image_data );
+				->once()
+					->with( $base_url . '/example_image.jpg' )
+					->andReturn( $image_data );
 
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
@@ -1268,9 +1274,9 @@ class Schema_Test extends TestCase {
 
 		$instance = Mockery::mock( Schema_Double::class )->makePartial();
 		$instance->expects( 'get_primary_term_or_first_term' )
-				 ->twice()
-				 ->with( 'product_cat', 1 )
-				 ->andReturn( (object) [ 'name' => $product_name ] );
+				->twice()
+				->with( 'product_cat', 1 )
+				->andReturn( (object) [ 'name' => $product_name ] );
 
 		$image_data = [
 			'@type'  => 'ImageObject',
@@ -1457,9 +1463,9 @@ class Schema_Test extends TestCase {
 
 		$instance = Mockery::mock( Schema_Double::class )->makePartial();
 		$instance->expects( 'get_primary_term_or_first_term' )
-				 ->twice()
-				 ->with( 'product_cat', 1 )
-				 ->andReturn( (object) [ 'name' => $product_name ] );
+				->twice()
+				->with( 'product_cat', 1 )
+				->andReturn( (object) [ 'name' => $product_name ] );
 
 		$this->meta
 			->expects( 'for_current_page' )
@@ -1797,8 +1803,8 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$expected_output                                                             = $input;
-		$expected_output['offers'][0]['@id']                                         = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output                     = $input;
+		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
 		$expected_output['offers'][0]['priceSpecification']['@type']                 = 'PriceSpecification';
 		$expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] = true;
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -94,7 +94,10 @@ class Schema_Test extends TestCase {
 	 */
 	public function test_construct_old_wc() {
 		$schema = new WPSEO_WooCommerce_Schema( '3.8' );
-		$this->assertSame( 10, \has_filter( 'woocommerce_structured_data_review', [ $schema, 'change_reviewed_entity' ] ) );
+		$this->assertSame( 10, \has_filter( 'woocommerce_structured_data_review', [
+			$schema,
+			'change_reviewed_entity'
+		] ) );
 	}
 
 	/**
@@ -116,12 +119,12 @@ class Schema_Test extends TestCase {
 
 		$utils = Mockery::mock( 'alias:WPSEO_Utils' );
 		$utils->expects( 'format_json_encode' )
-			->andReturnUsing(
-				static function( $data ) {
-					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
-					return \json_encode( $data );
-				}
-			);
+			  ->andReturnUsing(
+				  static function( $data ) {
+					  // phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encode -- Can't use it, since we are mocking it here.
+					  return \json_encode( $data );
+				  }
+			  );
 
 		$schema->data = $data;
 		$schema->output_schema_footer();
@@ -238,12 +241,12 @@ class Schema_Test extends TestCase {
 			'offers'      => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '49.00',
 					'priceSpecification' => [
+						'price'                 => '49.00',
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
 					],
-					'priceCurrency'      => 'GBP',
 					'availability'       => 'https://schema.org/InStock',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
@@ -255,15 +258,16 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$expected_output                     = $input;
-		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output                        = $input;
+		$expected_output['offers'][0]['@id']    = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output['offers'][0]['seller'] = [ '@id' => 'https://example.com/#organization' ];
 
 		Functions\stubs(
 			[
 				'get_site_url'             => 'http://example.com',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -273,14 +277,12 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
-		$product->expects( 'get_price' )->once()->andReturn( 49 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->once()
+			->twice()
 			->andReturn( (object) [ 'site_url' => 'https://example.com/' ] );
 
 		$output = $schema->filter_offers( $input, $product );
@@ -307,12 +309,12 @@ class Schema_Test extends TestCase {
 			'offers'      => [
 				[
 					'@type'              => 'Offer',
-					'price'              => '49.00',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
+						'price'                 => '49.00',
+						'priceCurrency'         => 'GBP',
 					],
-					'priceCurrency'      => 'GBP',
 					'availability'       => 'https://schema.org/PreOrder',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/',
 					'seller'             => [
@@ -324,15 +326,16 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$expected_output                     = $input;
-		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output                        = $input;
+		$expected_output['offers'][0]['@id']    = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output['offers'][0]['seller'] = [ '@id' => 'https://example.com/#organization' ];
 
 		Functions\stubs(
 			[
 				'get_site_url'             => 'http://example.com',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -342,14 +345,12 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
-		$product->expects( 'get_price' )->once()->andReturn( 49 );
-		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( true );
 
 		$this->meta
 			->expects( 'for_current_page' )
-			->once()
+			->twice()
 			->andReturn( (object) [ 'site_url' => 'https://example.com/' ] );
 
 		$output = $schema->filter_offers( $input, $product );
@@ -603,11 +604,11 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'@id'                => 'https://example.com/#/schema/offer/209643-0',
 					'name'               => 'Customizable responsive toolset - l',
-					'price'              => 10,
-					'priceCurrency'      => 'GBP',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/?attribute_pa_size=l',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
+						'price'                 => 10,
+						'priceCurrency'         => 'GBP',
 						'valueAddedTaxIncluded' => false,
 					],
 					'sku'                => '209643',
@@ -617,11 +618,11 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'@id'                => 'https://example.com/#/schema/offer/209643-1',
 					'name'               => 'Customizable responsive toolset - m',
-					'price'              => 8,
-					'priceCurrency'      => 'GBP',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/?attribute_pa_size=m',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
+						'price'                 => 8,
+						'priceCurrency'         => 'GBP',
 						'valueAddedTaxIncluded' => false,
 					],
 					'sku'                => '209644',
@@ -632,11 +633,11 @@ class Schema_Test extends TestCase {
 					'@type'              => 'Offer',
 					'@id'                => 'https://example.com/#/schema/offer/209643-2',
 					'name'               => 'Customizable responsive toolset - xl',
-					'price'              => 12,
-					'priceCurrency'      => 'GBP',
 					'url'                => 'https://example.com/product/customizable-responsive-toolset/?attribute_pa_size=xl',
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
+						'price'                 => 12,
+						'priceCurrency'         => 'GBP',
 						'valueAddedTaxIncluded' => false,
 					],
 					'sku'                => '209645',
@@ -1075,7 +1076,7 @@ class Schema_Test extends TestCase {
 				'wc_placeholder_img_src'   => $base_url . 'example_image.jpg',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -1085,9 +1086,9 @@ class Schema_Test extends TestCase {
 
 		$instance = Mockery::mock( Schema_Double::class )->makePartial();
 		$instance->expects( 'get_primary_term_or_first_term' )
-			->twice()
-			->with( 'product_cat', 1 )
-			->andReturn( (object) [ 'name' => $product_name ] );
+				 ->twice()
+				 ->with( 'product_cat', 1 )
+				 ->andReturn( (object) [ 'name' => $product_name ] );
 
 		$image_data   = [
 			'url'    => $base_url . '/example_image.jpg',
@@ -1096,13 +1097,13 @@ class Schema_Test extends TestCase {
 		];
 		$schema_image = Mockery::mock( 'overload:WPSEO_Schema_Image' );
 		$schema_image->expects( '__construct' )
-			->once()
-			->with( $canonical . '#woocommerceimageplaceholder' )
-			->andReturnSelf();
+					 ->once()
+					 ->with( $canonical . '#woocommerceimageplaceholder' )
+					 ->andReturnSelf();
 		$schema_image->expects( 'generate_from_url' )
-			->once()
-			->with( $base_url . '/example_image.jpg' )
-			->andReturn( $image_data );
+					 ->once()
+					 ->with( $base_url . '/example_image.jpg' )
+					 ->andReturn( $image_data );
 
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );
 
@@ -1257,7 +1258,7 @@ class Schema_Test extends TestCase {
 				'wc_placeholder_img_src'   => $base_url . 'example_image.jpg',
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -1267,9 +1268,9 @@ class Schema_Test extends TestCase {
 
 		$instance = Mockery::mock( Schema_Double::class )->makePartial();
 		$instance->expects( 'get_primary_term_or_first_term' )
-			->twice()
-			->with( 'product_cat', 1 )
-			->andReturn( (object) [ 'name' => $product_name ] );
+				 ->twice()
+				 ->with( 'product_cat', 1 )
+				 ->andReturn( (object) [ 'name' => $product_name ] );
 
 		$image_data = [
 			'@type'  => 'ImageObject',
@@ -1447,7 +1448,7 @@ class Schema_Test extends TestCase {
 				],
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -1456,9 +1457,9 @@ class Schema_Test extends TestCase {
 
 		$instance = Mockery::mock( Schema_Double::class )->makePartial();
 		$instance->expects( 'get_primary_term_or_first_term' )
-			->twice()
-			->with( 'product_cat', 1 )
-			->andReturn( (object) [ 'name' => $product_name ] );
+				 ->twice()
+				 ->with( 'product_cat', 1 )
+				 ->andReturn( (object) [ 'name' => $product_name ] );
 
 		$this->meta
 			->expects( 'for_current_page' )
@@ -1694,7 +1695,7 @@ class Schema_Test extends TestCase {
 			[
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => false,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',
@@ -1796,8 +1797,8 @@ class Schema_Test extends TestCase {
 			],
 		];
 
-		$expected_output                     = $input;
-		$expected_output['offers'][0]['@id'] = 'https://example.com/#/schema/offer/209643-0';
+		$expected_output                                                             = $input;
+		$expected_output['offers'][0]['@id']                                         = 'https://example.com/#/schema/offer/209643-0';
 		$expected_output['offers'][0]['priceSpecification']['@type']                 = 'PriceSpecification';
 		$expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] = true;
 
@@ -1807,7 +1808,7 @@ class Schema_Test extends TestCase {
 				'get_site_url'             => $base_url,
 				'wc_get_price_decimals'    => 2,
 				'wc_tax_enabled'           => true,
-				'wc_format_decimal'        => static function ( $number ) {
+				'wc_format_decimal'        => static function( $number ) {
 					return \number_format( $number, 2 );
 				},
 				'get_woocommerce_currency' => 'GBP',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve `Offers` / `priceSpecification` output to match Google's recent changes to their guidelines.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the Schema output for for `Offers` and `priceSpecification` to match Google's recent changes to their guidelines.
* Adds a feature to select a custom taxonomy for products to describe their `pattern` in the Schema output.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Product Schema changes
* Add some brands and manufacturers in Yoast SEO > WooCommerce SEO (the instructions are the same as per "Pattern" below)
* Create and publish some products (at least a simple one and a variable one)
* See that in the schema for `Product` > `offers` the `price` and `priceCurrency` properties have been moved inside `priceSpecification`
* See that the Schema has the correct `brand` and `manufacturer` properties: the former is of type `Brand`, the latter is of type "Organization"
```
"brand": {
  "@type": "Brand",
  "name": "Nike"
},
"manufacturer": {
  "@type": "Organization",
  "name": "Superga"
},
```
* check their Schema on the three tools we use
  * the changes should fix the issues in the Google Search Console about these two errors: `Invalid object type for field "brand"` and `Missing field "priceType"`
  * but we have to make sure we are not introducing errors in the other two validation tools.

#### Pattern
* visit Products > Attributes and add a new attribute for patterns
  * populate it with some terms
* visit Yoast SEO > WooCommerce SEO
  * see that there is a new "Pattern" dropdown
  * select the attribute we're dealing with and save the options
* edit a product
  * under Attributes, add the attribute you just created
  * populate it with some of the terms you created above 
  * Publish the product
* inspect the Schema of the product in the front-end
  * in the `Product` piece, you should see a "pattern" property which should be an array of the values you added to the Product

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/browse/IM-1962