### PR TITLE
Tests: make dataproviders `static`

### DIFF
--- a/tests/Unit/Classes/Integrations/TranslationsPress_Test.php
+++ b/tests/Unit/Classes/Integrations/TranslationsPress_Test.php
@@ -169,7 +169,7 @@ class TranslationsPress_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function site_transient_update_plugins_provider() {
+	public static function site_transient_update_plugins_provider() {
 		$expected               = new stdClass();
 		$expected->translations = [];
 

--- a/tests/Unit/Classes/Yoast_Ids_Test.php
+++ b/tests/Unit/Classes/Yoast_Ids_Test.php
@@ -72,7 +72,7 @@ class Yoast_Ids_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_save_data() {
+	public static function data_save_data() {
 		return [
 			'all_ok' => [
 				true,
@@ -193,7 +193,7 @@ class Yoast_Ids_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_add_variations_global_ids() {
+	public static function data_add_variations_global_ids() {
 		return [
 			[
 				1337,

--- a/tests/Unit/Classes/Yoast_Tab_Test.php
+++ b/tests/Unit/Classes/Yoast_Tab_Test.php
@@ -91,7 +91,7 @@ class Yoast_Tab_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_add_yoast_seo_fields() {
+	public static function data_add_yoast_seo_fields() {
 		return [
 			[ 'yoast_seo[gtin8]' ],
 			[ '<div id="yoast_seo" class="panel woocommerce_options_panel">' ],
@@ -234,7 +234,7 @@ class Yoast_Tab_Test extends TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_input_field_for_identifier() {
+	public static function data_input_field_for_identifier() {
 		return [
 			[ 'gtin8' ],
 			[ 'GTIN 8' ],

--- a/tests/WP/Classes/Option_Woo_Test.php
+++ b/tests/WP/Classes/Option_Woo_Test.php
@@ -47,7 +47,7 @@ class Option_Woo_Test extends TestCase {
 	 *
 	 * @return array[]
 	 */
-	public function validate_option_values() {
+	public static function validate_option_values() {
 		return [
 			// Tests a non defined value.
 			[ 'test', null, 123, null, null ],


### PR DESCRIPTION
## Context

*

## Summary

This PR can be summarized in the following changelog entry:

* Tests: use static dataproviders

## Relevant technical choices:

As of PHPUnit 10, data providers are (again) expected to be `static` methods.

This updates the test suite to respect that.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the builds pass, we're good.