### PR TITLE
Prevent replacing Woo breadcrumbs if using the blockified template

### DIFF
--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -1516,9 +1516,16 @@ class Yoast_WooCommerce_SEO {
 			remove_action( 'storefront_before_content', 'woocommerce_breadcrumb' );
 			add_action( 'storefront_before_content', [ $this, 'show_yoast_breadcrumbs' ] );
 		}
-
 		// Replaces the WooCommerce breadcrumbs.
 		if ( has_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb' ) ) {
+			// In a block theme, do not replace if Woo is using the new single product 'blockified' template.
+			if ( wp_is_block_theme() ) {
+				$templates               = get_block_templates( [ 'slug__in' => [ 'single-product' ] ] );
+				$single_product_template = reset( $templates );
+				if ( isset( $single_product_template->content ) && strpos( $single_product_template->content, 'woocommerce/legacy-template' ) === false ) {
+					return;
+				}
+			}
 			remove_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb', 20, 0 );
 			add_action( 'woocommerce_before_main_content', [ $this, 'show_yoast_breadcrumbs' ], 20, 0 );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures compatibility of the breadcrumbs replacement feature with WooCommerce 7.9.0 when using blockified template for single products.

## Relevant technical choices:

* Installing Woo 7.9.0 on a new site will enforce a single product _blockified_ template which is not compatible with the way we replace Woo breadcrumbs (i.e. replacing the function hooked into the `woocommerce_before_main_content` action) because it will rely on a block that we cannot hook into. It has been decided that we'll prevent any action in that case to avoid displaying 2 sets of breadcrumbs, which would not be matching.
* To detect if the single product is using a blockified template, we have to check that the template does not include `woocommerce/legacy-template`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**very important**: follow the order when testing because it's important to check the behavior both in new setups and when upgrading.

 #### New installation of Woo 7.9.0
* **on a new environment** make sure you have a block-based theme such as Twenty Twenty-Three active
* install WooCommerce [7.9.0-rc.2](https://github.com/woocommerce/woocommerce/releases/tag/7.9.0-rc.2)
* Install Yoast SEO (latest version is OK)
* Check the settings for the breadcrumbs, and possibly customize them e.g. by changing the value for Home or adding a prefix 
* Install WooCommerce SEO with this fix
* Check its settings, the `Replace WooCommerce Breadcrumbs` should be on by default.
* create and publish a product
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce** ones, which should be like `Home / Product Category / Product name` 
* Switch to a non-block theme such as Twenty Twenty-One
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce SEO** ones, which should be like `Home » Shop page » Product name` by default, unless you customized it above
* edit the WooCommerce SEO settings and set the `Replace WooCommerce Breadcrumbs` to off.
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce** ones, which should be like `Home / Product Category / Product name` 

 #### Upgrading to Woo 7.9.0
* **on a new environment** make sure you have a block-based theme such as Twenty Twenty-Three active
*  install WooCommerce 7.8.2 (currently the latest release)
* Install Yoast SEO (latest version is OK)
* Check the settings for the breadcrumbs, and possibly customize them e.g. by changing the value for Home or adding a prefix 
* Install WooCommerce SEO with this fix
* Check its settings, the `Replace WooCommerce Breadcrumbs` should be on by default.
* create and publish a product
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce SEO** ones, which should be like `Home » Shop page » Product name` by default, unless you customized it above
* edit the WooCommerce SEO settings and set the `Replace WooCommerce Breadcrumbs` to off.
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce** ones, which should be like `Home / Product Category / Product name` 
* edit the WooCommerce SEO settings and set the `Replace WooCommerce Breadcrumbs` to on.
* Upgrade to WooCommerce [7.9.0-rc.2](https://github.com/woocommerce/woocommerce/releases/tag/7.9.0-rc.2)
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce SEO** ones, which should be like `Home » Shop page » Product name` by default, unless you customized it above
* edit the WooCommerce SEO settings and set the `Replace WooCommerce Breadcrumbs` to off.
* visit the product in the frontend
* check that:
  * you don't see 2 occurrences of the breadcrumbs
  * the breadcrumbs you see are the **WooCommerce** ones, which should be like `Home / Product Category / Product name` 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The instructions above should cover all the cases, which are:
1. new installation of Woo 7.9.0 -> blockified template -> Woo breadcrumbs should not be replaced
2. new installation of Woo 7.9.0 -> non blockified template (in an older theme) -> Woo breadcrumbs should be replaced 
3. installation of Woo 7.8.2 -> non blockified template (because Woo doesn't enforce it)  -> Woo breadcrumbs should be replaced 
4. installation of Woo 7.8.2 upgraded to 7.9.0-> non blockified template (because Woo doesn't change the way it was)  -> Woo breadcrumbs should be replaced 

In particular, case 3. should cover all the people on recent Woo versions who don't have Woo 7.9.0 yet

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/842
