### PR TITLE
GH Actions: switch to Coveralls action runner to upload reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,26 +105,14 @@ jobs:
         if: ${{ matrix.coverage == true }}
         run: composer coverage
 
-      # PHP Coveralls doesn't fully support PHP 8.x yet, so switch the PHP version.
-      - name: Switch to PHP 7.4
-        if: ${{ success() && matrix.coverage == true && startsWith( matrix.php_version, '8' ) }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          coverage: none
-
-      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
-      - name: Install Coveralls
-        if: ${{ success() && matrix.coverage == true }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
-
       - name: Upload coverage results to Coveralls
         if: ${{ success() && matrix.coverage == true }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: unit-php-${{ matrix.php_version }}
-        run: php-coveralls -v -x build/logs/clover.xml
+        uses: coverallsapp/github-action@v2
+        with:
+          format: clover
+          file: build/logs/clover.xml
+          flag-name: unit-php-${{ matrix.php_version }}
+          parallel: true
 
   wp-test:
     runs-on: ubuntu-latest
@@ -255,34 +243,23 @@ jobs:
           WP_PLUGIN_DIR: "./vendor/yoast"
           WP_MULTISITE: 1
 
-      # PHP Coveralls doesn't fully support PHP 8.x yet, so switch the PHP version.
-      - name: Switch to PHP 7.4
-        if: ${{ success() && matrix.coverage == true && startsWith( matrix.php_version, '8' ) }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          coverage: none
-
-      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
-      - name: Install Coveralls
-        if: ${{ success() && matrix.coverage == true }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
-
       - name: Upload coverage results to Coveralls - single site
         if: ${{ success() && matrix.coverage == true }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}
-        run: php-coveralls -v -x build/logs/clover-wp.xml
+        uses: coverallsapp/github-action@v2
+        with:
+          format: clover
+          file: build/logs/clover-wp.xml
+          flag-name: php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}
+          parallel: true
 
       - name: Upload coverage results to Coveralls - multisite
         if: ${{ success() && matrix.multisite == true && matrix.coverage == true }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}-ms
-        run: php-coveralls -v -x build/logs/clover-wp-ms.xml
+        uses: coverallsapp/github-action@v2
+        with:
+          format: clover
+          file: build/logs/clover-wp-ms.xml
+          flag-name: php-${{ matrix.php_version }}-wp-${{ matrix.wp_version }}-ms
+          parallel: true
 
   coveralls-finish:
     needs: [unit-test, wp-test]
@@ -292,5 +269,4 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
## Context

* Simplify CI script

## Summary

This PR can be summarized in the following changelog entry:

* Simplify CI script

## Relevant technical choices:

Simplify the code coverage workflow by removing the dependency on the `php-coveralls/php-coveralls` package and switching to the `coverallsapp/github-action` action runner, which, as of the release of the [0.6.5 version of the Coverage Reporter](https://github.com/coverallsapp/coverage-reporter/releases/tag/v0.6.5) now natively supports the Clover format.

The `COVERALLS_TOKEN` can now be removed from Settings -> Secrets.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_