### PR TITLE
918 woocommerce seo php 81 improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,11 @@ yarn-error.log
 .phpunit.result.cache
 .env
 /build
+.vscode/
 
 ############
 # Temp
 ############
 /.tmp
 
-.vscode/
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ yarn-error.log
 # Temp
 ############
 /.tmp
+
+.vscode/

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -442,7 +442,7 @@ class Yoast_WooCommerce_SEO {
 	public function config_page_styles() {
 		global $pagenow;
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required here.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required here because we are purely doing a strict equals check.
 		$is_get_wpseo_woo = ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) && $_GET['page'] === 'wpseo_woo' );
 
 		$is_wpseo_woocommerce_page = ( $pagenow === 'admin.php' && $is_get_wpseo_woo );

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -443,7 +443,7 @@ class Yoast_WooCommerce_SEO {
 		global $pagenow;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required here because we are purely doing a strict equals check.
-		$is_get_wpseo_woo = ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) && $_GET['page'] === 'wpseo_woo' );
+		$is_get_wpseo_woo = ( isset( $_GET['page'] ) && $_GET['page'] === 'wpseo_woo' );
 
 		$is_wpseo_woocommerce_page = ( $pagenow === 'admin.php' && $is_get_wpseo_woo );
 		if ( ! $is_wpseo_woocommerce_page ) {

--- a/classes/woocommerce-seo.php
+++ b/classes/woocommerce-seo.php
@@ -435,14 +435,17 @@ class Yoast_WooCommerce_SEO {
 	}
 
 	/**
-	 * Loads CSS.
+	 * Loads CSS in Woocommerce SEO settings page.
 	 *
 	 * @since 1.0
 	 */
 	public function config_page_styles() {
 		global $pagenow;
 
-		$is_wpseo_woocommerce_page = ( $pagenow === 'admin.php' && filter_input( INPUT_GET, 'page' ) === 'wpseo_woo' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required here.
+		$is_get_wpseo_woo = ( isset( $_GET['page'] ) && is_string( $_GET['page'] ) && $_GET['page'] === 'wpseo_woo' );
+
+		$is_wpseo_woocommerce_page = ( $pagenow === 'admin.php' && $is_get_wpseo_woo );
 		if ( ! $is_wpseo_woocommerce_page ) {
 			return;
 		}

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -78,7 +78,7 @@ class WPSEO_WooCommerce_Yoast_Tab {
 	}
 
 	/**
-	 * Save the $_POST values from our tab.
+	 * Save the $_POST values from our tab in product page, woocommerce section.
 	 *
 	 * @param int $post_id The post ID.
 	 *
@@ -89,7 +89,7 @@ class WPSEO_WooCommerce_Yoast_Tab {
 			return false;
 		}
 
-		$nonce = filter_input( INPUT_POST, '_wpnonce_yoast_seo_woo' );
+		$nonce = isset( $_POST['_wpnonce_yoast_seo_woo'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce_yoast_seo_woo'] ) ) : null;
 		if ( ! wp_verify_nonce( $nonce, 'yoast_woo_seo_identifiers' ) ) {
 			return false;
 		}

--- a/classes/woocommerce-yoast-tab.php
+++ b/classes/woocommerce-yoast-tab.php
@@ -89,8 +89,9 @@ class WPSEO_WooCommerce_Yoast_Tab {
 			return false;
 		}
 
-		$nonce = isset( $_POST['_wpnonce_yoast_seo_woo'] ) ? sanitize_text_field( wp_unslash( $_POST['_wpnonce_yoast_seo_woo'] ) ) : null;
-		if ( ! wp_verify_nonce( $nonce, 'yoast_woo_seo_identifiers' ) ) {
+		// No need to sanitize or unslash nonce.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		if ( ! isset( $_POST['_wpnonce_yoast_seo_woo'] ) || ! wp_verify_nonce( $_POST['_wpnonce_yoast_seo_woo'], 'yoast_woo_seo_identifiers' ) ) {
 			return false;
 		}
 

--- a/tests/classes/woocommerce-yoast-tab-test.php
+++ b/tests/classes/woocommerce-yoast-tab-test.php
@@ -12,6 +12,15 @@ use Yoast\WP\Woocommerce\Tests\TestCase;
  */
 class WooCommerce_Yoast_Tab_Test extends TestCase {
 
+		/**
+		 * Removes the used option.
+		 */
+	public function tear_down() {
+		$_POST = [];
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Test our constructor.
 	 *
@@ -57,6 +66,8 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 
 		$this->stubTranslationFunctions();
 		$this->stubEscapeFunctions();
+
+		$_POST['_wpnonce_yoast_seo_woo'] = '1234567';
 
 		Functions\stubs(
 			[
@@ -109,10 +120,30 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::save_data
 	 */
 	public function test_save_data_wrong_nonce() {
+
+		$_POST['_wpnonce_yoast_seo_woo'] = '1234567';
+
 		Functions\stubs(
 			[
 				'wp_is_post_revision' => false,
 				'wp_verify_nonce'     => false,
+			]
+		);
+
+		$instance = new WPSEO_WooCommerce_Yoast_Tab();
+		$this->assertFalse( $instance->save_data( 123 ) );
+	}
+
+	/**
+	 * Test whether we don't save any data when there is no valid nonce.
+	 *
+	 * @covers WPSEO_WooCommerce_Yoast_Tab::save_data
+	 */
+	public function test_save_data_no_nonce() {
+
+		Functions\stubs(
+			[
+				'wp_is_post_revision' => false,
 			]
 		);
 
@@ -126,6 +157,8 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 	 * @covers WPSEO_WooCommerce_Yoast_Tab::save_data
 	 */
 	public function test_save_data_empty() {
+		$_POST['_wpnonce_yoast_seo_woo'] = '1234567';
+
 		Functions\stubs(
 			[
 				'wp_is_post_revision' => false,
@@ -158,9 +191,10 @@ class WooCommerce_Yoast_Tab_Test extends TestCase {
 		$instance = new WPSEO_WooCommerce_Yoast_Tab();
 
 		$_POST = [
-			'yoast_seo' => [
+			'yoast_seo'              => [
 				'gtin8' => '1234',
 			],
+			'_wpnonce_yoast_seo_woo' => '1234567',
 		];
 		$this->assertTrue( $instance->save_data( 123 ) );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove `filter_input` usage.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes `filter_input` usage for PHP 8.1 improvements.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Go to `Yoast SEO`->`Woocommerce SEO` 
* Check page looks as expected.
* Inspect page and search in `Elements` tab (or in page source) for `yoast-seo-admin-css-css`
* Check you find it once and a link to a style sheet.

* Go to `Products`, add a product or edit an existing product.
* Go to the woocommerce section in the product and go `Yoast SEO` tab
* Add values to the fields and save.
* Check fields were saved.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #918 
