### PR TITLE
Change image id from hash to image url

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -418,18 +418,18 @@ class WPSEO_WooCommerce_Schema {
 			unset( $this->data['image'] );
 		}
 
-		if ( has_post_thumbnail() ) {
+		if ( \has_post_thumbnail() ) {
 			$this->data['image'] = [
-				'@id' => YoastSEO()->meta->for_current_page()->canonical . Schema_IDs::PRIMARY_IMAGE_HASH,
+				'@id' => YoastSEO()->meta->for_current_page()->main_image_url,
 			];
 
 			return;
 		}
 
 		// Fallback to WooCommerce placeholder image.
-		if ( function_exists( 'wc_placeholder_img_src' ) ) {
+		if ( \function_exists( 'wc_placeholder_img_src' ) ) {
 			$image_schema_id     = YoastSEO()->meta->for_current_page()->canonical . '#woocommerceimageplaceholder';
-			$placeholder_img_src = wc_placeholder_img_src();
+			$placeholder_img_src = \wc_placeholder_img_src();
 			$this->data['image'] = YoastSEO()->helpers->schema->image->generate_from_url( $image_schema_id, $placeholder_img_src );
 		}
 	}

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1213,7 +1213,7 @@ class Schema_Test extends TestCase {
 				(object) [
 					'site_url'       => $base_url,
 					'main_schema_id' => $canonical,
-                    'main_image_url' => 'https://basic.wordpress.test/image.jpg',
+					'main_image_url' => 'https://basic.wordpress.test/image.jpg',
 				]
 			);
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1195,7 +1195,7 @@ class Schema_Test extends TestCase {
 				],
 			],
 			'mainEntityOfPage' => [ '@id' => $canonical ],
-			'image'            => [ '@id' => $canonical . '#primaryimage' ],
+			'image'            => [ '@id' => 'https://basic.wordpress.test/image.jpg' ],
 			'brand'            => [
 				'@type' => 'Brand',
 				'name'  => $product_name,
@@ -1212,8 +1212,8 @@ class Schema_Test extends TestCase {
 			->andReturn(
 				(object) [
 					'site_url'       => $base_url,
-					'canonical'      => $canonical,
 					'main_schema_id' => $canonical,
+                    'main_image_url' => 'https://basic.wordpress.test/image.jpg',
 				]
 			);
 
@@ -1466,7 +1466,7 @@ class Schema_Test extends TestCase {
 			->andReturn(
 				(object) [
 					'site_url'       => $base_url,
-					'canonical'      => $canonical,
+					'main_image_url' => 'https://basic.wordpress.test/image.jpg',
 					'main_schema_id' => $canonical,
 				]
 			);
@@ -1550,7 +1550,7 @@ class Schema_Test extends TestCase {
 				],
 			],
 			'mainEntityOfPage' => [ '@id' => $canonical ],
-			'image'            => [ '@id' => $canonical . '#primaryimage' ],
+			'image'            => [ '@id' => 'https://basic.wordpress.test/image.jpg' ],
 			'brand'            => [
 				'@type' => 'Brand',
 				'name'  => $product_name,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For the PR on Yoast SEO, we changed the `@id` of the `image`s in the schema to the URL of the image instead of the `#primaryimage` identifier. This PR fixes the change in ID for WooCommerce products.
* Note that this PR should be released together with [this PR](https://github.com/Yoast/wordpress-seo/pull/18916) in Yoast SEO.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjust the `@id` property of `image`s in the schema data to the URL of the image instead of the `#primaryimage` identifier.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate both Yoast SEO and Yoast SEO for WooCommerce.
* Create a product and *do not* add an image just yet.
* Check the page source of the product and see whether schema for the `Product` type *does not* have an `image` attribute (other than maybe the `#woocommerceimageplaceholder` one).
* Now add an image to the product.
* Check the page source once again and see whether the schema for the `Product` does have an `image` attribute and the attribute should be set to the absolute URL of the image.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [PC-19](https://yoast.atlassian.net/browse/PC-19) and [PC-20](https://yoast.atlassian.net/browse/PC-20)
