### PR TITLE
GH Actions/integration test: test against MySQL 5.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,9 @@ jobs:
 
     services:
       mysql:
-        # Use MySQL 5.7 for PHP < 7.4, otherwise MySQL 8.0.
+        # Use MySQL 5.6 for PHP 7.2, use MySQL 5.7 for PHP 7.3 < 7.4, otherwise MySQL 8.0.
         # Also see: https://core.trac.wordpress.org/ticket/52496
-        image: mysql:${{ ( matrix.php_version < '7.4' && '5.7' ) || '8.0' }}
+        image: mysql:${{ ( matrix.php_version == '7.2' && '5.6' ) || ( matrix.php_version < '7.4' && '5.7' ) || '8.0' }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
         ports:


### PR DESCRIPTION
## Context

* CI maintenance

## Summary
This PR can be summarized in the following changelog entry:

* CI maintenance

## Relevant technical choices:

This syncs the logic for determining the MySQL version to use in the integration tests with the logic used by the majority of plugins.

The difference is historic as the original script was based on what was being done in Travis, which was not always the same between plugins.

This commit is part of a standardization round.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the tests run & pass, we're good.
