### PR TITLE
Gh Actions: various tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -49,6 +49,9 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a week - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -54,8 +54,9 @@ jobs:
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Check PHP code style
-        continue-on-error: true
+        id: phpcs
         run: composer check-cs -- --report-full --report-checkstyle=./phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,7 +152,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           shortsha=$(echo "$SHA" | cut -b 1-6)
-          echo "::set-output name=SHORTSHA::$shortsha"
+          echo "SHORTSHA=$shortsha" >> $GITHUB_OUTPUT
 
       - name: "Set variables: target branch, commit title"
         id: set_vars
@@ -160,14 +160,14 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${{ github.event_name }}" == 'push' && "${{ github.ref_type }}" == 'branch' && "$REF_NAME" != "${{ env.DIST_DEFAULT_BRANCH }}" ]]; then
-            echo "::set-output name=BRANCH::$REF_NAME"
-            echo "::set-output name=TITLE::Syncing branch $REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})"
+            echo "BRANCH=$REF_NAME" >> $GITHUB_OUTPUT
+            echo "TITLE=Syncing branch $REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "$REF_NAME" != "${{ env.DIST_DEFAULT_BRANCH }}" ]]; then
-            echo "::set-output name=BRANCH::$REF_NAME"
-            echo "::set-output name=TITLE::Manual deploy for $REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})"
+            echo "BRANCH=$REF_NAME" >> $GITHUB_OUTPUT
+            echo "TITLE=Manual deploy for $REF_NAME (sha: ${{ steps.set_sha.outputs.SHORTSHA }})" >> $GITHUB_OUTPUT
           else # = Pushed tag.
-            echo "::set-output name=BRANCH::${{ env.DIST_DEFAULT_BRANCH }}"
-            echo "::set-output name=TITLE::Release $REF_NAME"
+            echo "BRANCH=${{ env.DIST_DEFAULT_BRANCH }}" >> $GITHUB_OUTPUT
+            echo "TITLE=Release $REF_NAME" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout Yoast Dist repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,9 @@ jobs:
       # defined dependencies for yoastseo installed and the build will fail.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a week - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       - name: "Debug info: show directory layout"
         run: tree -dC .

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -100,6 +100,8 @@ jobs:
           dependency-versions: "highest"
           # But make it selective.
           composer-options: "yoast/wp-test-utils --with-dependencies"
+          # Bust the cache at least once a week - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       # Update YoastSEO as a separate step so the caches will be reasonably stable.
       # This also prevents potentially updating dependencies of YoastSEO due to the above

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,6 +59,9 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a week - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,9 +31,6 @@ jobs:
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 
-    # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.2' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -64,6 +64,8 @@ jobs:
           dependency-versions: "highest"
           # But make it selective.
           composer-options: "yoast/wp-test-utils --with-dependencies"
+          # Bust the cache at least once a week - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       - name: Run unit tests
         run: composer test


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

### GH Actions: fix use of deprecated set-output

GitHub has deprecated the use of `set-output` (and `set-state`) in favour of new environment files.

This commit updates workflows to use the new methodology.

Refs:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.

### GH Actions: bust the cache semi-regularly

Caches used in GH Actions do not get updated, they can only be replaced by a different cache with a different cache key.

Now the predefined Composer install action this repo is using already creates a pretty comprehensive cache key:

> `ramsey/composer-install` will auto-generate a cache key which is composed of
the following elements:
> * The OS image name, like `ubuntu-latest`.
> * The exact PHP version, like `8.1.11`.
> * The options passed via `composer-options`.
> * The dependency version setting as per `dependency-versions`.
> * The working directory as per `working-directory`.
> * A hash of the `composer.json` and/or `composer.lock` files.

This means that aside from other factors, the cache will always be busted when changes are made to the (committed) `composer.json` or the `composer.lock` file (if the latter exists in the repo).

For packages running on recent versions of PHP, it also means that the cache will automatically be busted once a month when a new PHP version comes out.

#### The problem

For runs on older PHP versions which don't receive updates anymore, the cache will not be busted via new PHP version releases, so effectively, the cache will only be busted when a change is made to the `composer.json`/`composer.lock` file - which may not happen that frequently on low-traffic repos.

But... packages _in use_ on those older PHP versions - especially dependencies of declared dependencies - may still release new versions and those new versions will not exist in the cache and will need to be downloaded each time the action is run and over time the cache gets less and less relevant as more and more packages will need to be downloaded for each run.

#### The solution

To combat this issue, a new `custom-cache-suffix` option has been added to the Composer install action in version 2.2.0.
This new option allows for providing some extra information to add to the cache key, which allows for busting the cache based on your own additional criteria.

This commit implements the use of this `custom-cache-suffix` option for all relevant workflows in this repo.

Refs:
* https://github.com/ramsey/composer-install/#custom-cache-suffix
* https://github.com/ramsey/composer-install/releases/tag/2.2.0

### GH Actions: don't allow linting issues on PHP 8.2

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
