### PR TITLE
Never use the link table when looking for the placeholder image in Woo products

### DIFF
--- a/classes/woocommerce-schema.php
+++ b/classes/woocommerce-schema.php
@@ -446,7 +446,7 @@ class WPSEO_WooCommerce_Schema {
 		if ( function_exists( 'wc_placeholder_img_src' ) ) {
 			$image_schema_id     = YoastSEO()->meta->for_current_page()->canonical . '#woocommerceimageplaceholder';
 			$placeholder_img_src = wc_placeholder_img_src();
-			$this->data['image'] = YoastSEO()->helpers->schema->image->generate_from_url( $image_schema_id, $placeholder_img_src );
+			$this->data['image'] = YoastSEO()->helpers->schema->image->generate_from_url( $image_schema_id, $placeholder_img_src, '', false, false );
 		}
 	}
 

--- a/tests/classes/schema-test.php
+++ b/tests/classes/schema-test.php
@@ -1316,7 +1316,7 @@ class Schema_Test extends TestCase {
 
 		$this->helpers->schema->image
 			->expects( 'generate_from_url' )
-			->with( $image_data['@id'], $image_data['url'] )
+			->with( $image_data['@id'], $image_data['url'], '', false, false )
 			->andReturn( $image_data );
 
 		Functions\expect( 'wp_strip_all_tags' )->twice()->andReturn( 'TestProduct' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because
  * we no longer create indexables for attachments
  * we instead use the SEO Link table for retrieving an image's id 
  * and the placeholder image will almost never gonna be in the SEO_Links table
* we now don't use the SEO link table for products with only a placeholder image, so that we avoid performing an unnecessary query 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make product schema creation compatible with the latest Yoast Free changes

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* No test instructions, since we're just refactoring some code to follow the new way of attachment indexable handling.
* Follow the impact check, to understand what to test


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Image schema creation for products. Specifically:
  * For products with product image/gallery, nothing is changed. The schema should be identical to previous versions of the plugin
  * For products with no product image/gallery (so, for products with placeholder image), the way to calculate the schema is changed, but the result should again be identical. To confirm:
    * Load the frontend of a product with no product image/gallery with this PR/RC and take note of its schema
    * Load the frontend of a product with no product image/gallery with this PR/RC (and the respective Free PR/RC) with indexables cleaned out and `Enable media pages` set to disabled. Compare the schema to the one above and confirm it's the same
    * Load the frontend of a product with no product image/gallery with this PR/RC (and the respective Free PR/RC) with indexables cleaned out and `Enable media pages` set to enabled. Compare the schema to the one above and confirm it's the same.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #
