### PR TITLE
GH Actions: run the tests against PHP 8.2

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -52,6 +52,11 @@ jobs:
             wp_version: 'latest'
             multisite: true
 
+          # WP 6.1 is the earliest version which supports PHP 8.2.
+          - php_version: '8.2'
+            wp_version: '6.1'
+            multisite: true
+
     name: "Integration Test: PHP ${{ matrix.php_version }} | WP ${{ matrix.wp_version }}${{ matrix.multisite == true && ' (+ ms)' || '' }}"
 
     # Allow builds to fail on as-of-yet unreleased WordPress versions.

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ['5.6', '7.0', '7.2', '7.4', '8.0', '8.1']
+        php_version: ['5.6', '7.0', '7.2', '7.4', '8.0', '8.1', '8.2']
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"
 


### PR DESCRIPTION
## Context

* CI maintenance

## Summary

This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

Turn on the tests for PHP 8.2 and as the tests currently pass without issue, don't allow the build to fail.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_