### PR TITLE
870 fix actionable buttons for variation product without variations

### DIFF
--- a/js/src/initializers/input-focus.js
+++ b/js/src/initializers/input-focus.js
@@ -1,7 +1,7 @@
 import { addAction } from "@wordpress/hooks";
 import handleInputFocusForVariableProducts from "./input-focus/variable-product";
 import handleInputFocusForSimpleProducts from "./input-focus/simple-product";
-import { getProductData } from "./woo-identifiers";
+import { getProductData, getProductVariants } from "./woo-identifiers";
 import { openWooCommerceMetabox } from "./input-focus/helpers";
 
 /**
@@ -20,10 +20,15 @@ export function inputFocus( id ) {
 	const productData = getProductData();
 
 	if ( productData.productType === "variable" ) {
-		handleInputFocusForVariableProducts( id );
-	} else {
-		handleInputFocusForSimpleProducts( id );
+		const productVariants = getProductVariants();
+
+		if ( productVariants.length > 0 ) {
+			handleInputFocusForVariableProducts( id );
+			return;
+		}
 	}
+
+	handleInputFocusForSimpleProducts( id );
 }
 
 /**

--- a/js/tests/initializers/input-focus.test.js
+++ b/js/tests/initializers/input-focus.test.js
@@ -1,9 +1,10 @@
 import { addAction } from "@wordpress/hooks";
 
 import initializeInputFocus, { inputFocus } from "../../src/initializers/input-focus";
-import { getProductData } from "../../src/initializers/woo-identifiers";
+import { getProductData, getProductVariants } from "../../src/initializers/woo-identifiers";
 import handleInputFocusForVariableProducts from "../../src/initializers/input-focus/variable-product";
 import handleInputFocusForSimpleProducts from "../../src/initializers/input-focus/simple-product";
+import expect from "expect";
 
 jest.mock( "@wordpress/hooks", () => (
 	{
@@ -14,6 +15,7 @@ jest.mock( "@wordpress/hooks", () => (
 jest.mock( "../../src/initializers/woo-identifiers", () => (
 	{
 		getProductData: jest.fn(),
+		getProductVariants: jest.fn(),
 	}
 ) );
 
@@ -29,14 +31,31 @@ describe( "The initializeInputFocus function", () => {
 } );
 
 describe( "The inputFocus function", () => {
-	it( "handles input focus for variable products", () => {
+	it( "handles input focus for variable products without variations", () => {
 		getProductData.mockReturnValueOnce( {
 			productType: "variable",
 		} );
 
+		getProductVariants.mockReturnValueOnce( [] );
+
 		inputFocus( "productSKU" );
 
 		expect( getProductData ).toBeCalled();
+		expect( getProductVariants ).toBeCalled();
+		expect( handleInputFocusForSimpleProducts ).toBeCalled();
+	} );
+
+	it( "handles input focus for variable products with variations", () => {
+		getProductData.mockReturnValueOnce( {
+			productType: "variable",
+		} );
+
+		getProductVariants.mockReturnValueOnce( [ {} ] );
+
+		inputFocus( "productSKU" );
+
+		expect( getProductData ).toBeCalled();
+		expect( getProductVariants ).toBeCalled();
 		expect( handleInputFocusForVariableProducts ).toBeCalled();
 	} );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Actionable buttons for SKU and product identifier do not work in case variation product doesn't have variations.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where actionable buttons for _product identifier assessment_ and _SKU assessment_ would not work when a variable product did not have variations.

## Relevant technical choices:

* Check if variable product has variations added. If no variations than it acts as for simple product.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Use the acceptance test plan for [the SKU assessment](https://docs.google.com/document/d/1pFWST3KtD3sT1WkKkz92AmoSycQrHht_g0-nQl39GrU/edit) and [the Product identifier assessment](https://docs.google.com/document/d/1kbBneoTf9CWYS2rRqzY5pZNK75Vb-os43nAd2Br80_w/edit).



Scenario 1: SKU assessment.
* Change the product to a variable product, but don’t create any variants yet. Make sure that the SKU in the Inventory tab is still filled in.
* Confirm that the SKU assessment returns a green bullet with the following feedback:
 SKU: Your product has a SKU. Good job!
* Remove the SKU in the Inventory tab.
* Confirm that the SKU assessment shows up in the SEO assessments with an orange bullet and the following feedback:
 SKU Your product is missing a SKU. Include it if you can, as it will help search engines to better understand your content.
* Confirm that the edit button appears next to the assessment feedback
* Click on the edit button
* Confirm that the SKU field in the Inventory tab is focused

Scenario 2: Product identifiers assessment.
* Change the product to a variable product, but don’t create any variants yet. Make sure that the SKU in the Inventory tab is still filled in.
* Confirm that the SKU assessment returns a green bullet with the following feedback:
 SKU: Your product has a SKU. Good job!
* Remove the SKU in the Inventory tab.
* Confirm that the SKU assessment shows up in the SEO assessments with an orange bullet and the following feedback:
 Product identifier: Your product is missing an identifier (like a GTIN code). Include it if you can, as it will help search engines to better understand your content.
* Confirm that the edit button appears next to the assessment feedback
* Click on the edit button
* Confirm that the Product identifiers in the Yoast SEO tab is focused

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR affects the functioning of the actionable buttons for the SKU and Product identifier assessments.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #870 
