### PR TITLE
PC-626 Fix the `color` and `pattern` output

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -449,9 +449,11 @@ class WPSEO_WooCommerce_Schema {
 			if ( is_array( $terms ) ) {
 				// Variable products can have more than one color.
 				$is_variable_product = false;
-				foreach ( $this->data['offers'] as $offer ) {
-					if ( $offer['@type'] === 'AggregateOffer' ) {
-						$is_variable_product = true;
+				if ( isset( $data['offers'] ) ) {
+					foreach ( $this->data['offers'] as $offer ) {
+						if ( $offer['@type'] === 'AggregateOffer' ) {
+							$is_variable_product = true;
+						}
 					}
 				}
 
@@ -489,9 +491,11 @@ class WPSEO_WooCommerce_Schema {
 			if ( is_array( $terms ) ) {
 				// Variable products can have more than one pattern.
 				$is_variable_product = false;
-				foreach ( $this->data['offers'] as $offer ) {
-					if ( $offer['@type'] === 'AggregateOffer' ) {
-						$is_variable_product = true;
+				if ( isset( $data['offers'] ) ) {
+					foreach ( $this->data['offers'] as $offer ) {
+						if ( $offer['@type'] === 'AggregateOffer' ) {
+							$is_variable_product = true;
+						}
 					}
 				}
 

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -449,7 +449,7 @@ class WPSEO_WooCommerce_Schema {
 			if ( is_array( $terms ) ) {
 				// Variable products can have more than one color.
 				$is_variable_product = false;
-				if ( isset( $data['offers'] ) ) {
+				if ( isset( $this->data['offers'] ) ) {
 					foreach ( $this->data['offers'] as $offer ) {
 						if ( $offer['@type'] === 'AggregateOffer' ) {
 							$is_variable_product = true;
@@ -491,7 +491,7 @@ class WPSEO_WooCommerce_Schema {
 			if ( is_array( $terms ) ) {
 				// Variable products can have more than one pattern.
 				$is_variable_product = false;
-				if ( isset( $data['offers'] ) ) {
+				if ( isset( $this->data['offers'] ) ) {
 					foreach ( $this->data['offers'] as $offer ) {
 						if ( $offer['@type'] === 'AggregateOffer' ) {
 							$is_variable_product = true;

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -436,6 +436,8 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Adds the product color property to the Schema output.
 	 *
+	 * Adds the property if only one color has been added to the Product.
+	 *
 	 * @param WC_Product $product The product object.
 	 *
 	 * @return void
@@ -446,19 +448,17 @@ class WPSEO_WooCommerce_Schema {
 		if ( ! empty( $schema_color ) ) {
 			$terms = get_the_terms( $product->get_id(), $schema_color );
 
-			if ( is_array( $terms ) ) {
-				$colors = [];
-				foreach ( $terms as $term ) {
-					$colors[] = strtolower( $term->name );
-				}
-
-				$this->data['color'] = $colors;
+			if ( is_array( $terms ) && count( $terms ) === 1 ) {
+				$term                = reset( $terms );
+				$this->data['color'] = strtolower( $term->name );
 			}
 		}
 	}
 
 	/**
 	 * Adds the product pattern property to the Schema output.
+	 *
+	 * Adds the property if only one pattern has been added to the Product.
 	 *
 	 * @param WC_Product $product The product object.
 	 *
@@ -470,13 +470,9 @@ class WPSEO_WooCommerce_Schema {
 		if ( ! empty( $schema_pattern ) ) {
 			$terms = get_the_terms( $product->get_id(), $schema_pattern );
 
-			if ( is_array( $terms ) ) {
-				$patterns = [];
-				foreach ( $terms as $term ) {
-					$patterns[] = strtolower( $term->name );
-				}
-
-				$this->data['pattern'] = $patterns;
+			if ( is_array( $terms ) && count( $terms ) === 1 ) {
+				$term                  = reset( $terms );
+				$this->data['pattern'] = strtolower( $term->name );
 			}
 		}
 	}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -496,7 +496,7 @@ class WPSEO_WooCommerce_Schema {
 				}
 
 				if ( ! $is_variable_product ) {
-					if ( count( $terms ) === 1) {
+					if ( count( $terms ) === 1 ) {
 						$term                  = reset( $terms );
 						$this->data['pattern'] = strtolower( $term->name );
 					}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -436,8 +436,6 @@ class WPSEO_WooCommerce_Schema {
 	/**
 	 * Adds the product color property to the Schema output.
 	 *
-	 * Adds the property if only one color has been added to the Product.
-	 *
 	 * @param WC_Product $product The product object.
 	 *
 	 * @return void
@@ -448,17 +446,35 @@ class WPSEO_WooCommerce_Schema {
 		if ( ! empty( $schema_color ) ) {
 			$terms = get_the_terms( $product->get_id(), $schema_color );
 
-			if ( is_array( $terms ) && count( $terms ) === 1 ) {
-				$term                = reset( $terms );
-				$this->data['color'] = strtolower( $term->name );
+			if ( is_array( $terms ) ) {
+				// Variable products can have more than one color.
+				$is_variable_product = false;
+				foreach ( $this->data['offers'] as $offer ) {
+					if ( $offer['@type'] === 'AggregateOffer' ) {
+						$is_variable_product = true;
+					}
+				}
+
+				if ( ! $is_variable_product ) {
+					if ( count( $terms ) === 1 ) {
+						$term                = reset( $terms );
+						$this->data['color'] = strtolower( $term->name );
+					}
+				}
+				else {
+					$colors = [];
+					foreach ( $terms as $term ) {
+						$colors[] = strtolower( $term->name );
+					}
+
+					$this->data['color'] = $colors;
+				}
 			}
 		}
 	}
 
 	/**
 	 * Adds the product pattern property to the Schema output.
-	 *
-	 * Adds the property if only one pattern has been added to the Product.
 	 *
 	 * @param WC_Product $product The product object.
 	 *
@@ -470,9 +486,29 @@ class WPSEO_WooCommerce_Schema {
 		if ( ! empty( $schema_pattern ) ) {
 			$terms = get_the_terms( $product->get_id(), $schema_pattern );
 
-			if ( is_array( $terms ) && count( $terms ) === 1 ) {
-				$term                  = reset( $terms );
-				$this->data['pattern'] = strtolower( $term->name );
+			if ( is_array( $terms ) ) {
+				// Variable products can have more than one pattern.
+				$is_variable_product = false;
+				foreach ( $this->data['offers'] as $offer ) {
+					if ( $offer['@type'] === 'AggregateOffer' ) {
+						$is_variable_product = true;
+					}
+				}
+
+				if ( ! $is_variable_product ) {
+					if ( count( $terms ) === 1) {
+						$term                  = reset( $terms );
+						$this->data['pattern'] = strtolower( $term->name );
+					}
+				}
+				else {
+					$colors = [];
+					foreach ( $terms as $term ) {
+						$colors[] = strtolower( $term->name );
+					}
+
+					$this->data['pattern'] = $colors;
+				}
 			}
 		}
 	}

--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -457,13 +457,11 @@ class WPSEO_WooCommerce_Schema {
 					}
 				}
 
-				if ( ! $is_variable_product ) {
-					if ( count( $terms ) === 1 ) {
-						$term                = reset( $terms );
-						$this->data['color'] = strtolower( $term->name );
-					}
+				if ( count( $terms ) === 1 ) {
+					$term                = reset( $terms );
+					$this->data['color'] = strtolower( $term->name );
 				}
-				else {
+				elseif ( $is_variable_product ) {
 					$colors = [];
 					foreach ( $terms as $term ) {
 						$colors[] = strtolower( $term->name );
@@ -499,13 +497,11 @@ class WPSEO_WooCommerce_Schema {
 					}
 				}
 
-				if ( ! $is_variable_product ) {
-					if ( count( $terms ) === 1 ) {
-						$term                  = reset( $terms );
-						$this->data['pattern'] = strtolower( $term->name );
-					}
+				if ( count( $terms ) === 1 ) {
+					$term                  = reset( $terms );
+					$this->data['pattern'] = strtolower( $term->name );
 				}
-				else {
+				elseif ( $is_variable_product ) {
 					$colors = [];
 					foreach ( $terms as $term ) {
 						$colors[] = strtolower( $term->name );

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1440,9 +1440,6 @@ class Schema_Test extends TestCase {
 				'has_post_thumbnail'       => true,
 				'get_post_meta'            => false,
 				'get_the_terms'            => [
-					(object) [ 'name' => 'green' ],
-					(object) [ 'name' => 'white' ],
-					(object) [ 'name' => 'red' ],
 					(object) [ 'name' => 'UPPERCASECOLOR' ],
 				],
 				'wc_get_price_decimals'    => 2,
@@ -1559,12 +1556,7 @@ class Schema_Test extends TestCase {
 				'@type' => 'Organization',
 				'name'  => $product_name,
 			],
-			'color'            => [
-				'green',
-				'white',
-				'red',
-				'uppercasecolor',
-			],
+			'color'            => 'uppercasecolor',
 		];
 
 		$instance->change_product( $data, $product );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid the GSC tool to display a "Duplicate field" warning when `pattern` or `color` are set to an array of multiple element.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Product Schema output would trigger a "Duplicate field" warning for the `color` property for non-variable products.
 
## Relevant technical choices:

* the changelog lines mentions only the `color` property because the `pattern` one is being introduced in this version.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create two attributes, one for color and the other for pattern
* add some terms to both
* in the WooCommerce SEO settings, set the attributes to color and pattern
* Create a new product (either Simple, Grouped or External)
* under Attributes, add the attributes you just created
* populate each one with just **one** terms you created above
* Publish the product
* Inspect the schema and see that the `color` and `pattern` properties display a single value, e.g.:
```
"color": "green",
"pattern": "v-shape"
```
* check the schema validators that they don't complain about those properties
* edit the product and add terms to the attributes so they don't have only one value each
* update the product
* Inspect the schema and see that the `color` and `pattern` properties are not displayed anymore.
* Create a new **Variable** product
* under Attributes, add the attributes you just created
* populate each one with just **one** terms you created above
* Publish the product
* Inspect the schema and see that the `color` and `pattern` properties display a single value, e.g.:
```
"color": "green",
"pattern": "v-shape"
```
* edit the product and add terms to the attributes so they don't have only one value each
* update the product
* Inspect the schema and see that the `color` and `pattern` properties are now displayed as arrays:
```
"color": [ "green", "red" ],
"pattern": [ "v-shape", "cross" ],
```
* check the schema validators that they don't complain about those properties

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [PC-626]


[PC-626]: https://yoast.atlassian.net/browse/PC-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