### PR TITLE
PHP 8.2 | Tests: fix some dynamic property creation errors in the tests

### DIFF
--- a/tests/classes/slack-test.php
+++ b/tests/classes/slack-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_WooCommerce_Slack;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
@@ -167,10 +168,10 @@ class Slack_Test extends TestCase {
 	 *
 	 * @param object $model The model.
 	 *
-	 * @return Mockery\MockInterface The mock presentation.
+	 * @return Indexable_Presentation|Mockery\MockInterface The mock presentation.
 	 */
 	private function mock_presentation( $model ) {
-		$presentation = Mockery::mock();
+		$presentation = Mockery::mock( Indexable_Presentation::class );
 
 		$presentation->model = $model;
 

--- a/tests/classes/twitter-test.php
+++ b/tests/classes/twitter-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_WooCommerce_Twitter;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\Woocommerce\Tests\TestCase;
 
 /**
@@ -137,10 +138,10 @@ class Twitter_Test extends TestCase {
 	 * @param object $context The meta context.
 	 * @param object $model   The model.
 	 *
-	 * @return Mockery\MockInterface The mock presentation
+	 * @return Indexable_Presentation|Mockery\MockInterface The mock presentation
 	 */
 	private function mock_presentation( $context, $model ) {
-		$presentation = Mockery::mock();
+		$presentation = Mockery::mock( Indexable_Presentation::class );
 
 		$presentation->context = $context;
 		$presentation->model   = $model;

--- a/tests/classes/woocommerce-yoast-ids-test.php
+++ b/tests/classes/woocommerce-yoast-ids-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\Woocommerce\Tests\Classes;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use stdClass;
 use WP_Post;
 use Yoast\WP\Woocommerce\Tests\Doubles\Yoast_Ids_Double;
 use Yoast\WP\Woocommerce\Tests\TestCase;
@@ -169,7 +170,7 @@ class WooCommerce_Yoast_Ids_Test extends TestCase {
 		$this->stubTranslationFunctions();
 		$this->stubEscapeFunctions();
 
-		$mock_variation              = Mockery::mock( WP_Post::class )->makePartial();
+		$mock_variation              = Mockery::mock( WP_Post::class, stdClass::class )->makePartial();
 		$mock_variation->post_parent = $post_id;
 		$mock_variation->ID          = $variation_id;
 


### PR DESCRIPTION
## Context

* Improve compatibility with PHP 8.2

## Summary

This PR can be summarized in the following changelog entry:

* Improve compatibility with PHP 8.2

## Relevant technical choices:

This is a test only change.

Mockery is used to create some anonymous mocks/mocks for unavailable classes and then either the tests or the code under test sets properties on those mock objects, which leads to "Creation of dynamic property ... is deprecated" notices on PHP 8.2.

To fix this, I'm proposing the following:
1. For the mock for an unavailable class - `WP_Post` in `WooCommerce_Yoast_Ids_Test` - let the mock `extend` `stdClass` to allow properties to be set. As the method under test does not have a type declaration for the expected parameter, this will not run into a `TypeError` and extending `stdClass` allows for setting dynamic properties on the mock.
2. For the other two cases, which were using fully anonymous mocks, but were mocking classes from YoastSEO Free, which are available during the test run, I'm proposing to mock the _actual_ class. The tests set the `$model` and the `$presentation` properties on the Mock, and as those properties are actually declared properties on the `Indexable_Presentation`, mocking the _real_ class solves the deprecations.
    As a side-note: mocking the _real_ class also makes the test more descriptive and will make potential future error messages _also_ more descriptive, which is why, IMO, this is a better choice than mocking `stdClass` (or using an anonymous mock) for these tests.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a test-only change.

If needs be:
* Check out `trunk`.
* Run the unit tests  on PHP 8.1 and see them pass.
* Run the unit tests on PHP 8.2 and see them fail with 7 errors.
* Check out this branch.
* Run the unit tests again on PHP 8.1 and PHP 8.2 and see them pass in both cases.

**Note:** once this PR has been merged, I will enable the running of the tests (both unit as well as integration) on PHP 8.2 in CI.
