### PR TITLE
Prevents an error when the short description metabox is not present

### DIFF
--- a/js/src/yoastseo-woo-replacevars.js
+++ b/js/src/yoastseo-woo-replacevars.js
@@ -34,7 +34,8 @@ function getPrice() {
  * @returns {string} The value of the short description.
  */
 function getShortDescription() {
-	var productDescription = document.getElementById( "excerpt" ).value;
+	let productDescription = document.getElementById( "excerpt" ) &&
+		document.getElementById( "excerpt" ).value || "";
 	if ( typeof tinyMCE !== "undefined" && tinyMCE.get( "excerpt" ) !== null ) {
 		productDescription = tinyMCE.get( "excerpt" ).getContent();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR prevents an error when the short description metabox is not present. We do so by adding some defensive coding in fetching the short description.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast SEO metabox would not load when the short description metabox had been deactivated.

## Relevant technical choices:

* Did not boy scout the rest of the file to keep the impact as minimal as possible.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* First, reproduce the original bug using the instructions in #897, including updating your `functions.php` file. 
* Then, with this PR, note that the Yoast metabox still works and the console error is no longer shown.
* Also, confirm that you can add the replacement variable `wc_shortdesc` to the SEO title / meta description, but that does not lead to errors. 
* Then, after removing the removal of the short description metabox in `functions.php`, confirm that you can edit the short description, and the SEO title / meta description updates accordingly.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The short product description replacement variable.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes #897 
