### PR TITLE
Extend the global identifier import/export feature to variations

### DIFF
--- a/tests/Unit/Classes/Import_Export_Test.php
+++ b/tests/Unit/Classes/Import_Export_Test.php
@@ -3,8 +3,10 @@
 namespace Yoast\WP\Woocommerce\Tests\Unit\Classes;
 
 use Brain\Monkey\Functions;
-use Yoast_Woocommerce_Import_Export;
+use Mockery;
+use WC_Product;
 use Yoast\WP\Woocommerce\Tests\Unit\TestCase;
+use Yoast_Woocommerce_Import_Export;
 
 /**
  * Class Import_Export_Test.
@@ -23,7 +25,7 @@ class Import_Export_Test extends TestCase {
 	/**
 	 * The product object
 	 *
-	 * @var object
+	 * @var WC_Product|Mockery\MockInterface
 	 */
 	protected $product;
 
@@ -34,9 +36,8 @@ class Import_Export_Test extends TestCase {
 		parent::set_up();
 		$this->instance = new Yoast_Woocommerce_Import_Export();
 
-		$this->product = (object) [
-			'id' => 1,
-		];
+		$this->product     = Mockery::mock( 'WC_Product' );
+		$this->product->id = 1;
 	}
 
 	/**
@@ -47,18 +48,115 @@ class Import_Export_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertNotFalse( has_filter( 'woocommerce_product_export_column_names', [ $this->instance, 'add_columns' ] ), 'Adds options to export.' );
-		$this->assertNotFalse( has_filter( 'woocommerce_product_export_product_default_columns', [ $this->instance, 'add_columns' ] ), 'Adds default options to export.' );
+		$this->assertNotFalse(
+			has_filter(
+				'woocommerce_product_export_column_names',
+				[
+					$this->instance,
+					'add_columns',
+				]
+			),
+			'Adds options to export.'
+		);
+		$this->assertNotFalse(
+			has_filter(
+				'woocommerce_product_export_product_default_columns',
+				[
+					$this->instance,
+					'add_columns',
+				]
+			),
+			'Adds default options to export.'
+		);
 
-		$this->assertNotFalse( has_filter( 'woocommerce_csv_product_import_mapping_options', [ $this->instance, 'add_columns' ] ), 'Adds columns to import.' );
-		$this->assertEquals( 10, has_filter( 'woocommerce_csv_product_import_mapping_default_columns', [ $this->instance, 'add_column_to_mapping_screen' ] ), 'Adds columns to mapping screen.' );
+		$this->assertNotFalse(
+			has_filter(
+				'woocommerce_csv_product_import_mapping_options',
+				[
+					$this->instance,
+					'add_columns',
+				]
+			),
+			'Adds columns to import.'
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_csv_product_import_mapping_default_columns',
+				[
+					$this->instance,
+					'add_column_to_mapping_screen',
+				]
+			),
+			'Adds columns to mapping screen.'
+		);
 
-		$this->assertEquals( 10, has_filter( 'woocommerce_product_export_product_column_gtin8', [ $this->instance, 'add_export_data_global_identifier_values' ] ), 'Adds export data gtin8.' );
-		$this->assertEquals( 10, has_filter( 'woocommerce_product_export_product_column_gtin12', [ $this->instance, 'add_export_data_global_identifier_values' ] ), 'Adds export data gtin12.' );
-		$this->assertEquals( 10, has_filter( 'woocommerce_product_export_product_column_gtin13', [ $this->instance, 'add_export_data_global_identifier_values' ] ), 'Adds export data gtin13.' );
-		$this->assertEquals( 10, has_filter( 'woocommerce_product_export_product_column_gtin14', [ $this->instance, 'add_export_data_global_identifier_values' ] ), 'Adds export data gtin14.' );
-		$this->assertEquals( 10, has_filter( 'woocommerce_product_export_product_column_isbn', [ $this->instance, 'add_export_data_global_identifier_values' ] ), 'Adds export data isbn.' );
-		$this->assertEquals( 10, has_filter( 'woocommerce_product_export_product_column_mpn', [ $this->instance, 'add_export_data_global_identifier_values' ] ), 'Adds export data mpn.' );
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_product_export_product_column_gtin8',
+				[
+					$this->instance,
+					'add_export_data_global_identifier_values',
+				]
+			),
+			'Adds export data gtin8.'
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_product_export_product_column_gtin12',
+				[
+					$this->instance,
+					'add_export_data_global_identifier_values',
+				]
+			),
+			'Adds export data gtin12.'
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_product_export_product_column_gtin13',
+				[
+					$this->instance,
+					'add_export_data_global_identifier_values',
+				]
+			),
+			'Adds export data gtin13.'
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_product_export_product_column_gtin14',
+				[
+					$this->instance,
+					'add_export_data_global_identifier_values',
+				]
+			),
+			'Adds export data gtin14.'
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_product_export_product_column_isbn',
+				[
+					$this->instance,
+					'add_export_data_global_identifier_values',
+				]
+			),
+			'Adds export data isbn.'
+		);
+		$this->assertEquals(
+			10,
+			has_filter(
+				'woocommerce_product_export_product_column_mpn',
+				[
+					$this->instance,
+					'add_export_data_global_identifier_values',
+				]
+			),
+			'Adds export data mpn.'
+		);
 	}
 
 	/**
@@ -111,6 +209,48 @@ class Import_Export_Test extends TestCase {
 	}
 
 	/**
+	 * Tests add_export_data_global_identifier_values method.
+	 *
+	 * @covers ::add_export_data_global_identifier_values
+	 * @covers ::get_global_identifier_values
+	 *
+	 * @dataProvider data_provider_add_export_data_global_identifier_values
+	 *
+	 * @param string $current_filter      The current filter.
+	 * @param int    $get_post_meta_times Number of times get_post_meta() is expected to be called.
+	 * @param array  $global_identifier   The global identifier values.
+	 * @param string $expected            The expected result.
+	 * @param int    $id_times            Times get_id should be called.
+	 * @param string $type                The product type.
+	 */
+	public function test_add_export_data_global_identifier_values(
+		$current_filter,
+		$get_post_meta_times,
+		$global_identifier,
+		$expected,
+		$id_times,
+		$type
+	) {
+
+		if ( $id_times !== 0 ) {
+			$this->product->expects( 'get_id' )->times( $id_times )->andReturn( 1 );
+			$this->product->expects( 'get_type' )->andReturn( $type );
+		}
+
+
+		Functions\expect( 'current_filter' )
+			->once()
+			->andReturn( $current_filter );
+
+		Functions\expect( 'get_post_meta' )
+			->times( $get_post_meta_times )
+			->with( $this->product->id, 'wpseo_global_identifier_values', true )
+			->andReturn( $global_identifier );
+
+		$this->assertEquals( $expected, $this->instance->add_export_data_global_identifier_values( '', $this->product ) );
+	}
+
+	/**
 	 * Tests add_columns method.
 	 *
 	 * @covers ::add_columns
@@ -136,32 +276,6 @@ class Import_Export_Test extends TestCase {
 	}
 
 	/**
-	 * Tests add_export_data_global_identifier_values method.
-	 *
-	 * @covers ::add_export_data_global_identifier_values
-	 * @covers ::get_global_identifier_values
-	 *
-	 * @dataProvider data_provider_add_export_data_global_identifier_values
-	 *
-	 * @param string $current_filter The current filter.
-	 * @param int    $get_post_meta_times Number of times get_post_meta() is expected to be called.
-	 * @param array  $global_identifier The global identifier values.
-	 * @param string $expected The expected result.
-	 */
-	public function test_add_export_data_global_identifier_values( $current_filter, $get_post_meta_times, $global_identifier, $expected ) {
-		Functions\expect( 'current_filter' )
-			->once()
-			->andReturn( $current_filter );
-
-		Functions\expect( 'get_post_meta' )
-			->times( $get_post_meta_times )
-			->with( $this->product->id, 'wpseo_global_identifier_values', true )
-			->andReturn( $global_identifier );
-
-		$this->assertEquals( $expected, $this->instance->add_export_data_global_identifier_values( '', $this->product ) );
-	}
-
-	/**
 	 * Data provider for the test_add_export_data_global_identifier_values.
 	 *
 	 * @return array
@@ -173,24 +287,32 @@ class Import_Export_Test extends TestCase {
 				'get_post_meta_times' => 1,
 				'global_identifier'   => [ 'gtin8' => '12345678' ],
 				'expected'            => '12345678',
+				'id_times'            => 1,
+				'type'                => 'product',
 			],
 			'Callback form a filter not woocommerce_product_export_product_column' => [
 				'current_filter'      => 'other_filter',
 				'get_post_meta_times' => 0,
 				'global_identifier'   => [],
 				'expected'            => '',
+				'id_times'            => 0,
+				'type'                => 'product',
 			],
 			'No post meta value' => [
 				'current_filter'      => 'woocommerce_product_export_product_column_gtin8',
 				'get_post_meta_times' => 1,
 				'global_identifier'   => false,
 				'expected'            => '',
+				'id_times'            => 1,
+				'type'                => 'product',
 			],
 			'No global_identifier in the post meta value' => [
 				'current_filter'      => 'woocommerce_product_export_product_column_gtin8',
 				'get_post_meta_times' => 1,
 				'global_identifier'   => [],
 				'expected'            => '',
+				'id_times'            => 1,
+				'type'                => 'product',
 			],
 		];
 	}
@@ -203,21 +325,40 @@ class Import_Export_Test extends TestCase {
 	 * @covers ::process_import
 	 * @covers ::get_global_identifier_values
 	 *
-	 * @param array $data                      The data to be imported.
-	 * @param array $global_identifier_values The global identifier values.
-	 * @param int   $update_times    Number of times update_post_meta_times() is expected to be called.
-	 * @param array $expected                  The expected result.
+	 * @param array  $data                     The data to be imported.
+	 * @param array  $global_identifier_values The global identifier values.
+	 * @param int    $update_times             Number of times update_post_meta_times() is expected to be called.
+	 * @param array  $expected                 The expected result.
+	 * @param string $type                     The product type.
+	 * @param int    $times_id                 Times get_id should be called.
 	 */
