### PR TITLE
Loads translations for Woo assessments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Release date: 2023-04-25
 
 #### Other
 
+* Only shows the _word complexity_ and the _keyphrase distribution_ assessments on Product pages when Yoast SEO Premium is also activated.
 * Bumps the minimum required version of Yoast SEO to 20.6.
 * Drops compatibility with PHP 5.6, 7.0 and 7.1.
 * Sets the WordPress tested up to version to 6.2.

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1394,15 +1394,18 @@ class Yoast_WooCommerce_SEO {
 							__( '%1$sSKU%3$s: Your product is missing a SKU.%4$s %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s', 'yoast-woo-seo' ),
 						],
 						'%1$sSKU%2$s: Your product has a SKU. Good job!' => [
+							/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 							__( '%1$sSKU%2$s: Your product has a SKU. Good job!', 'yoast-woo-seo' ),
 						],
 						'%1$sSKU%3$s: Not all your product variants have a SKU. You can add a SKU via the \"Variations\" tab in the Product data box. %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s' => [
+							/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag. */
 							__(
 								'%1$sSKU%3$s: Not all your product variants have a SKU. You can add a SKU via the \"Variations\" tab in the Product data box. %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s',
 								'yoast-woo-seo'
 							),
 						],
 						'%1$sSKU%2$s: All your product variants have a SKU. Good job!' => [
+							/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 							__( '%1$sSKU%2$s: All your product variants have a SKU. Good job!', 'yoast-woo-seo' ),
 						],
 					],

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1338,12 +1338,14 @@ class Yoast_WooCommerce_SEO {
 							__( '%1$sLists%2$s: There is at least one list on this page. Great!', 'yoast-woo-seo' ),
 						],
 						'%3$sImage alt tags%5$s: %1$d image out of %2$d doesn\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!' => [
+							/* Translators: %3$s and %4$s expand to links on yoast.com, %5$s expands to the anchor end tag, %1$d expands to the number of images without alt tags, %2$d expands to the number of images found in the text */
 							_n(
 								'%3$sImage alt tags%5$s: %1$d image out of %2$d doesn\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
 								'%3$sImage alt tags%5$s: %1$d images out of %2$d don\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
 								1,
 								'yoast-woo-seo'
 							),
+							/* Translators: %3$s and %4$s expand to links on yoast.com, %5$s expands to the anchor end tag, %1$d expands to the number of images without alt tags, %2$d expands to the number of images found in the text */
 							_n(
 								'%3$sImage alt tags%5$s: %1$d image out of %2$d doesn\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
 								'%3$sImage alt tags%5$s: %1$d images out of %2$d don\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
@@ -1352,9 +1354,11 @@ class Yoast_WooCommerce_SEO {
 							),
 						],
 						'%1$sImage alt tags%2$s: All images have alt attributes. Good job!' => [
+							/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 							__( '%1$sImage alt tags%2$s: All images have alt attributes. Good job!', 'yoast-woo-seo' ),
 						],
 						'%1$sImage alt tags%3$s: None of the images has alt attributes. %2$sAdd alt attributes to your images%3$s!' => [
+							/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 							__( '%1$sImage alt tags%3$s: None of the images has alt attributes. %2$sAdd alt attributes to your images%3$s!', 'yoast-woo-seo' ),
 						],
 						'Your product is missing an identifier (like a GTIN code). You can add a product identifier via the \"Yoast SEO\" tab in the Product data box' => [
@@ -1382,15 +1386,19 @@ class Yoast_WooCommerce_SEO {
 							__( 'All your product variants have a barcode', 'yoast-woo-seo' ),
 						],
 						'%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it will help search engines to better understand your content.%5$s' => [
+							/* Translators: %1$s and %4$s expand to links on yoast.com, %5$s expands to the anchor end tag, %2$s expands to the string "Barcode" or "Product identifier", %3$s expands to the string "Not all your product variants have a product identifier" or "Not all your product variants have a barcode" */
 							__( '%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it will help search engines to better understand your content.%5$s', 'yoast-woo-seo' ),
 						],
 						'%1$s%2$s%4$s: %3$s. Good job!' => [
+							/* Translators: %1$s expands to a link on yoast.com, %4$s expands to the anchor end tag, %2$s expands to the string "Barcode" or "Product identifier", %3$s expands to the feedback string "All your product variants have a product identifier" or "All your product variants have a barcode" */
 							__( '%1$s%2$s%4$s: %3$s. Good job!', 'yoast-woo-seo' ),
 						],
 						' You can add a SKU via the \"Inventory\" tab in the Product data box.' => [
+							/* Translators: please keep the space at the start of the sentence in your translation unless your language does not use spaces. */
 							__( ' You can add a SKU via the \"Inventory\" tab in the Product data box.', 'yoast-woo-seo' ),
 						],
 						'%1$sSKU%3$s: Your product is missing a SKU.%4$s %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s' => [
+							/* Translators: %1$s and %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag, %4%s expands to the translated string ' You can add a SKU via the "Inventory" tab in the Product data box.' */
 							__( '%1$sSKU%3$s: Your product is missing a SKU.%4$s %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s', 'yoast-woo-seo' ),
 						],
 						'%1$sSKU%2$s: Your product has a SKU. Good job!' => [

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1308,12 +1308,106 @@ class Yoast_WooCommerce_SEO {
 		}
 
 		return [
-			'script_url'              => plugins_url( 'js/dist/yoastseo-woo-worker-' . $version . '.js', self::get_plugin_file() ),
-			'woo_desc_none'           => __( 'You should write a short description for this product.', 'yoast-woo-seo' ),
-			'woo_desc_short'          => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
-			'woo_desc_good'           => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
-			'woo_desc_long'           => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
-			'wooGooglePreviewData'    => $google_preview,
+			'script_url'           => plugins_url( 'js/dist/yoastseo-woo-worker-' . $version . '.js', self::get_plugin_file() ),
+			'woo_desc_none'        => __( 'You should write a short description for this product.', 'yoast-woo-seo' ),
+			'woo_desc_short'       => __( 'The short description for this product is too short.', 'yoast-woo-seo' ),
+			'woo_desc_good'        => __( 'Your short description has a good length.', 'yoast-woo-seo' ),
+			'woo_desc_long'        => __( 'The short description for this product is too long.', 'yoast-woo-seo' ),
+			'wooGooglePreviewData' => $google_preview,
+			'analysisTranslations' => $this->get_analysis_translations(),
+		];
+	}
+
+	/**
+	 * Get the translation strings for the analysis.
+	 *
+	 * @return array[] The translation strings for the analysis.
+	 */
+	private function get_analysis_translations() {
+		return [
+			'yoast-woo-seo' => [
+				'domain'      => 'yoast-woo-seo',
+				'locale_data' => [
+					'yoast-woo-seo' => [
+						'%1$sLists%3$s: No lists appear on this page. %2$sAdd at least one ordered or unordered list%3$s!' => [
+							/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+							__( '%1$sLists%3$s: No lists appear on this page. %2$sAdd at least one ordered or unordered list%3$s!', 'yoast-woo-seo' ),
+						],
+						'%1$sLists%2$s: There is at least one list on this page. Great!' => [
+							/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
+							__( '%1$sLists%2$s: There is at least one list on this page. Great!', 'yoast-woo-seo' ),
+						],
+						'%3$sImage alt tags%5$s: %1$d image out of %2$d doesn\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!' => [
+							_n(
+								'%3$sImage alt tags%5$s: %1$d image out of %2$d doesn\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
+								'%3$sImage alt tags%5$s: %1$d images out of %2$d don\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
+								1,
+								'yoast-woo-seo'
+							),
+							_n(
+								'%3$sImage alt tags%5$s: %1$d image out of %2$d doesn\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
+								'%3$sImage alt tags%5$s: %1$d images out of %2$d don\'t have alt attributes. %4$sAdd alt attributes to your images%5$s!',
+								6,
+								'yoast-woo-seo'
+							),
+						],
+						'%1$sImage alt tags%2$s: All images have alt attributes. Good job!' => [
+							__( '%1$sImage alt tags%2$s: All images have alt attributes. Good job!', 'yoast-woo-seo' ),
+						],
+						'%1$sImage alt tags%3$s: None of the images has alt attributes. %2$sAdd alt attributes to your images%3$s!' => [
+							__( '%1$sImage alt tags%3$s: None of the images has alt attributes. %2$sAdd alt attributes to your images%3$s!', 'yoast-woo-seo' ),
+						],
+						'Your product is missing an identifier (like a GTIN code). You can add a product identifier via the \"Yoast SEO\" tab in the Product data box' => [
+							__( 'Your product is missing an identifier (like a GTIN code). You can add a product identifier via the \"Yoast SEO\" tab in the Product data box', 'yoast-woo-seo' ),
+						],
+						'Your product has an identifier' => [
+							__( 'Your product has an identifier', 'yoast-woo-seo' ),
+						],
+						'Not all your product variants have an identifier. You can add a product identifier via the \"Variations\" tab in the Product data box' => [
+							__( 'Not all your product variants have an identifier. You can add a product identifier via the \"Variations\" tab in the Product data box', 'yoast-woo-seo' ),
+						],
+						'All your product variants have an identifier' => [
+							__( 'All your product variants have an identifier', 'yoast-woo-seo' ),
+						],
+						'Your product is missing a barcode (like a GTIN code)' => [
+							__( 'Your product is missing a barcode (like a GTIN code)', 'yoast-woo-seo' ),
+						],
+						'Your product has a barcode' => [
+							__( 'Your product has a barcode', 'yoast-woo-seo' ),
+						],
+						'Not all your product variants have a barcode' => [
+							__( 'Not all your product variants have a barcode', 'yoast-woo-seo' ),
+						],
+						'All your product variants have a barcode' => [
+							__( 'All your product variants have a barcode', 'yoast-woo-seo' ),
+						],
+						'%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it will help search engines to better understand your content.%5$s' => [
+							__( '%1$s%2$s%5$s: %3$s. %4$sInclude it if you can, as it will help search engines to better understand your content.%5$s', 'yoast-woo-seo' ),
+						],
+						'%1$s%2$s%4$s: %3$s. Good job!' => [
+							__( '%1$s%2$s%4$s: %3$s. Good job!', 'yoast-woo-seo' ),
+						],
+						' You can add a SKU via the \"Inventory\" tab in the Product data box.' => [
+							__( ' You can add a SKU via the \"Inventory\" tab in the Product data box.', 'yoast-woo-seo' ),
+						],
+						'%1$sSKU%3$s: Your product is missing a SKU.%4$s %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s' => [
+							__( '%1$sSKU%3$s: Your product is missing a SKU.%4$s %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s', 'yoast-woo-seo' ),
+						],
+						'%1$sSKU%2$s: Your product has a SKU. Good job!' => [
+							__( '%1$sSKU%2$s: Your product has a SKU. Good job!', 'yoast-woo-seo' ),
+						],
+						'%1$sSKU%3$s: Not all your product variants have a SKU. You can add a SKU via the \"Variations\" tab in the Product data box. %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s' => [
+							__(
+								'%1$sSKU%3$s: Not all your product variants have a SKU. You can add a SKU via the \"Variations\" tab in the Product data box. %2$sInclude it if you can, as it will help search engines to better understand your content.%3$s',
+								'yoast-woo-seo'
+							),
+						],
+						'%1$sSKU%2$s: All your product variants have a SKU. Good job!' => [
+							__( '%1$sSKU%2$s: All your product variants have a SKU. Good job!', 'yoast-woo-seo' ),
+						],
+					],
+				],
+			],
 		];
 	}
 

--- a/js/src/yoastseo-woo-plugin.js
+++ b/js/src/yoastseo-woo-plugin.js
@@ -55,6 +55,8 @@ class YoastWooCommercePlugin {
 			.then( () => worker.sendMessage( "initialize", { l10n: wpseoWooL10n, productDescription }, PLUGIN_NAME ) )
 			.then( YoastSEO.app.refresh );
 
+		worker.initialize( { translations: wpseoWooL10n.analysisTranslations } );
+
 		addExcerptEventHandlers( worker );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With this PR, we add translations for the `yoast-woo-seo` domain to the AnalysisWebWorker.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds translations for the `yoast-woo-seo` domain to the AnalysisWebWorker.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Set your site language to Spanish.
2. Create an empty product, without a title.
3. Add a title and some content to your post, and also include a list.
4. Confirm that the _list_ assessment returns 🟢 with the following feedback: `Hay al menos una lista en esta página. ¡Genial!`
5. Add an image, but don't include an alt tag. 
6. Confirm that the _image alt tags_ assessment returns 🔴 with the following feedback: `Ninguna de las imágenes tiene atributo alt. ¡Añade atributos alt a tus imágenes!`
7. Set a SKU, but do not add a product identifier.
8. Confirm that the _SKU_ assessment returns 🟢 with the following feedback: `Tu producto tiene SKU. ¡Buen trabajo!`
9. Confirm that the _product identifiers_ assessment returns 🟠 with the following feedback: `A tu producto le falta un identificador (como por ejemplo un código GTIN). Puedes añadir un identificador del producto desde la pestaña «Yoast SEO» en la caja de datos del producto. Inclúyelo si puedes, ya que ayudará a los motores de búsqueda a comprender mejor tu contenido.`
10. Repeat these steps for Elementor. 
13. Repeat these steps, keep the site language to Spanish, but set the user language to Italian. Confirm that the feedback is the same as in steps, but the feedback is in Italian. You can check the expected translations [here](https://translationspress.com/app/yoast/wordpress-seo-premium/it/default/).
14. Repeat these steps, but now set the site language to French. Use a new text.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Woocommerce assessment translations.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label and noted the work hours.

Fixes https://github.com/Yoast/plugins-automated-testing/issues/654
