### PR TITLE
Composer: normalize the file, add script descriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,5 +94,17 @@
 		"coverage": [
 			"@php ./vendor/phpunit/phpunit/phpunit"
 		]
+	},
+	"scripts-descriptions": {
+		"lint": "Check the PHP files for parse errors.",
+		"cs": "See a menu with the code style checking script options.",
+		"check-cs": "Check the PHP files for code style violations and best practices.",
+		"check-staged-cs": "Check the staged PHP files for code style violations and best practices.",
+		"check-branch-cs": "Check the PHP files changed in the current branch for code style violations and best practices.",
+		"fix-cs": "Auto-fix code style violations in the PHP files.",
+		"integration-test": "Run the integration tests without code coverage.",
+		"integration-coverage": "Run the integration tests with code coverage.",
+		"test": "Run the unit tests without code coverage.",
+		"coverage": "Run the unit tests with code coverage."
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,96 +1,98 @@
 {
-    "name": "yoast/wpseo-woocommerce",
-    "description": "This extension to WooCommerce and WordPress SEO by Yoast makes sure there's perfect communication between the two plugins.",
-    "type": "wordpress-plugin",
-    "homepage": "https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "Team Yoast",
-            "email": "support@yoast.com",
-            "homepage": "https://yoast.com"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/Yoast/wpseo-woocommerce/issues",
-        "source": "https://github.com/Yoast/wpseo-woocommerce"
-    },
-    "autoload": {
-        "classmap": [ "classes/" ]
-    },
-    "autoload-dev": {
-        "classmap": [
-            "tests/",
-            "integration-tests/",
-            "config/"
-        ]
-    },
-    "config": {
-        "platform": {
-            "php": "7.2.5"
-        },
-        "preferred-install": {
-            "yoast/wordpress-seo": "source"
-        },
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true
-        }
-    },
-    "repositories": {
-        "wordpress-seo": {
-            "type": "vcs",
-            "url": "https://github.com/yoast/wordpress-seo"
-        }
-    },
-    "require": {
-        "php": "^7.2.5 || ^8.0",
-        "composer/installers": "^1.12.0"
-    },
-    "require-dev": {
-        "yoast/yoastcs": "^2.3.1",
-        "yoast/wp-test-utils": "^1.1.1",
-        "yoast/wordpress-seo": "dev-trunk@dev"
-    },
-    "extra": {
-        "installer-paths": {
-            "vendor/{$vendor}/{$name}": [
-                "type:wordpress-plugin"
-            ]
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git --exclude wp-content"
-        ],
-        "cs": [
-            "Yoast\\WP\\Woocommerce\\Composer\\Actions::check_coding_standards"
-        ],
-        "check-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
-        ],
-        "check-staged-cs": [
-            "@check-cs --filter=GitStaged"
-        ],
-        "check-branch-cs": [
-            "Yoast\\WP\\SEO\\Composer\\Actions::check_branch_cs"
-        ],
-        "fix-cs": [
-            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
-        ],
-        "integration-test": [
-            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist --no-coverage"
-        ],
-        "integration-coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
-        ],
-        "test": [
-            "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
-        ],
-        "coverage": [
-            "@php ./vendor/phpunit/phpunit/phpunit"
-        ]
-    }
+	"name": "yoast/wpseo-woocommerce",
+	"description": "This extension to WooCommerce and WordPress SEO by Yoast makes sure there's perfect communication between the two plugins.",
+	"license": "GPL-2.0-or-later",
+	"type": "wordpress-plugin",
+	"authors": [
+		{
+			"name": "Team Yoast",
+			"email": "support@yoast.com",
+			"homepage": "https://yoast.com"
+		}
+	],
+	"homepage": "https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/",
+	"support": {
+		"issues": "https://github.com/Yoast/wpseo-woocommerce/issues",
+		"source": "https://github.com/Yoast/wpseo-woocommerce"
+	},
+	"require": {
+		"php": "^7.2.5 || ^8.0",
+		"composer/installers": "^1.12.0"
+	},
+	"require-dev": {
+		"yoast/wordpress-seo": "dev-trunk@dev",
+		"yoast/wp-test-utils": "^1.1.1",
+		"yoast/yoastcs": "^2.3.1"
+	},
+	"repositories": {
+		"wordpress-seo": {
+			"type": "vcs",
+			"url": "https://github.com/yoast/wordpress-seo"
+		}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"autoload": {
+		"classmap": [
+			"classes/"
+		]
+	},
+	"autoload-dev": {
+		"classmap": [
+			"tests/",
+			"integration-tests/",
+			"config/"
+		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/installers": true
+		},
+		"platform": {
+			"php": "7.2.5"
+		},
+		"preferred-install": {
+			"yoast/wordpress-seo": "source"
+		}
+	},
+	"extra": {
+		"installer-paths": {
+			"vendor/{$vendor}/{$name}": [
+				"type:wordpress-plugin"
+			]
+		}
+	},
+	"scripts": {
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git --exclude wp-content"
+		],
+		"cs": [
+			"Yoast\\WP\\Woocommerce\\Composer\\Actions::check_coding_standards"
+		],
+		"check-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+		],
+		"check-staged-cs": [
+			"@check-cs --filter=GitStaged"
+		],
+		"check-branch-cs": [
+			"Yoast\\WP\\SEO\\Composer\\Actions::check_branch_cs"
+		],
+		"fix-cs": [
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+		],
+		"integration-test": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist --no-coverage"
+		],
+		"integration-coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
+		],
+		"test": [
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
+		],
+		"coverage": [
+			"@php ./vendor/phpunit/phpunit/phpunit"
+		]
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cc5b0bd55348abdbbf8e1b67c59f1c0",
+    "content-hash": "137a378dddd19db85b16098c8e3e3831",
     "packages": [
         {
             "name": "composer/installers",
@@ -2407,14 +2407,14 @@
                 "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "guzzlehttp/guzzle": "6.5.8",
+                "guzzlehttp/guzzle": "7.8.0",
                 "humbug/php-scoper": "^0.13.4",
-                "league/oauth2-client": "2.6.1",
+                "league/oauth2-client": "2.7.0",
                 "psr/container": "1.0.0",
                 "psr/log": "^1.0",
                 "symfony/config": "^3.4",
                 "symfony/dependency-injection": "^3.4",
-                "wordproof/wordpress-sdk": "1.3.2",
+                "wordproof/wordpress-sdk": "1.3.5",
                 "yoast/wp-test-utils": "^1.1.1",
                 "yoast/yoastcs": "^2.3.1"
             },
@@ -2493,6 +2493,7 @@
                     "composer prefix-wordproof"
                 ],
                 "prefix-oauth2-client": [
+                    "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/symfony/deprecation-contracts --config=config/php-scoper/deprecation-contracts.inc.php --force --quiet",
                     "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/league/oauth2-client --config=config/php-scoper/oauth2-client.inc.php --force --quiet",
                     "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/guzzlehttp --config=config/php-scoper/guzzlehttp.inc.php --force --quiet",
                     "@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/psr --config=config/php-scoper/psr.inc.php --force --quiet"
@@ -2684,5 +2685,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Context

* Tidy up `composer.json` file and improve usability of scripts

## Summary

This PR can be summarized in the following changelog entry:

* Tidy up `composer.json` file and improve usability of scripts

## Relevant technical choices:

### Composer: normalize the file

Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize

### Composer: add script descriptions

These descriptions will be used when a list of the available scripts is requested on the command-line using the `composer list` or `composer run -l` commands.

These descriptions also help document the different scripts for the maintainers of the `composer.json` file.

Ref: https://getcomposer.org/doc/articles/scripts.md#custom-descriptions-

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_