-	public function test_process_import( $data, $global_identifier_values, $update_times, $expected ) {
+	public function test_process_import(
+		$data,
+		$global_identifier_values,
+		$update_times,
+		$expected,
+		$type,
+		$times_id
+	) {
+
+		$this->product->expects( 'get_id' )->times( $times_id )->andReturn( 1 );
+
+		$this->product->expects( 'get_type' )->times( 2 )->andReturn( $type );
+
+		$meta_name = 'wpseo_global_identifier_values';
+		if ( $type === 'variation' ) {
+			$meta_name = 'wpseo_variation_global_identifiers_values';
+		}
 
 		Functions\expect( 'get_post_meta' )
 			->once()
-			->with( $this->product->id, 'wpseo_global_identifier_values', true )
+			->with( $this->product->id, $meta_name, true )
 			->andReturn( $global_identifier_values );
+
 
 		Functions\expect( 'update_post_meta' )
 			->times( $update_times )
-			->with( $this->product->id, 'wpseo_global_identifier_values', $expected );
+			->with( $this->product->id, $meta_name, $expected );
 
 		$this->instance->process_import( $this->product, $data );
 	}
@@ -229,7 +370,7 @@ class Import_Export_Test extends TestCase {
 	 */
 	public static function data_provider_process_import() {
 		return [
-			'Update data' => [
+			'Update data'                           => [
 				'data'                     => [
 					'gtin8'  => '12345678',
 					'gtin12' => '123456789012',
@@ -255,8 +396,41 @@ class Import_Export_Test extends TestCase {
 					'isbn'   => '1234567890123',
 					'mpn'    => '1234567890123',
 				],
+
+				'type'                     => 'product',
+				'times_id'                 => 2,
 			],
-			'New partial data' => [
+			'Update data for variant'               => [
+				'data'                     => [
+					'gtin8'  => '12345678',
+					'gtin12' => '123456789012',
+					'gtin13' => '1234567890123',
+					'gtin14' => '12345678901234',
+					'isbn'   => '1234567890123',
+					'mpn'    => '1234567890123',
+				],
+				'global_identifier_values' => [
+					'gtin8'  => '12',
+					'gtin12' => '1234012',
+					'gtin13' => '1230123',
+					'gtin14' => '101234',
+					'isbn'   => '1234123',
+					'mpn'    => '123453',
+				],
+				'update_times'             => 1,
+				'expected'                 => [
+					'gtin8'  => '12345678',
+					'gtin12' => '123456789012',
+					'gtin13' => '1234567890123',
+					'gtin14' => '12345678901234',
+					'isbn'   => '1234567890123',
+					'mpn'    => '1234567890123',
+				],
+
+				'type'                     => 'variation',
+				'times_id'                 => 2,
+			],
+			'New partial data'                      => [
 				'data'                     => [
 					'gtin8'  => '12345678',
 					'gtin13' => '1234567890123',
@@ -273,8 +447,12 @@ class Import_Export_Test extends TestCase {
 					'isbn'   => '',
 					'mpn'    => '',
 				],
+
+				'type'                     => 'product',
+				'times_id'                 => 2,
+
 			],
-			'No data' => [
+			'No data'                               => [
 				'data'                     => [],
 				'global_identifier_values' => [
 					'gtin8'  => '12',
@@ -286,8 +464,11 @@ class Import_Export_Test extends TestCase {
 				],
 				'update_times'             => 0,
 				'expected'                 => [],
+
+				'type'                     => 'product',
+				'times_id'                 => 1,
 			],
-			'update_partial_data' => [
+			'update_partial_data'                   => [
 				'data'                     => [
 					'gtin8' => '888',
 				],
@@ -308,8 +489,11 @@ class Import_Export_Test extends TestCase {
 					'isbn'   => '1234123',
 					'mpn'    => '123453',
 				],
+
+				'type'                     => 'product',
+				'times_id'                 => 2,
 			],
-			'No matching data' => [
+			'No matching data'                      => [
 				'data'                     => [
 					'test' => 123,
 				],
@@ -323,6 +507,9 @@ class Import_Export_Test extends TestCase {
 				],
 				'update_times'             => 0,
 				'expected'                 => [],
+
+				'type'                     => 'product',
+				'times_id'                 => 1,
 			],
 			'No global_identifier_values post meta' => [
 				'data'                     => [
@@ -338,6 +525,8 @@ class Import_Export_Test extends TestCase {
 					'isbn'   => '',
 					'mpn'    => '',
 				],
+				'type'                     => 'product',
+				'times_id'                 => 2,
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to support variations in our global identifier import/export tool.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Extends the global identifier import/export feature to variations.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Instructions in #945 have been updated to take into account variations, please refer to them.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
