### PR TITLE
Fix the Schema for Product prices with and without taxes

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -214,9 +214,17 @@ class WPSEO_WooCommerce_Schema {
 
 			// Add an @id to the offer.
 			if ( $offer['@type'] === 'Offer' ) {
+				$price                         = WPSEO_WooCommerce_Utils::get_product_display_price( $product );
 				$data['offers'][ $key ]['@id'] = YoastSEO()->meta->for_current_page()->site_url . '#/schema/offer/' . $product->get_id() . '-' . $key;
 
 				$data['offers'][ $key ]['priceSpecification']['@type'] = 'PriceSpecification';
+				$data['offers'][ $key ]['priceSpecification']['price'] = $price;
+				if ( wc_tax_enabled() ) {
+					$data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] = WPSEO_WooCommerce_Utils::prices_have_tax_included();
+				}
+				else {
+					unset( $data['offers'][ $key ]['priceSpecification']['valueAddedTaxIncluded'] );
+				}
 
 				$data['offers'][ $key ]['seller'] = [ '@id' => YoastSEO()->meta->for_current_page()->site_url . '#organization' ];
 
@@ -232,6 +240,14 @@ class WPSEO_WooCommerce_Schema {
 			if ( $offer['@type'] === 'AggregateOffer' ) {
 				$data['offers'][ $key ]['@id']    = YoastSEO()->meta->for_current_page()->site_url . '#/schema/aggregate-offer/' . $product->get_id() . '-' . $key;
 				$data['offers'][ $key ]['offers'] = $this->add_individual_offers( $product );
+				if ( $product instanceof WC_Product_Variable ) {
+					$decimals = wc_get_price_decimals();
+					$lowest   = $product->get_variation_price( 'min', true );
+					$highest  = $product->get_variation_price( 'max', true );
+
+					$data['offers'][ $key ]['lowPrice']  = wc_format_decimal( $lowest, $decimals );
+					$data['offers'][ $key ]['highPrice'] = wc_format_decimal( $highest, $decimals );
+				}
 			}
 
 			// Alter availability when product is "on backorder".
@@ -548,7 +564,8 @@ class WPSEO_WooCommerce_Schema {
 		$variations = $product->get_available_variations();
 
 		$currency           = get_woocommerce_currency();
-		$prices_include_tax = ( wc_tax_enabled() && WPSEO_WooCommerce_Utils::prices_have_tax_included() );
+		$tax_enabled        = wc_tax_enabled();
+		$prices_include_tax = WPSEO_WooCommerce_Utils::prices_have_tax_included();
 		$decimals           = wc_get_price_decimals();
 		$data               = [];
 		$product_id         = $product->get_id();
@@ -567,12 +584,15 @@ class WPSEO_WooCommerce_Schema {
 					'@type'                 => 'PriceSpecification',
 					'price'                 => wc_format_decimal( $variation['display_price'], $decimals ),
 					'priceCurrency'         => $currency,
-					'valueAddedTaxIncluded' => $prices_include_tax,
 				],
 			];
 
 			if ( ! empty( $variation['sku'] ) ) {
 				$offer['sku'] = $variation['sku'];
+			}
+
+			if ( $tax_enabled ) {
+				$offer['priceSpecification']['valueAddedTaxIncluded'] = $prices_include_tax;
 			}
 
 			// Adds variation's global identifiers to the $offer array.

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -267,6 +267,7 @@ class Schema_Test extends TestCase {
 		$expected_output                        = $input;
 		$expected_output['offers'][0]['@id']    = 'https://example.com/#/schema/offer/209643-0';
 		$expected_output['offers'][0]['seller'] = [ '@id' => 'https://example.com/#organization' ];
+		unset( $expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] );
 
 		Functions\stubs(
 			[
@@ -283,6 +284,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
+		$product->expects( 'get_price' )->once()->andReturn( '49.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 
@@ -335,6 +338,7 @@ class Schema_Test extends TestCase {
 		$expected_output                        = $input;
 		$expected_output['offers'][0]['@id']    = 'https://example.com/#/schema/offer/209643-0';
 		$expected_output['offers'][0]['seller'] = [ '@id' => 'https://example.com/#organization' ];
+		unset( $expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] );
 
 		Functions\stubs(
 			[
@@ -351,6 +355,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
+		$product->expects( 'get_price' )->once()->andReturn( '49.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( true );
 
@@ -615,7 +621,6 @@ class Schema_Test extends TestCase {
 						'@type'                 => 'PriceSpecification',
 						'price'                 => 10,
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 					'sku'                => '209643',
 					'gtin8'              => '01234567',
@@ -629,7 +634,6 @@ class Schema_Test extends TestCase {
 						'@type'                 => 'PriceSpecification',
 						'price'                 => 8,
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 					'sku'                => '209644',
 					'gtin8'              => '11112222',
@@ -644,7 +648,6 @@ class Schema_Test extends TestCase {
 						'@type'                 => 'PriceSpecification',
 						'price'                 => 12,
 						'priceCurrency'         => 'GBP',
-						'valueAddedTaxIncluded' => false,
 					],
 					'sku'                => '209645',
 					'gtin8'              => '11112222',
@@ -664,12 +667,22 @@ class Schema_Test extends TestCase {
 			]
 		);
 
-		$product = Mockery::mock( 'WC_Product' );
+		$product = Mockery::mock( 'WC_Product_Variable' );
 		$product->expects( 'get_id' )->twice()->andReturn( '209643' );
 		$product->expects( 'get_available_variations' )->once()->andReturn( $variants );
 		$product->expects( 'get_name' )->once()->andReturn( 'Customizable responsive toolset' );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
+
+		$product->expects( 'get_variation_price' )
+				->with( 'min', true )
+				->once()
+				->andReturn( '8.00' );
+
+		$product->expects( 'get_variation_price' )
+				->with( 'max', true )
+				->once()
+				->andReturn( '12.00' );
 
 		Functions\expect( 'get_permalink' )
 			->andReturn(
@@ -1058,6 +1071,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 7 )->with()->andReturn( $product_id );
+		$product->expects( 'get_price' )->once()->andReturn( '1.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
@@ -1134,6 +1149,7 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
 					],
 				],
 			],
@@ -1172,7 +1188,8 @@ class Schema_Test extends TestCase {
 					],
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
-						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
+						'price'                 => '1.00',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
 				],
@@ -1240,6 +1257,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 7 )->with()->andReturn( $product_id );
+		$product->expects( 'get_price' )->once()->andReturn( '1.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
@@ -1318,6 +1337,7 @@ class Schema_Test extends TestCase {
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
 						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
 					],
 					'seller'             => [
 						'@type' => 'Organization',
@@ -1356,7 +1376,8 @@ class Schema_Test extends TestCase {
 					'url'                => $canonical,
 					'priceSpecification' => [
 						'@type'                 => 'PriceSpecification',
-						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
+						'price'                 => '1.00',
 					],
 					'seller'             => [
 						'@id' => $base_url . '#organization',
@@ -1424,6 +1445,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->times( 6 )->with()->andReturn( $product_id );
+		$product->expects( 'get_price' )->once()->andReturn( '1.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'get_name' )->once()->with()->andReturn( $product_name );
 		$product->expects( 'get_sku' )->once()->with()->andReturn( $product_sku );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
@@ -1485,10 +1508,15 @@ class Schema_Test extends TestCase {
 			'sku'         => 'sku1234',
 			'offers'      => [
 				[
-					'@type'  => 'Offer',
-					'price'  => '1.00',
-					'url'    => $canonical,
-					'seller' => [
+					'@type'              => 'Offer',
+					'price'              => '1.00',
+					'url'                => $canonical,
+					'priceSpecification' => [
+						'@type'                 => 'PriceSpecification',
+						'valueAddedTaxIncluded' => false,
+						'priceCurrency'         => 'GBP',
+					],
+					'seller'             => [
 						'@type' => 'Organization',
 						'name'  => 'WP',
 						'url'   => $base_url,
@@ -1523,13 +1551,16 @@ class Schema_Test extends TestCase {
 				[
 					'@type'              => 'Offer',
 					'url'                => $canonical,
+					'priceSpecification' => [
+						'@type'                 => 'PriceSpecification',
+						'priceCurrency'         => 'GBP',
+						'price'                 => '1.00',
+					],
 					'seller'             => [
 						'@id' => $base_url . '#organization',
 					],
 					'@id'                => $base_url . '#/schema/offer/1-0',
-					'priceSpecification' => [
-						'@type'                 => 'PriceSpecification',
-					],
+
 				],
 			],
 			'review'           => [
@@ -1682,6 +1713,7 @@ class Schema_Test extends TestCase {
 		$expected_output                        = $input;
 		$expected_output['offers'][0]['@id']    = 'http://example.com/#/schema/offer/209643-0';
 		$expected_output['offers'][0]['seller'] = [ '@id' => 'http://example.com/#organization' ];
+		unset( $expected_output['offers'][0]['priceSpecification']['valueAddedTaxIncluded'] );
 
 		Functions\stubs(
 			[
@@ -1696,6 +1728,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
+		$product->expects( 'get_price' )->once()->andReturn( '49.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( true );
 		$product->expects( 'get_date_on_sale_to' )->once()->andReturn( 'not-a-null-value' );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
@@ -1812,6 +1846,8 @@ class Schema_Test extends TestCase {
 
 		$product = Mockery::mock( 'WC_Product' );
 		$product->expects( 'get_id' )->once()->andReturn( '209643' );
+		$product->expects( 'get_price' )->once()->andReturn( '49.00' );
+		$product->expects( 'get_min_purchase_quantity' )->once()->andReturn( 1 );
 		$product->expects( 'is_on_sale' )->once()->andReturn( false );
 		$product->expects( 'is_on_backorder' )->once()->andReturn( false );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the Schema output for `Product`, including a fix for a bug affecting setups where prices are inserted without taxes but displayed with taxes or viceversa.

## Relevant technical choices:

* I've just adapted the existing unit tests but they fail short from covering the wide array of cases we'd need to check. Integration tests would definitely be a better choice.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preparation:
* create a simple Product with price set to 10.00
* create a variable product with three variations, with prices set to 8.00, 11.00, 12.00

#### 1 Taxes are not enabled
- in the WooCommerce settings, untick "Enable tax rates and calculations" and save.
- visit the Simple product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "Offer",
                    "priceSpecification": {
                        "price": "10.00",
                        "priceCurrency": "USD",
                        "@type": "PriceSpecification"
                    },
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/prodotto/",
                    "seller": {
                        "@id": "http://basic.wordpress.test/#organization"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/offer/135-0"
                }
            ],
```

- visit the Variable product
- Check the schema for the `Product` piece, look at the `offers` property:
```
"offers": [
                {
                    "@type": "AggregateOffer",
                    "lowPrice": "8.00",
                    "highPrice": "12.00",
                    "offerCount": 3,
                    "priceCurrency": "USD",
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/variable-product/",
                    "seller": {
                        "@type": "Organization",
                        "name": "Basic",
                        "url": "http://basic.wordpress.test"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/aggregate-offer/137-0",
                    "offers": [
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-0",
                            "name": "Variable product - blue",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=blue",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "8.00",
                                "priceCurrency": "USD"
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-1",
                            "name": "Variable product - red",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=red",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "11.00",
                                "priceCurrency": "USD"
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-2",
                            "name": "Variable product - white",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=white",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "12.00",
                                "priceCurrency": "USD"
                            }
                        }
                    ]
                }
            ],
```

#### 2 Taxes enabled, prices are inserted and displayed without taxes
- in the WooCommerce settings, tick "Enable tax rates and calculations" and save.
- in the Tax tab, add a Standard rate of 20%
- in the Tax tab, set "No, I will enter prices exclusive of tax" and Display prices "excluding tax"
- visit the Simple product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "Offer",
                    "priceSpecification": {
                        "price": "10.00",
                        "priceCurrency": "USD",
                        "valueAddedTaxIncluded": false,
                        "@type": "PriceSpecification"
                    },
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/prodotto/",
                    "seller": {
                        "@id": "http://basic.wordpress.test/#organization"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/offer/135-0"
                }
            ],
```
- visit the Variable product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "AggregateOffer",
                    "lowPrice": "8.00",
                    "highPrice": "12.00",
                    "offerCount": 3,
                    "priceCurrency": "USD",
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/variable-product/",
                    "seller": {
                        "@type": "Organization",
                        "name": "Basic",
                        "url": "http://basic.wordpress.test"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/aggregate-offer/137-0",
                    "offers": [
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-0",
                            "name": "Variable product - blue",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=blue",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "8.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": false
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-1",
                            "name": "Variable product - red",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=red",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "11.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": false
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-2",
                            "name": "Variable product - white",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=white",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "12.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": false
                            }
                        }
                    ]
                }
            ],
```

#### 3 Taxes enabled, prices are inserted and displayed with taxes
- in the WooCommerce settings, tick "Enable tax rates and calculations" and save.
- in the Tax tab, add a Standard rate of 20%
- in the Tax tab, set "Yes, I will enter prices inclusive of tax" and Display prices "including tax"
- visit the Simple product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "Offer",
                    "priceSpecification": {
                        "price": "10.00",
                        "priceCurrency": "USD",
                        "valueAddedTaxIncluded": true,
                        "@type": "PriceSpecification"
                    },
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/prodotto/",
                    "seller": {
                        "@id": "http://basic.wordpress.test/#organization"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/offer/135-0"
                }
            ],
```
- visit the Variable product
- Check the schema for the `Product` piece, look at the `offers` property:
```
"offers": [
                {
                    "@type": "AggregateOffer",
                    "lowPrice": "8.00",
                    "highPrice": "12.00",
                    "offerCount": 3,
                    "priceCurrency": "USD",
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/variable-product/",
                    "seller": {
                        "@type": "Organization",
                        "name": "Basic",
                        "url": "http://basic.wordpress.test"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/aggregate-offer/137-0",
                    "offers": [
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-0",
                            "name": "Variable product - blue",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=blue",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "8.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": true
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-1",
                            "name": "Variable product - red",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=red",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "11.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": true
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-2",
                            "name": "Variable product - white",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=white",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "12.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": true
                            }
                        }
                    ]
                }
            ],
```

#### 4 Taxes enabled, prices inserted without taxes but displayed with taxes
- in the WooCommerce settings, tick "Enable tax rates and calculations" and save.
- in the Tax tab, add a Standard rate of 20%
- in the Tax tab, set "No, I will enter prices exclusive of tax" and Display prices "including tax"
- visit the Simple product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "Offer",
                    "priceSpecification": {
                        "price": "12.00",
                        "priceCurrency": "USD",
                        "valueAddedTaxIncluded": true,
                        "@type": "PriceSpecification"
                    },
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/prodotto/",
                    "seller": {
                        "@id": "http://basic.wordpress.test/#organization"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/offer/135-0"
                }
            ],
```
- visit the Variable product
- Check the schema for the `Product` piece, look at the `offers` property:
```
"offers": [
                {
                    "@type": "AggregateOffer",
                    "lowPrice": "9.60",
                    "highPrice": "14.40",
                    "offerCount": 3,
                    "priceCurrency": "USD",
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/variable-product/",
                    "seller": {
                        "@type": "Organization",
                        "name": "Basic",
                        "url": "http://basic.wordpress.test"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/aggregate-offer/137-0",
                    "offers": [
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-0",
                            "name": "Variable product - blue",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=blue",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "9.60",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": true
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-1",
                            "name": "Variable product - red",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=red",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "13.20",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": true
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-2",
                            "name": "Variable product - white",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=white",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "14.40",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": true
                            }
                        }
                    ]
                }
            ],
```

#### 5 Taxes enabled, prices inserted with taxes but displayed without taxes
- in the WooCommerce settings, tick "Enable tax rates and calculations" and save.
- in the Tax tab, add a Standard rate of 20%
- in the Tax tab, set "Yes, I will enter prices inclusive of tax" and Display prices "excluding tax"
- visit the Simple product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "Offer",
                    "priceSpecification": {
                        "price": "8.33",
                        "priceCurrency": "USD",
                        "valueAddedTaxIncluded": false,
                        "@type": "PriceSpecification"
                    },
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/prodotto/",
                    "seller": {
                        "@id": "http://basic.wordpress.test/#organization"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/offer/135-0"
                }
            ],
```
- visit the Variable product
- Check the schema for the `Product` piece, look at the `offers` property:
```
           "offers": [
                {
                    "@type": "AggregateOffer",
                    "lowPrice": "6.67",
                    "highPrice": "10.00",
                    "offerCount": 3,
                    "priceCurrency": "USD",
                    "availability": "http://schema.org/InStock",
                    "url": "http://basic.wordpress.test/product/variable-product/",
                    "seller": {
                        "@type": "Organization",
                        "name": "Basic",
                        "url": "http://basic.wordpress.test"
                    },
                    "@id": "http://basic.wordpress.test/#/schema/aggregate-offer/137-0",
                    "offers": [
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-0",
                            "name": "Variable product - blue",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=blue",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "6.67",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": false
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-1",
                            "name": "Variable product - red",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=red",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "9.17",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": false
                            }
                        },
                        {
                            "@type": "Offer",
                            "@id": "http://basic.wordpress.test/#/schema/offer/137-2",
                            "name": "Variable product - white",
                            "url": "http://basic.wordpress.test/product/variable-product/?attribute_pa_color=white",
                            "priceSpecification": {
                                "@type": "PriceSpecification",
                                "price": "10.00",
                                "priceCurrency": "USD",
                                "valueAddedTaxIncluded": false
                            }
                        }
                    ]
                }
            ],
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #868 
