### PR TITLE
Add material to schema data output

### DIFF
--- a/classes/option-woo.php
+++ b/classes/option-woo.php
@@ -63,6 +63,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 			'woo_schema_manufacturer' => '',
 			'woo_schema_color'        => '',
 			'woo_schema_pattern'      => '',
+			'woo_schema_material'     => '',
 			'woo_breadcrumbs'         => true,
 			'woo_metabox_top'         => true,
 		];
@@ -125,6 +126,7 @@ if ( ! class_exists( 'WPSEO_Option_Woo' ) && class_exists( 'WPSEO_Option' ) ) {
 					case 'woo_schema_manufacturer':
 					case 'woo_schema_color':
 					case 'woo_schema_pattern':
+					case 'woo_schema_material':
 						if ( isset( $dirty[ $key ] ) ) {
 							if ( in_array( $dirty[ $key ], $valid_taxonomies, true ) ) {
 								$clean[ $key ] = $dirty[ $key ];

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -479,6 +479,7 @@ class Yoast_WooCommerce_SEO {
 		Yoast_Form::get_instance()->select( 'woo_schema_brand', esc_html__( 'Brand', 'yoast-woo-seo' ), $taxonomies );
 		Yoast_Form::get_instance()->select( 'woo_schema_color', esc_html__( 'Color', 'yoast-woo-seo' ), $taxonomies );
 		Yoast_Form::get_instance()->select( 'woo_schema_pattern', esc_html__( 'Pattern', 'yoast-woo-seo' ), $taxonomies );
+		Yoast_Form::get_instance()->select( 'woo_schema_material', esc_html__( 'Material', 'yoast-woo-seo' ), $taxonomies );
 
 		if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
 			echo '<h2>' . esc_html__( 'Breadcrumbs', 'yoast-woo-seo' ) . '</h2>';

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1068,6 +1068,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturn( 'product_cat' );
+		$mock->expects( 'get' )->once()->with( 'woo_schema_material' )->andReturn( '' );
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 
@@ -1249,6 +1250,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturn( 'product_cat' );
+		$mock->expects( 'get' )->once()->with( 'woo_schema_material' )->andReturn( '' );
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 
@@ -1432,6 +1434,7 @@ class Schema_Test extends TestCase {
 		$mock->expects( 'get' )->once()->with( 'woo_schema_manufacturer' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_color' )->andReturn( 'product_cat' );
 		$mock->expects( 'get' )->once()->with( 'woo_schema_pattern' )->andReturnNull();
+		$mock->expects( 'get' )->once()->with( 'woo_schema_material' )->andReturn( '' );
 		$mock->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 		$mock->expects( 'get' )->once()->with( 'company_name' )->andReturn( 'WP' );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `material` property to products' pages schema.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO and Yoast SEO for WooCommerce.
* Go to the administration dashboard and click on Yoast SEO -> WooCommerce SEO.
* Set the `Material` option to `Product categories`.
* Click on `Products` -> `Add new`.
* Set a name and price for the product. Also add a category.
* Go to the product page, inspect the source code and scroll down to the product schema data.
* Observe that in the Product type a `material` item exists which is set to the product category.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [PC-627](https://yoast.atlassian.net/browse/PC-627)
