### PR TITLE
Fix #875 attempt to read undefined property warning

### DIFF
--- a/classes/woocommerce-opengraph.php
+++ b/classes/woocommerce-opengraph.php
@@ -127,6 +127,9 @@ class WPSEO_WooCommerce_OpenGraph {
 	protected function is_opengraph_image_set_by_user( $product_id ) {
 		$indexable_repository = YoastSEO()->classes->get( 'Yoast\WP\SEO\Repositories\Indexable_Repository' );
 		$indexable            = $indexable_repository->find_by_id_and_type( $product_id, 'post' );
+		if ( is_bool( $indexable ) ) {
+			return false;
+		}
 
 		return $indexable->open_graph_image_source === 'set-by-user';
 	}


### PR DESCRIPTION
## Context
<!--
Fixes a PHP 8 attempt to read undefined property warning.
-->

* We want to avoid showing a Php 8.0 warning when trying to access a property of a non-object.

## Summary

* Avoids triggering a PHP 8 warning when attempting to access a non-existent object. Props to @37Rb.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure your site is running on Php version 8.0 or higher 
* Make sure you have at least one product published
* Either use the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin or add the following filter to your theme's `functions.php`:
  ```
  add_filter( 'wpseo_indexable_excluded_post_types', function( $post_types ) {
    $post_types[] = 'product';
    return $post_types;
  } );
  ```
* Reset your indexables table through the `Yoast Test Helper`
* Without this PR:
  *  you get a Php Warning: Attempt to read property "open_graph_image_source" on bool
* With this PR:
  * No warning is displayed  


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [X] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).

## Innovation


Fixes https://github.com/Yoast/wpseo-woocommerce/issues/875