### PR TITLE
PC-613-product-identifier-feedback-only-updates-when-you-click-on-the-page

### DIFF
--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -363,14 +363,14 @@ function registerEventListeners() {
 
 	// Detect changes in the variation product identifiers and handle them.
 	jQuery( document.body ).on(
-		"change", "#variable_product_options .woocommerce_variations :input[id^=yoast_variation_identifier]",
+		"input", "#variable_product_options .woocommerce_variations :input[id^=yoast_variation_identifier]",
 		YoastSEO.app.refresh
 	);
 
 	if ( canRetrieveVariantSkus ) {
 		// Detect changes in the variation SKU identifiers and handle them.
 		jQuery( document.body ).on(
-			"change", "#variable_product_options .woocommerce_variations :input[id^=variable_sku]",
+			"input", "#variable_product_options .woocommerce_variations :input[id^=variable_sku]",
 			YoastSEO.app.refresh
 		);
 	}

--- a/js/src/yoastseo-woo-identifiers.js
+++ b/js/src/yoastseo-woo-identifiers.js
@@ -343,13 +343,13 @@ function registerEventListeners() {
 	// Register event listeners for the global identifier inputs (non-variation);
 	identifierKeys.forEach( key => {
 		const globalIdentifierInput = document.getElementById( `yoast_identifier_${ key }` );
-		globalIdentifierInput.addEventListener( "change", YoastSEO.app.refresh );
+		globalIdentifierInput.addEventListener( "input", YoastSEO.app.refresh );
 	} );
 
 	// Register event listeners for the global sku input from Woocommerce (non-variation);
 	const globalSkuInput = document.getElementById( "_sku" );
 	if ( globalSkuInput ) {
-		globalSkuInput.addEventListener( "change", YoastSEO.app.refresh );
+		globalSkuInput.addEventListener( "input", YoastSEO.app.refresh );
 	}
 
 	// Detect changes in the product type.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Identifier assessment was only updated once the input field was 'un-focused' by clicking elsewhere on the page. This was not true for the SKU assessment.
* This PR fixes that by changing the type of event-listener.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Product identifier assessment was only updated once the identifier field was de-focussed.

## Relevant technical choices:

* Also changed the event listener type for the sku input field. This worked before this PR. But I think it is better to keep the listeners to sku and identifier uniform. I added test instruction to also check sku.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a simple product.
* Make sure that the SKU assessment gives the following feedback:

> SKU: Your product is missing a SKU. You can add a SKU via the "Inventory" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.

* Make sure that the Product Identifier Assessment gives the following feedback:

> Product identifier: Your product is missing an identifier (like a GTIN code). You can add a product identifier via the "Yoast SEO" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.

#### SKU simple product
* Add a SKU. Don't un-select (de-focus) the SKU input field (i.e. don't click outside of it).
* Make sure the SKU assessment gives the following feedback

> SKU: Your product has a SKU. Good job!

* Remove the SKU. Don't un focus the input field.
* Make sure the SKU assessment gives the following feedback.

> SKU: Your product is missing a SKU. You can add a SKU via the "Inventory" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.

#### Product Identifiers
* For all of the types of product identifier (`GTIN8`, `GTIN12`, `GTIN13`, `GTIN14`, `ISBN`, `MPN`) do the following:
  * Add an identifier. Don't un-focus the input field.
  * Make sure the Product Identifier assessment gives the following feedback

> Product identifier: Your product has an identifier. Good job!

  * Remove the identifier. Don't un-focus the input field.
  * Make sure the Product Identifier assessment gives the following feedback

> Product identifier: Your product is missing an identifier (like a GTIN code). You can add a product identifier via the "Yoast SEO" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.

#### Variable product
* Create a variable product with a few variants (3 or 5 must be enough)

* Make sure the Premium SEO analysis in the metabox is expanded. Otherwise you cannot check the assessments without unfocussing the input fields.

* Add a SKU to all variants. Don't un-focus the input field after you added the last sku.
* Make sure the SKU assessment gives the following feedback:

> SKU: All your product variants have a SKU. Good job!

* Remove the sku of one variant. Don't un-focus the input field.
* Make sure the SKU assessment gives the following feedback:

> SKU: Not all your product variants have a SKU. You can add a SKU via the "Variations" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.

* Add a Product Identifier (just one type of product identifier (e.g. `GTIN8` suffices) to all variants. Don't un-focus the input field after you added the last Product Identifier.
* Make sure the Product Identifier Assessment gives the following feedback

> Product identifier: All your product variants have an identifier. Good job!

* Remove the Product Identifier of one variant. Don't un-focus the input field.
* Make sure the SKU assessment gives the following feedback:

> Product identifier: Not all your product variants have an identifier. You can add a product identifier via the "Variations" tab in the Product data box. Include it if you can, as it will help search engines to better understand your content.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
