### PR TITLE
Remove keyphraseDistribution and wordComplexity from the product assessor initializer

### DIFF
--- a/js/src/initializers/product-assessor.js
+++ b/js/src/initializers/product-assessor.js
@@ -51,8 +51,6 @@ export default function initialize() {
 		imageKeyphraseCTAUrl: "https://yoa.st/4f6",
 		imageAltTagsUrlTitle: "https://yoa.st/33c",
 		imageAltTagsCTAUrl: "https://yoa.st/33d",
-		keyphraseDistributionUrlTitle: "https://yoa.st/33q",
-		keyphraseDistributionCTAUrl: "https://yoa.st/33u",
 		productIdentifierUrlTitle: "https://yoa.st/4ly",
 		productIdentifierCTAUrl: "https://yoa.st/4lz",
 		productSKUUrlTitle: "https://yoa.st/4lw",
@@ -96,8 +94,6 @@ export default function initialize() {
 		imageKeyphraseCTAUrl: "https://yoa.st/4f6",
 		imageAltTagsUrlTitle: "https://yoa.st/33c",
 		imageAltTagsCTAUrl: "https://yoa.st/33d",
-		keyphraseDistributionUrlTitle: "https://yoa.st/33q",
-		keyphraseDistributionCTAUrl: "https://yoa.st/33u",
 		productIdentifierUrlTitle: "https://yoa.st/4ly",
 		productIdentifierCTAUrl: "https://yoa.st/4lz",
 		productSKUUrlTitle: "https://yoa.st/4lw",
@@ -120,8 +116,6 @@ export default function initialize() {
 		textPresenceCTAUrl: "https://yoa.st/35i",
 		listsUrlTitle: "https://yoa.st/4fe",
 		listsCTAUrl: "https://yoa.st/4ff",
-		wordComplexityTitleUrl: "https://yoa.st/4ls",
-		wordComplexityCTAUrl: "https://yoa.st/4lt",
 	}  );
 	analysisWorker.setCustomCornerstoneContentAssessorClass( productCornerstoneContentAssessor.default, "productPage", {
 		subheadingUrlTitle: "https://yoa.st/34x",
@@ -138,8 +132,6 @@ export default function initialize() {
 		textPresenceCTAUrl: "https://yoa.st/35i",
 		listsUrlTitle: "https://yoa.st/4fe",
 		listsCTAUrl: "https://yoa.st/4ff",
-		wordComplexityTitleUrl: "https://yoa.st/4ls",
-		wordComplexityCTAUrl: "https://yoa.st/4lt",
 	}  );
 	analysisWorker.setCustomRelatedKeywordAssessorClass( productRelatedKeywordAssessor.default, "productPage", {
 		introductionKeyphraseUrlTitle: "https://yoa.st/33e",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the shortlinks of _keyphrase distribution_ and _word complexity_ assessments from the product assessor initializer. 

## Relevant technical choices:

* This is a complementary task to the PR that removes [Premium assessments from productPages assessors](https://github.com/Yoast/wordpress-seo/pull/19897#top)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This task should be tested together with task to [Remove Premium assessments from productPages assessors](https://github.com/Yoast/wordpress-seo/pull/19897#top). 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/a

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #[19828](https://github.com/Yoast/wordpress-seo/issues/19828)
